### PR TITLE
Rework JSON logs, in particular nested logs from the network layer 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ pre: "<b>5. </b>"
    This behaviour can be bypassed where sequential processsing is not required, by setting the new
    construction option `sequential` to `false`.
 
+- Nested logs are now also structured, in particular those coming from the Handshake or TxSubmission protocols. Before, any message from these layers where actually plain strings with unprocessable gibberish. Now, the submitted transaction payload is shown encoded as hexadecimals and errors are also serialized to json using the same model / codec as the one used for websockets. The handshake is also more verbose now clearly showing what version is being requested and what the node replies / select. All in all, better logs. 
+
 #### Changed
 
 - The `moveInstantaneousRewards` certificates have a new optional field `value` and not only a `rewards` map as before. When `value` is present, it signifies that rewards are moved to the other pot.

--- a/server/cabal.project
+++ b/server/cabal.project
@@ -7,7 +7,6 @@ packages:
   modules/git-th
   modules/hspec-json-schema
   modules/json-wsp
-  modules/json-via-show
 
 -----------------------------------------------------------
 -- Disable all tests by default

--- a/server/modules/cardano-client/cardano-client.cabal
+++ b/server/modules/cardano-client/cardano-client.cabal
@@ -3,8 +3,6 @@ cabal-version: 1.12
 -- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: af817fcd073b7f00a7e40f90315ee4563e0b03a3a743f7d9ca53ce6cdf3d0d28
 
 name:           cardano-client
 version:        1.0.0
@@ -75,7 +73,8 @@ library
   build-tool-depends:
       hspec-discover:hspec-discover
   build-depends:
-      base >=4.7 && <5
+      aeson
+    , base >=4.7 && <5
     , bytestring
     , cardano-ledger-byron
     , cborg
@@ -90,5 +89,6 @@ library
     , ouroboros-consensus-shelley
     , ouroboros-network
     , ouroboros-network-framework
+    , typed-protocols
     , typed-protocols-examples
   default-language: Haskell2010

--- a/server/modules/cardano-client/package.yaml
+++ b/server/modules/cardano-client/package.yaml
@@ -25,6 +25,7 @@ library:
   source-dirs: src
   ghc-options: *ghc-options-lib
   dependencies:
+    - aeson
     - bytestring
     - cardano-ledger-byron
     - cborg
@@ -39,6 +40,7 @@ library:
     - ouroboros-consensus-shelley
     - ouroboros-network
     - ouroboros-network-framework
+    - typed-protocols
     - typed-protocols-examples
   build-tools:
   - hspec-discover

--- a/server/modules/cardano-client/src/Cardano/Network/Protocol/NodeToClient.hs
+++ b/server/modules/cardano-client/src/Cardano/Network/Protocol/NodeToClient.hs
@@ -67,14 +67,12 @@ import Network.Mux
     ( MuxError (..), MuxMode (..) )
 import Network.TypedProtocol.Codec
     ( Codec )
-import Ouroboros.Consensus.Byron.Ledger
-    ( GenTx )
 import Ouroboros.Consensus.Byron.Ledger.Config
     ( CodecConfig (..) )
 import Ouroboros.Consensus.Cardano
     ( CardanoBlock )
 import Ouroboros.Consensus.Cardano.Block
-    ( CardanoEras, CodecConfig (..), HardForkApplyTxErr )
+    ( CardanoEras, CodecConfig (..), GenTx, HardForkApplyTxErr )
 import Ouroboros.Consensus.Ledger.Query
     ( Query (..) )
 import Ouroboros.Consensus.Network.NodeToClient
@@ -178,7 +176,7 @@ connectClient tr client vData addr = liftIO $ withIOManager $ \iocp -> do
 
     tracers :: NetworkConnectTracers LocalAddress NodeToClientVersion
     tracers = NetworkConnectTracers
-        { nctMuxTracer = contramap TrMux tr
+        { nctMuxTracer = nullTracer
         , nctHandshakeTracer = contramap TrHandshake tr
         }
 

--- a/server/modules/cardano-client/src/Cardano/Network/Protocol/NodeToClient/Trace.hs
+++ b/server/modules/cardano-client/src/Cardano/Network/Protocol/NodeToClient/Trace.hs
@@ -4,6 +4,7 @@
 
 module Cardano.Network.Protocol.NodeToClient.Trace
     ( TraceClient (..)
+    , encodeTraceClient
     ) where
 
 import Prelude
@@ -14,26 +15,122 @@ import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
 import Codec.CBOR.Term
     ( Term )
+import Data.Aeson
+    ( (.=) )
+import GHC.Generics
+    ( Generic )
 import Network.Mux
-    ( MuxTrace, WithMuxBearer )
+    ( WithMuxBearer (..) )
+import Network.TypedProtocol.Codec
+    ( AnyMessageAndAgency (..) )
 import Ouroboros.Network.Driver.Simple
-    ( TraceSendRecv )
+    ( TraceSendRecv (..) )
 import Ouroboros.Network.NodeToClient
-    ( ConnectionId (..), Handshake, LocalAddress, NodeToClientVersion )
+    ( ConnectionId (..), LocalAddress, NodeToClientVersion )
+import Ouroboros.Network.Protocol.Handshake.Type
+    ( Handshake, Message (..), RefuseReason (..) )
 import Ouroboros.Network.Protocol.LocalTxSubmission.Type
-    ( LocalTxSubmission )
+    ( LocalTxSubmission, Message (..) )
+
+import qualified Data.Aeson as Json
+import qualified Data.Aeson.Types as Json
+import qualified Data.Map.Strict as Map
 
 type HandshakeTrace = TraceSendRecv (Handshake NodeToClientVersion Term)
 
 data TraceClient tx err
     = TrTxSubmission (TraceSendRecv (LocalTxSubmission tx err))
-    | TrMux (WithMuxBearer (ConnectionId LocalAddress) MuxTrace)
     | TrHandshake (WithMuxBearer (ConnectionId LocalAddress) HandshakeTrace)
-    deriving (Show)
+    deriving (Generic, Show)
+
+encodeTraceClient
+    :: forall tx err. ()
+    => (tx -> Json.Value)
+    -> (err -> Json.Value)
+    -> TraceClient tx err
+    -> Json.Value
+encodeTraceClient encodeTx encodeErr = \case
+    TrTxSubmission tr ->
+        Json.object (("tag" .= Json.String "TxSubmission")
+            : encodeTraceSendRecvTxSubmission tr
+        )
+    TrHandshake tr ->
+        Json.object (("tag" .= Json.String "Handshake")
+            : encodeTraceSendRecvHandshake tr
+        )
+  where
+    encodeTraceSendRecvTxSubmission
+        :: TraceSendRecv (LocalTxSubmission tx err)
+        -> [Json.Pair]
+    encodeTraceSendRecvTxSubmission = \case
+        TraceSendMsg (AnyMessageAndAgency agency msg) ->
+            [ "event" .= ("send" :: String)
+            , "agency" .= show agency
+            ] ++ encodeMsg msg
+        TraceRecvMsg (AnyMessageAndAgency agency msg) ->
+            [ "event" .= ("receive" :: String)
+            , "agency" .= show agency
+            ] ++ encodeMsg msg
+      where
+        encodeMsg
+            :: Message (LocalTxSubmission tx err) from to
+            -> [Json.Pair]
+        encodeMsg = \case
+            MsgSubmitTx tx ->
+                [ "tag" .= ("SubmitTx" :: String)
+                , "tx" .= encodeTx tx
+                ]
+            MsgAcceptTx ->
+                [ "tag" .= ("AcceptTx" :: String)
+                ]
+            MsgRejectTx err ->
+                [ "tag" .= ("RejectTx" :: String)
+                , "reasons" .= encodeErr err
+                ]
+            MsgDone ->
+                [ "tag" .= ("Done" :: String)
+                ]
+
+    encodeTraceSendRecvHandshake
+        :: WithMuxBearer (ConnectionId LocalAddress) HandshakeTrace
+        -> [Json.Pair]
+    encodeTraceSendRecvHandshake = \case
+        WithMuxBearer _peerId (TraceSendMsg (AnyMessageAndAgency agency msg)) ->
+            [ "event" .= ("send" :: String)
+            , "agency" .= show agency
+            ] ++ encodeMsg msg
+        WithMuxBearer _peerId (TraceRecvMsg (AnyMessageAndAgency agency msg)) ->
+            [ "event" .= ("receive" :: String)
+            , "agency" .= show agency
+            ] ++ encodeMsg msg
+      where
+        encodeMsg
+            :: Message (Handshake NodeToClientVersion Term) from to
+            -> [Json.Pair]
+        encodeMsg = \case
+            MsgProposeVersions versions ->
+                [ "tag" .= ("ProposeVersions" :: String)
+                , "versions" .= (show <$> Map.keys versions)
+                ]
+            MsgAcceptVersion v _ ->
+                [ "tag" .= ("AcceptVersion" :: String)
+                , "version" .= show (show v)
+                ]
+            MsgRefuse reason ->
+                [ "tag" .= ("RefuseVersions" :: String)
+                , "reason" .= encodeRefuseReason reason
+                ]
+
+        encodeRefuseReason
+            :: RefuseReason vNumber
+            -> Json.Value
+        encodeRefuseReason = \case
+            VersionMismatch{} -> Json.String "VersionMismatchOrUnknown"
+            HandshakeDecodeError{} -> Json.String "HandshakeDecodeError"
+            Refused{} -> Json.String "ServerRejected"
 
 instance HasPrivacyAnnotation (TraceClient tx err)
 instance HasSeverityAnnotation (TraceClient tx err) where
     getSeverityAnnotation = \case
         TrTxSubmission{} -> Info
-        TrMux{}          -> Debug
-        TrHandshake{}    -> Debug
+        TrHandshake{}    -> Info

--- a/server/modules/json-via-show/CHANGELOG.md
+++ b/server/modules/json-via-show/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [2.0.0] -- 2021-06-05
+
+### Added
+
+- Unit tests for `ToJSONViaShow`
+
+### Changed
+
+- Renamed `GenericToJsonViaShow` to `ToJSONViaShow` with a completely revised implementation. The previous implementation tried to do something using generics but turned out to hit a wall
+  when it came to nested types. The new approach does actually parse the `show` output and transforms it into JSON which is a bit more involved at runtime, but should give better results for deeply nested types.
+
+### Removed
+
+- `ViaJson` data-type wrapper which was used to force `ToJSON` instance on nested types, no longer needed.
+
 ## [1.0.0] -- 2021-04-23
 
 ### Added

--- a/server/modules/json-via-show/README.md
+++ b/server/modules/json-via-show/README.md
@@ -2,29 +2,63 @@
 
 ## Overview 
 
-Automatically derive `ToJSON` instances from types that have `Show` and `Generic` instances.
+Automatically derive `ToJSON` instances from types that have `Show` instances. This project was very much an _interesting_ experiment which turned out to be even more hacky than anticipated. As a matter of fact:
+
+- Without any prior knowledge of the target data-type, it may actually not be possible to parse
+  a rendered data-type correctly. This is the case for instance of the show instance for `UTCTime`
+
+- Unfortunately, many types in the wild aren't using stock show instances and don't necessarily follow strict rules when it comes to the grammar. For example, while every constructor in Haskell starts with a capital letter, the "shown" constructor for many `containers` like `Set` or `Map` are displayed as `fromList []`. 
+
+- It feels like _a lot_ is going on in order to re-parse each type and re-transform them back into JSON and, all of it is happening at runtime, leaving room for mistakes and possible failures. Since the primary purpose of this module was to get an easy way to quickly write JSON instances for logging; relying on something that may break at any input does not seem like a good idea. 
+
+- On the plus side, there has been some good results when plugged in a real system, in particular with nested types coming from a sub-system for which the JSON structure was auto-magically discovered:
+
+
+```
+[ogmios:Info:5] [2021-06-06 13:44:58.80 UTC] {"OgmiosNetwork":{"NetworkParameters":{"networkMagic":"1097911063","systemStart":["2019-07-24","20:20:16",{"UTC":[]}],"slotsPerEpoch":"21600"}}}
+
+[ogmios:Info:14] [2021-06-06 13:44:58.80 UTC] {"OgmiosServer":{"ServerStarted":{"nodeSocket":"/home/ktorz/Documents/IOHK/networks/testnet/node.socket","dashboardUrl":"http://127.0.0.1:1338/"}}}
+
+[ogmios:Info:22] [2021-06-06 13:44:58.81 UTC] {"OgmiosHealth":{"HealthTick":{"Health":{"metrics":{"totalUnrouted":"0","totalMessages":"0","runtimeStats":{"gcCpuTime":"0","cpuTime":"5970744","maxHeapSize":"0","currentHeapSize":"0"},"totalConnections":"0","sessionDurations":{"max":"0.0","mean":"0.0","min":"0.0"},"activeConnections":"0"},"startTime":"2021-06-06 13:44:58.807426705 UTC","lastTipUpdate":["2021-06-06","13:44:58.810905762",{"UTC":[]}],"lastKnownTip":[{"SlotNo":"28617866"},"4cf6200d4f37f106c173612cb1473d41b93788d000f5450d2996b1e4a4b18315",{"BlockNo":"2648278"}],"networkSynchronization":"0.99999","currentEra":"Mary"}}}}
+
+[ogmios:Info:533] [2021-06-06 13:45:39.80 UTC] {"OgmiosWebSocket":{"WebSocketConnectionEnded":"User-Agent unknown"}}
+[ogmios:Info:548] [2021-06-06 13:45:40.31 UTC] {"OgmiosWebSocket":{"WebSocketConnectionAccepted":{"mode":"FullSerialization","userAgent":"User-Agent unknown"}}}
+
+[ogmios:Info:541] [2021-06-06 13:45:39.80 UTC]{"OgmiosWebSocket":{"WebSocketClient":{"TrTxSubmission":{"Send":[{"ClientAgency":{"TokIdle":[]}},{"MsgSubmitTx":{"HardForkGenTx":{"S":{"S":{"S":{"Z":{"TxRaw":{"_wits":{"txWitsBytes":"\\161\\NUL\\129\\130X \\207\\DC4\\209\\200\\&4\\206\\202\\184\\225\\245D{\\222U\\EMF\\128@W3(%\\226nd\\238C\\a\\157\\212\\b5X@$|^`\\146\\DC10\\250\\GS\\248\\NUL\\211\\DLE\\243\\151\\136\\244\\174\\EOT\\131u4\\173\\230rxu\\219\\184r\\CAN\\245\\180^\\150\\204\\209%\\161LE\\DLE\\232\\SYN\\148\\231\\170\\211\\186\\138$E\\138\\175ko\\156O\\SUBH\\SOH\\190\\186\\ENQ","addrWits'":[{"WitVKey'":{"wvkKey'":{"VerKeyEd25519DSIGN":{"PublicKey":"\\207\\DC4\\209\\200\\&4\\206\\202\\184\\225\\245D{\\222U\\EMF\\128@W3(%\\226nd\\238C\\a\\157\\212\\b5"}},"wvkSig'":{"SigEd25519DSIGN":{"Signature":"$|^`\\146\\DC10\\250\\GS\\248\\NUL\\211\\DLE\\243\\151\\136\\244\\174\\EOT\\131u4\\173\\230rxu\\219\\184r\\CAN\\245\\180^\\150\\204\\209%\\161LE\\DLE\\232\\SYN\\148\\231\\170\\211\\186\\138$E\\138\\175ko\\156O\\SUBH\\SOH\\190\\186\\ENQ"}},"wvkKeyHash":"ff7b4521589238cfb9c26870edfa782541e61544474422d849ceb103","wvkBytes":"\\130X \\207\\DC4\\209\\200\\&4\\206\\202\\184\\225\\245D{\\222U\\EMF\\128@W3(%\\226nd\\238C\\a\\157\\212\\b5X@$|^`\\146\\DC10\\250\\GS\\248\\NUL\\211\\DLE\\243\\151\\136\\244\\174\\EOT\\131u4\\173\\230rxu\\219\\184r\\CAN\\245\\180^\\150\\204\\209%\\161LE\\DLE\\232\\SYN\\148\\231\\170\\211\\186\\138$E\\138\\175ko\\156O\\SUBH\\SOH\\190\\186\\ENQ"}}],"bootWits'":[],"scriptWits'":[]},"_body":{"TxBodyRaw":{"adHash":"SNothing","vldt":{"invalidHereafter":{"SlotNo":"100000000"},"invalidBefore":"SNothing"},"inputs":[{"TxInCompact":[{"TxId":{"SafeHash":"e1e86da6446c7f81da8d5e440bb0d4eed0f1530ba15bf77e49c33d6f050d8fb5"}},"0"]}],"certs":{},"wdrls":{},"outputs":[[{"Addr":{"Testnet":[{"KeyHashObj":{"KeyHash":"ff7b4521589238cfb9c26870edfa782541e61544474422d849ceb103"}},{"StakeRefNull":[]}]}},{"Value":["1660110",{}]}]],"txfee":"169945","mint":["0",{}],"update":"SNothing"}},"_auxiliaryData":"SNothing"}}}}}}}}]}}}}
+
+[ogmios:Info:541] [2021-06-06 13:45:39.80 UTC] {"OgmiosWebSocket":{"WebSocketClient":{"TrTxSubmission":{"Recv":[{"ServerAgency":{"TokBusy":[]}},{"MsgRejectTx":{"HardForkApplyTxErrFromEra":{"S":{"S":{"S":{"Z":{"WrapApplyTxErr":{"ApplyTxError":[{"UtxowFailure":{"UtxoFailure":{"ValueNotConservedUTxO":[{"Value":["0",{}]},{"Value":["1830055",{}]}]}}},{"UtxowFailure":{"UtxoFailure":{"BadInputsUTxO":[{"TxInCompact":[{"TxId":{"SafeHash":"e1e86da6446c7f81da8d5e440bb0d4eed0f1530ba15bf77e49c33d6f050d8fb5"}},"0"]}]}}}]}}}}}}}}]}}}}
+```
 
 ## Usage
 
 ```hs
 {-# LANGUAGE DerivingVia #-}
 
-import Data.Aeson
-    ( ToJSON )
-import Data.Aeson.Via.Show
-    ( GenericToJsonViaShow(..), ViaJson (..) )
-
 data Foo = Foo
-  { foo :: String
-  , bar :: ViaJson bar
-  } deriving stock (Generic)
-    deriving ToJSON via GenericToJsonViaShow Foo
+    { foo :: [Int]
+    , bar :: String
+    }
+    deriving stock Show
+    deriving ToJSON via ToJSONViaShow Foo
 
-data Bar = Bar Int Bool String
-  deriving stock (Generic)
-  deriving ToJSON via GenericToJsonViaShow Bar
+data Log = Log Bool LastUpdate
+    deriving stock Show
+    deriving ToJSON via ToJSONViaShow Log
+
+newtype LastUpdate = LastUpdate
+    { unLastUpdate :: UTCTime
+    }
+    deriving stock Show
+    deriving ToJSON via ToJSONViaShow LastUpdate
 ```
 
+```hs
+>>> encode (Foo [42] "str")
+{"Foo":{"foo":["42"],"bar":"str"}}
+
+>>> encode (Log True (LastUpdate now))
+{"Log":[true,{"LastUpdate":"2021-06-05 17:17:54.710264188 UTC"}]}
+```
 
 <hr/>
 

--- a/server/modules/json-via-show/json-via-show.cabal
+++ b/server/modules/json-via-show/json-via-show.cabal
@@ -3,11 +3,9 @@ cabal-version: 1.12
 -- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 6e47685e6bbe363a3b404851f7f2467b33367856a83f9b15a0e89d0d0dacaa10
 
 name:           json-via-show
-version:        1.0.0
+version:        2.0.0
 synopsis:       Generic ToJSON instance deriving via Show
 description:    Please see the README on GitHub at <https://github.com/cardanosolutions/ogmios/tree/master/server/modules/json-via-show>
 category:       Codec
@@ -31,6 +29,7 @@ source-repository head
 library
   exposed-modules:
       Data.Aeson.Via.Show
+      Data.Aeson.Via.Show.Internal
   other-modules:
       Paths_json_via_show
   hs-source-dirs:
@@ -75,4 +74,60 @@ library
       aeson
     , base >=4.7 && <5
     , text
+  default-language: Haskell2010
+
+test-suite unit
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Data.Aeson.Via.ShowSpec
+      Paths_json_via_show
+  hs-source-dirs:
+      test/unit
+  default-extensions:
+      BangPatterns
+      BinaryLiterals
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveTraversable
+      EmptyDataDecls
+      ExistentialQuantification
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      NoImplicitPrelude
+      NumericUnderscores
+      OverloadedStrings
+      PartialTypeSignatures
+      PatternGuards
+      RankNTypes
+      ScopedTypeVariables
+      StandaloneDeriving
+      TupleSections
+      TypeFamilies
+      TypeSynonymInstances
+      ViewPatterns
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+  build-tool-depends:
+      hspec-discover:hspec-discover
+  build-depends:
+      aeson
+    , base >=4.7 && <5
+    , containers
+    , hspec
+    , json-via-show
+    , text
+    , time
   default-language: Haskell2010

--- a/server/modules/json-via-show/package.yaml
+++ b/server/modules/json-via-show/package.yaml
@@ -1,7 +1,7 @@
 _config: !include "../../.hpack.config.yaml"
 
 name:                json-via-show
-version:             1.0.0
+version:             2.0.0
 github:              "cardanosolutions/ogmios"
 license:             MPL-2.0
 author:              "KtorZ <matthias.benkort@gmail.com>"
@@ -27,3 +27,18 @@ library:
   dependencies:
     - aeson
     - text
+
+tests:
+  unit:
+    main: Spec.hs
+    source-dirs: test/unit
+    ghc-options: *ghc-options-test
+    dependencies:
+    - aeson
+    - containers
+    - json-via-show
+    - hspec
+    - text
+    - time
+    build-tools:
+    - hspec-discover

--- a/server/modules/json-via-show/src/Data/Aeson/Via/Show.hs
+++ b/server/modules/json-via-show/src/Data/Aeson/Via/Show.hs
@@ -2,100 +2,49 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE UndecidableInstances #-}
-
 module Data.Aeson.Via.Show
-    ( GenericToJsonViaShow (..)
-    , ViaJson (..)
+    ( ToJSONViaShow (..)
     ) where
 
 import Prelude
 
-import GHC.Generics
-
 import Data.Aeson
-    ( ToJSON (..), Value (..), (.=) )
-import Data.Kind
-    ( Type )
-import Data.Text
-    ( Text )
+    ( ToJSON (..) )
+import Data.Aeson.Via.Show.Internal
+    ( exprToJSON, parseExpr )
 
-import qualified Data.Aeson as Json
-import qualified Data.Text as T
-
--- | Newtype wrapping any existing type which carries showable terminal values.
+-- | DerivingVia wrapper to auto-magically derive JSON instances for data-types
+-- that have a 'Show' instance.
 --
--- This is meant to be used in conjunction with a deriving via clause, as such:
+-- For example:
 --
---     data Foo = Foo
---         { bar :: Int
---         }
---         deriving stock (Generic)
---         deriving ToJSON via GenericToJsonViaShow Foo
+-- @
+-- {-# LANGUAGE DerivingVia #-}
 --
-newtype GenericToJsonViaShow a =
-    GenericToJsonViaShow { unGenericToJsonViaShow :: a }
-    deriving (Generic)
+-- data Foo = Foo
+--     { foo :: [Int]
+--     , bar :: String
+--     }
+--     deriving stock Show
+--     deriving ToJSON via ToJSONViaShow Foo
+--
+-- data Log = Log Bool LastUpdate
+--     deriving stock Show
+--     deriving ToJSON via ToJSONViaShow Log
+--
+-- newtype LastUpdate = LastUpdate
+--     { unLastUpdate :: UTCTime
+--     }
+--     deriving stock Show
+--     deriving ToJSON via ToJSONViaShow LastUpdate
+-- @
+--
+-- >>> encode (Foo [42] "str")
+-- {"Foo":{"foo":["42"],"bar":"str"}}
+--
+-- >>> encode (Log True (LastUpdate now))
+-- {"Log":[true,{"LastUpdate":"2021-06-05 17:17:54.710264188 UTC"}]}
+newtype ToJSONViaShow a = ToJSONViaShow { unToJSONViaShow :: a }
 
--- | A wrapper to force a particular type to be encoded using its Json instance.
-data ViaJson a = ToJSON a => ViaJson a
-
-instance Show a => Show (ViaJson a) where
-    show (ViaJson a) = show a
-
-class GToJsonViaShow (f :: Type -> Type) where
-    gToJsonViaShow :: f a -> Value
-
-instance
-    ( Generic a
-    , GToJsonViaShow (Rep a)
-    ) => ToJSON (GenericToJsonViaShow a)
-  where
-    toJSON = gToJsonViaShow . from . unGenericToJsonViaShow
-
-instance GToJsonViaShow f => GToJsonViaShow (D1 c f) where
-    gToJsonViaShow = gToJsonViaShow . unM1
-
-instance {-# OVERLAPS #-} (Constructor c) => GToJsonViaShow (C1 c U1) where
-    gToJsonViaShow (M1 _) = toJSON fieldName
-      where
-        fieldName = T.pack $ conName (undefined :: C1 c U1 a)
-
-instance (Constructor c, GToJsonViaShow f) => GToJsonViaShow (C1 c f) where
-    gToJsonViaShow (M1 f) = Json.object [ fieldName .= gToJsonViaShow f ]
-      where
-        fieldName = T.pack $ conName (undefined :: C1 c f a)
-
-instance (GToJsonViaShow f, GToJsonViaShow g) => GToJsonViaShow (f :+: g) where
-    gToJsonViaShow = \case
-        L1 f -> gToJsonViaShow f
-        R1 g -> gToJsonViaShow g
-
-instance (GToJsonViaShow f, GToJsonViaShow g) => GToJsonViaShow (f :*: g) where
-    gToJsonViaShow (f :*: g) =
-        case (gToJsonViaShow f, gToJsonViaShow g) of
-            (Object ff, Object gg) ->
-                Object (ff <> gg)
-            (ff, gg) ->
-                toJSON [ff, gg]
-
-instance (Selector s, GToJsonViaShow f) => GToJsonViaShow (S1 s f) where
-    gToJsonViaShow (M1 f) =
-        if null fieldName
-        then gToJsonViaShow f
-        else Json.object [ T.pack fieldName .= gToJsonViaShow f ]
-      where
-        fieldName = selName (undefined :: S1 s f a)
-
-instance (Show c) => GToJsonViaShow (K1 i c) where
-    gToJsonViaShow = toJSON . show . unK1
-
-instance {-# OVERLAPS #-} GToJsonViaShow (K1 i String) where
-    gToJsonViaShow = toJSON . unK1
-
-instance {-# OVERLAPS #-} GToJsonViaShow (K1 i Text) where
-    gToJsonViaShow = toJSON . unK1
-
-instance {-# OVERLAPS #-} GToJsonViaShow (K1 i (ViaJson a)) where
-    gToJsonViaShow (K1 (ViaJson a)) = toJSON a
+instance Show a => ToJSON (ToJSONViaShow a) where
+    toJSON = exprToJSON . fst . parseExpr False . show . unToJSONViaShow

--- a/server/modules/json-via-show/src/Data/Aeson/Via/Show/Internal.hs
+++ b/server/modules/json-via-show/src/Data/Aeson/Via/Show/Internal.hs
@@ -1,0 +1,160 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+module Data.Aeson.Via.Show.Internal
+    ( -- * Data-Types
+      Expr (..)
+
+    -- * Logic
+    , parseExpr
+    , exprToJSON
+    ) where
+
+import Prelude
+
+import Control.Arrow
+    ( first )
+import Data.Aeson
+    ( ToJSON (..), Value (..), object, (.=) )
+import Data.Char
+    ( isUpper )
+import Data.Text
+    ( Text )
+
+import qualified Data.Text as T
+
+--
+-- Data-Types
+--
+
+data Expr
+    = Record Text [(Text, Expr)]
+    | Product Text [Expr]
+    | List [Expr]
+    | Val Text
+    deriving (Show, Eq)
+
+exprToJSON :: Expr -> Value
+exprToJSON = \case
+    Val s ->
+        String s
+    List xs ->
+        toJSON (exprToJSON <$> xs)
+    Record c [(_, x)] ->
+        object [c .= exprToJSON x]
+    Record c xs ->
+        object [c .= object (keyValToJSON <$> xs)]
+    Product "True" [] ->
+        Bool True
+    Product "False" [] ->
+        Bool False
+    Product "Nothing" [] ->
+        Null
+    Product "Just" [x] ->
+        exprToJSON x
+    Product c [Val d, Val t, Product "UTC" []] ->
+        exprToJSON $ Product c [Val (d <> " " <> t <> " UTC")]
+    Product "Container" [List xs] ->
+        case tryZip xs of
+            Nothing -> exprToJSON (List xs)
+            Just keyVal -> object (keyValToJSON <$> keyVal)
+    Product c [x] ->
+        object [c .= exprToJSON x]
+    Product c xs ->
+        object [c .= (exprToJSON <$> xs)]
+  where
+    keyValToJSON = \case
+        (k, Record c xs) ->
+            case xs of
+            []       -> k .= c
+            [(_, x)] -> k .= exprToJSON x
+            _        -> k .= object (keyValToJSON <$> xs)
+        (k, Product c xs) | c `notElem` ["True", "False", "Nothing"] ->
+            case xs of
+            []  -> k .= c
+            [x] -> k .= exprToJSON x
+            _   -> k .= (exprToJSON <$> xs)
+        (k, v) ->
+            k .= exprToJSON v
+
+    tryZip = \case
+        [] -> Just []
+        (List [Val k,v]:q) -> let xs = tryZip q in ((k,v):)<$>xs
+        _ -> Nothing
+
+parseExpr :: Bool -> String -> (Expr, String)
+parseExpr spaceAreSep = \case
+    c:q | isUpper c ->
+        let (cons, q') = parseCons (c:q) in parseProductOrRecord cons q'
+    'f':'r':'o':'m':'L':'i':'s':'t':q ->
+        parseProductOrRecord "Container" q
+    '(':')':q ->
+        (List [], q)
+    '(':q ->
+        case parseMany (Just ')') ',' (parseExpr False) q of
+            ([e], q') -> (e, q')
+            (es, q') -> (List es, q')
+    '[':']':q ->
+        (List [], q)
+    '[':q ->
+        first List (parseMany (Just ']') ',' (parseExpr False) q)
+    str ->
+        first Val (parseVal spaceAreSep str)
+
+parseCons :: String -> (Text, String)
+parseCons = first T.pack . go
+  where
+    go = \case
+        [] -> ("", "")
+        c:q | c `elem` ("[]{}(), " :: String) -> ("", c:q)
+        c:q -> let (cs, q') = go q in (c:cs, q')
+
+parseProductOrRecord :: Text -> String -> (Expr, String)
+parseProductOrRecord cons = \case
+    _:'{':q ->
+        first (Record cons) (parseMany (Just '}') ',' parseKeyVal q)
+    ' ':q ->
+        first (Product cons) (parseMany Nothing ' ' (parseExpr True) q)
+    q ->
+        (Product cons [], q)
+
+parseVal :: Bool -> String -> (Text, String)
+parseVal spaceAreSep = first T.pack . go
+  where
+    go = \case
+        [] -> ("", "")
+        c:q | c `elem` ("}])," :: String) -> ("", c:q)
+        ' ':q | spaceAreSep -> ("", ' ':q)
+        c:q ->
+            let (cs, q') = go q in
+            if c `elem` ("\"'" :: String) then (cs, q') else (c:cs, q')
+
+parseKeyVal :: String -> ((Text, Expr), String)
+parseKeyVal s =
+    let (k, q) = parseKey s in first (k,) (parseExpr False q)
+  where
+    parseKey :: String -> (Text, String)
+    parseKey = first T.pack . go
+      where
+        go = \case
+            [] -> ("", "") -- Absurd
+            ' ':'=':' ':q -> ("", q)
+            c:q -> let (cs, q') = go q in (c:cs, q')
+
+parseMany :: Maybe Char -> Char -> (String -> (expr, String)) -> String -> ([expr], String)
+parseMany end delim parseElem = \case
+    [] ->
+        ([], "")
+    s ->
+        case parseElem s of
+            (e, "") ->
+                ([e], "")
+            (e, c:q) | Just c == end ->
+                ([e], q)
+            (e, c:' ':q) | c == delim ->
+                let (es, q') = parseMany end delim parseElem q in (e:es, q')
+            (e, c:q) | c == delim ->
+                let (es, q') = parseMany end delim parseElem q in (e:es, q')
+            (e, q) ->
+                ([e], q)

--- a/server/modules/json-via-show/test/unit/Data/Aeson/Via/ShowSpec.hs
+++ b/server/modules/json-via-show/test/unit/Data/Aeson/Via/ShowSpec.hs
@@ -1,0 +1,152 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Data.Aeson.Via.ShowSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Control.Monad
+    ( forM_ )
+import Data.Aeson
+    ( ToJSON (..) )
+import Data.Aeson.QQ.Simple
+    ( aesonQQ )
+import Data.Aeson.Via.Show
+    ( ToJSONViaShow (..) )
+import Data.Aeson.Via.Show.Internal
+    ( Expr (..), parseExpr )
+import Data.Map.Strict
+    ( Map )
+import Data.Time
+    ( UTCTime (..) )
+import Test.Hspec
+    ( Spec, context, shouldBe, specify )
+
+import qualified Data.Map.Strict as Map
+
+data Foo = Foo
+    { foo :: Int
+    }
+    deriving stock Show
+    deriving ToJSON via ToJSONViaShow Foo
+
+data Bar = Bar Int Bool
+    deriving stock Show
+    deriving ToJSON via ToJSONViaShow Bar
+
+data Fizz = Fizz { a :: Foo, b :: Bar }
+    deriving stock Show
+    deriving ToJSON via ToJSONViaShow Fizz
+
+newtype MyMap = MyMap (Map Char Bool)
+    deriving stock Show
+    deriving ToJSON via ToJSONViaShow MyMap
+
+data LastUpdate = LastUpdate (Maybe UTCTime)
+    deriving stock Show
+    deriving ToJSON via ToJSONViaShow LastUpdate
+
+data NetworkParameters = NetworkParameters
+    { epoch :: Maybe Int
+    , systemStart :: UTCTime
+    , networkMagic :: NetworkMagic
+    }
+    deriving stock Show
+    deriving ToJSON via ToJSONViaShow NetworkParameters
+
+newtype NetworkMagic = NetworkMagic
+    { unNetworkMagic :: Int
+    }
+    deriving stock Show
+
+data Some = forall a. (Show a, ToJSON a) => Some a
+
+spec :: Spec
+spec = do
+    context "parseExpr" $ do
+        let matrix =
+                [ ( "Foo", Product "Foo" [] )
+                , ( "Foo Foo", Product "Foo" [Product "Foo" []] )
+                , ( "Foo 14", Product "Foo" [Val "14"] )
+                , ( show $ Foo 14 , Record "Foo" [("foo",Val "14")] )
+                , ( show $ Bar 42 True, Product "Bar" [Val "42", Product "True" []] )
+                , ( show $ Fizz (Foo 14) (Bar 42 True)
+                  , Record "Fizz"
+                        [ ("a", Record "Foo" [("foo",Val"14")])
+                        , ("b", Product "Bar" [Val "42", Product "True" []] )
+                        ]
+                  )
+                , ( "[]", List [] )
+                , ( "[1,2,3]", List [Val "1", Val "2", Val "3"] )
+                , ( "fromList [('a',True),('b',False)]", Product "Container"
+                    [ List
+                        [ List [Val "a", Product "True" []]
+                        , List [Val "b", Product "False" []]
+                        ]
+                    ]
+                  )
+                , ( "Health {time = 2021-06-05 17:17:54.710264188 UTC}"
+                  , Record "Health" [("time", Val "2021-06-05 17:17:54.710264188 UTC")]
+                  )
+                , ( "LastUpdate (Just 2021-06-05 17:17:54.710264188 UTC)"
+                  , Product "LastUpdate" [Product "Just" [Val "2021-06-05", Val "17:17:54.710264188", Product "UTC" []]]
+                  )
+                , ( "OgmiosNetwork {networkParameters = NetworkParameters {networkMagic = NetworkMagic {unNetworkMagic = 764824073}, systemStart = SystemStart 2017-09-23 21:44:51 UTC, slotsPerEpoch = EpochSlots {unEpochSlots = 21600}}}"
+                  , Record "OgmiosNetwork"
+                        [ ( "networkParameters", Record "NetworkParameters"
+                            [ ( "networkMagic", Record "NetworkMagic"
+                                [ ( "unNetworkMagic", Val "764824073" )
+                                ]
+                              )
+                            , ( "systemStart", Product "SystemStart"
+                                [ Val "2017-09-23", Val "21:44:51", Product "UTC" []
+                                ]
+                              )
+                            , ( "slotsPerEpoch", Record "EpochSlots"
+                                [ ( "unEpochSlots", Val "21600" )
+                                ]
+                              )
+                            ]
+                          )
+                        ]
+                  )
+                ]
+        forM_ matrix $ \(input, expected) -> do
+            specify input $ parseExpr False input `shouldBe` (expected, "")
+
+    context "ToJSONViaShow" $ do
+        let time = read "2021-06-05 17:17:54.710264188 UTC"
+        let matrix =
+                [ ( Some (Foo 42)
+                  , [aesonQQ|{"Foo":"42"}|]
+                  )
+                , ( Some (Bar 14 True)
+                  , [aesonQQ|{"Bar":["14",true]}|]
+                  )
+                , ( Some (Fizz (Foo 42) (Bar 14 True))
+                  , [aesonQQ|{"Fizz":{"a":"42","b":["14",true]}}|]
+                  )
+                , ( Some (LastUpdate Nothing)
+                  , [aesonQQ|{"LastUpdate": null}|]
+                  )
+                , ( Some (LastUpdate (Just time))
+                  , [aesonQQ|{"LastUpdate": "2021-06-05 17:17:54.710264188 UTC"}|]
+                  )
+                , ( Some (NetworkParameters (Just 42) time (NetworkMagic 14))
+                  , [aesonQQ|{"NetworkParameters": { "epoch": "42", "systemStart": "2021-06-05 17:17:54.710264188 UTC", "networkMagic": "14" } }|]
+                  )
+                , ( Some (NetworkParameters Nothing time (NetworkMagic 14))
+                  , [aesonQQ|{"NetworkParameters": { "epoch": null, "systemStart": "2021-06-05 17:17:54.710264188 UTC", "networkMagic": "14" } }|]
+                  )
+                , ( Some (MyMap $ Map.fromList [('a', True), ('b', False)])
+                  , [aesonQQ|{"MyMap":{"a":true,"b":false}}|]
+                  )
+                ]
+        forM_ matrix $ \(Some input, expected) ->
+            specify (show input) $ toJSON input `shouldBe` expected

--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -3,11 +3,9 @@ cabal-version: 2.0
 -- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: e35d7f4a03f6076120f2e477d63caeb6b7493261b7f8fe91f70477e29d4a3869
 
 name:           ogmios
-version:        4.0.0
+version:        3.2.0
 synopsis:       A JSON-WSP WebSocket client for cardano-node
 description:    Please see the README on GitHub at <https://github.com/cardanosolutions/ogmios/tree/master/server#ogmios-server>
 category:       Web
@@ -154,7 +152,6 @@ library
     , io-sim-classes
     , iohk-monitoring
     , iproute
-    , json-via-show
     , json-wsp
     , memory
     , mtl

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -73,7 +73,6 @@ library:
     - iohk-monitoring
     - iproute
     - json-wsp
-    - json-via-show
     - memory
     - mtl
     - optparse-applicative

--- a/server/src/Ogmios.hs
+++ b/server/src/Ogmios.hs
@@ -2,6 +2,7 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TypeApplications #-}
@@ -80,8 +81,6 @@ import Cardano.Network.Protocol.NodeToClient
     ( Block )
 import Control.Monad.Class.MonadST
     ( MonadST )
-import Data.Aeson.Via.Show
-    ( ToJSONViaShow (..) )
 
 --
 -- App
@@ -90,7 +89,7 @@ import Data.Aeson.Via.Show
 -- | Main application monad.
 newtype App a = App
     { unApp :: ReaderT (Env App) IO a
-    } deriving
+    } deriving newtype
         ( Functor, Applicative, Monad
         , MonadReader (Env App)
         , MonadIO
@@ -135,7 +134,7 @@ data Env (m :: Type -> Type) = Env
     , sampler :: !(Sampler RuntimeStats m)
     , network :: !NetworkParameters
     , options :: !Options
-    } deriving (Generic)
+    } deriving stock (Generic)
 
 newEnvironment
     :: Logger TraceOgmios
@@ -173,7 +172,7 @@ data TraceOgmios where
         :: { networkParameters :: NetworkParameters }
         -> TraceOgmios
     deriving stock (Generic, Show)
-    deriving ToJSON via ToJSONViaShow TraceOgmios
+    deriving anyclass ToJSON
 
 instance HasSeverityAnnotation TraceOgmios where
     getSeverityAnnotation = \case

--- a/server/src/Ogmios.hs
+++ b/server/src/Ogmios.hs
@@ -81,7 +81,7 @@ import Cardano.Network.Protocol.NodeToClient
 import Control.Monad.Class.MonadST
     ( MonadST )
 import Data.Aeson.Via.Show
-    ( GenericToJsonViaShow (..), ViaJson (..) )
+    ( ToJSONViaShow (..) )
 
 --
 -- App
@@ -110,18 +110,18 @@ runWith app = runReaderT (unApp app)
 application :: Logger TraceOgmios -> App ()
 application tr = withDebouncer _10s $ \debouncer -> do
     env@Env{network} <- ask
-    logWith tr (OgmiosNetwork $ ViaJson network)
+    logWith tr (OgmiosNetwork network)
 
-    healthCheckClient <- newHealthCheckClient (contramap (OgmiosHealth . ViaJson) tr) debouncer
+    healthCheckClient <- newHealthCheckClient (contramap OgmiosHealth tr) debouncer
 
-    webSocketApp <- newWebSocketApp (contramap (OgmiosWebSocket . ViaJson) tr) (`runWith` env)
+    webSocketApp <- newWebSocketApp (contramap OgmiosWebSocket tr) (`runWith` env)
     httpApp      <- mkHttpApp @_ @_ @Block (`runWith` env)
 
     concurrently_
         (connectHealthCheckClient
-            (contramap (OgmiosHealth . ViaJson) tr) (`runWith` env) healthCheckClient)
+            (contramap OgmiosHealth tr) (`runWith` env) healthCheckClient)
         (connectHybridServer
-            (contramap (OgmiosServer . ViaJson) tr) webSocketApp httpApp)
+            (contramap OgmiosServer tr) webSocketApp httpApp)
 
 --
 -- Environment
@@ -145,7 +145,7 @@ newEnvironment
 newEnvironment tr network options = do
     health  <- getCurrentTime >>= atomically . newTVar . emptyHealth
     sensors <- newSensors
-    sampler <- newSampler (contramap (OgmiosMetrics . ViaJson) tr)
+    sampler <- newSampler (contramap OgmiosMetrics tr)
     pure $ Env{health,sensors,sampler,network,options}
 
 --
@@ -154,31 +154,31 @@ newEnvironment tr network options = do
 
 data TraceOgmios where
     OgmiosHealth
-        :: { healthCheck :: ViaJson (TraceHealth (Health Block)) }
+        :: { healthCheck :: TraceHealth (Health Block) }
         -> TraceOgmios
 
     OgmiosMetrics
-        :: { metrics :: ViaJson TraceMetrics }
+        :: { metrics :: TraceMetrics }
         -> TraceOgmios
 
     OgmiosWebSocket
-        :: { webSocket :: ViaJson TraceWebSocket }
+        :: { webSocket :: TraceWebSocket }
         -> TraceOgmios
 
     OgmiosServer
-        :: { server :: ViaJson TraceServer }
+        :: { server :: TraceServer }
         -> TraceOgmios
 
     OgmiosNetwork
-        :: { networkParameters :: ViaJson NetworkParameters }
+        :: { networkParameters :: NetworkParameters }
         -> TraceOgmios
     deriving stock (Generic, Show)
-    deriving ToJSON via GenericToJsonViaShow TraceOgmios
+    deriving ToJSON via ToJSONViaShow TraceOgmios
 
 instance HasSeverityAnnotation TraceOgmios where
     getSeverityAnnotation = \case
-        OgmiosHealth (ViaJson msg)  -> getSeverityAnnotation msg
-        OgmiosMetrics (ViaJson msg) -> getSeverityAnnotation msg
-        OgmiosWebSocket (ViaJson msg)  -> getSeverityAnnotation msg
-        OgmiosServer (ViaJson msg)     -> getSeverityAnnotation msg
-        OgmiosNetwork{}      -> Info
+        OgmiosHealth msg    -> getSeverityAnnotation msg
+        OgmiosMetrics msg   -> getSeverityAnnotation msg
+        OgmiosWebSocket msg -> getSeverityAnnotation msg
+        OgmiosServer msg    -> getSeverityAnnotation msg
+        OgmiosNetwork{}     -> Info

--- a/server/src/Ogmios/App/Health.hs
+++ b/server/src/Ogmios/App/Health.hs
@@ -72,7 +72,7 @@ import qualified Ogmios.App.Metrics as Metrics
 import Cardano.Network.Protocol.NodeToClient
     ( Block, Clients (..), connectClient, mkClient )
 import Data.Aeson.Via.Show
-    ( GenericToJsonViaShow (..), ViaJson (..) )
+    ( ToJSONViaShow (..) )
 import Data.Time.Clock
     ( DiffTime, UTCTime )
 import Network.TypedProtocol.Pipelined
@@ -141,7 +141,7 @@ newHealthCheckClient tr Debouncer{debounce} = do
                 , currentEra
                 , metrics
                 }
-            logWith tr (HealthTick $ ViaJson health)
+            logWith tr (HealthTick health)
 
         , txSubmissionClient =
             LocalTxSubmissionClient idle
@@ -344,7 +344,7 @@ newTimeInterpreterClient = do
 
 data TraceHealth s where
     HealthTick
-        :: { status :: ViaJson s }
+        :: { status :: s }
         -> TraceHealth s
 
     HealthFailedToConnect
@@ -359,7 +359,7 @@ data TraceHealth s where
         :: { exception :: SomeException }
         -> TraceHealth s
     deriving stock (Show, Generic)
-    deriving ToJSON via GenericToJsonViaShow (TraceHealth s)
+    deriving ToJSON via ToJSONViaShow (TraceHealth s)
 
 instance HasSeverityAnnotation (TraceHealth s) where
     getSeverityAnnotation = \case

--- a/server/src/Ogmios/App/Metrics.hs
+++ b/server/src/Ogmios/App/Metrics.hs
@@ -54,7 +54,7 @@ import Ogmios.Data.Metrics
 import qualified Ogmios.Control.MonadMetrics as Metrics
 
 import Data.Aeson.Via.Show
-    ( GenericToJsonViaShow (..) )
+    ( ToJSONViaShow (..) )
 import Data.Time.Clock
     ( DiffTime )
 import GHC.Stats
@@ -227,7 +227,7 @@ data TraceMetrics where
         :: { recommendation :: Text }
         -> TraceMetrics
     deriving stock (Generic, Show)
-    deriving ToJSON via GenericToJsonViaShow TraceMetrics
+    deriving ToJSON via ToJSONViaShow TraceMetrics
 
 instance HasSeverityAnnotation TraceMetrics where
     getSeverityAnnotation = \case

--- a/server/src/Ogmios/App/Metrics.hs
+++ b/server/src/Ogmios/App/Metrics.hs
@@ -2,6 +2,7 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingVia #-}
 
 -- Mildly safe here and "necessary" because of ekg's internal store. When
@@ -53,8 +54,6 @@ import Ogmios.Data.Metrics
 
 import qualified Ogmios.Control.MonadMetrics as Metrics
 
-import Data.Aeson.Via.Show
-    ( ToJSONViaShow (..) )
 import Data.Time.Clock
     ( DiffTime )
 import GHC.Stats
@@ -79,7 +78,7 @@ data Sensors (m :: Type -> Type) = Sensors
     , sessionDurationsDistribution :: Distribution m
     , totalMessagesCounter :: Counter m
     , totalUnroutedCounter :: Counter m
-    } deriving (Generic)
+    } deriving stock (Generic)
 
 -- | Initialize new application sensors in 'IO'.
 newSensors
@@ -227,7 +226,7 @@ data TraceMetrics where
         :: { recommendation :: Text }
         -> TraceMetrics
     deriving stock (Generic, Show)
-    deriving ToJSON via ToJSONViaShow TraceMetrics
+    deriving anyclass ToJSON
 
 instance HasSeverityAnnotation TraceMetrics where
     getSeverityAnnotation = \case

--- a/server/src/Ogmios/App/Server.hs
+++ b/server/src/Ogmios/App/Server.hs
@@ -2,6 +2,7 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 
@@ -25,8 +26,6 @@ import Ogmios.Control.MonadWebSocket
 import Ogmios.Data.Json
     ( ToJSON )
 
-import Data.Aeson.Via.Show
-    ( ToJSONViaShow (..) )
 import System.Directory
     ( doesPathExist )
 
@@ -89,9 +88,8 @@ data TraceServer where
     ServerNodeSocketNotFound
         :: { path :: FilePath }
         -> TraceServer
-
     deriving stock (Generic, Show)
-    deriving ToJSON via ToJSONViaShow TraceServer
+    deriving anyclass ToJSON
 
 instance HasSeverityAnnotation TraceServer where
     getSeverityAnnotation = \case

--- a/server/src/Ogmios/App/Server.hs
+++ b/server/src/Ogmios/App/Server.hs
@@ -26,7 +26,7 @@ import Ogmios.Data.Json
     ( ToJSON )
 
 import Data.Aeson.Via.Show
-    ( GenericToJsonViaShow (..) )
+    ( ToJSONViaShow (..) )
 import System.Directory
     ( doesPathExist )
 
@@ -91,7 +91,7 @@ data TraceServer where
         -> TraceServer
 
     deriving stock (Generic, Show)
-    deriving ToJSON via GenericToJsonViaShow TraceServer
+    deriving ToJSON via ToJSONViaShow TraceServer
 
 instance HasSeverityAnnotation TraceServer where
     getSeverityAnnotation = \case

--- a/server/src/Ogmios/App/Server/WebSocket.hs
+++ b/server/src/Ogmios/App/Server/WebSocket.hs
@@ -89,7 +89,7 @@ import Cardano.Network.Protocol.NodeToClient
 import Cardano.Network.Protocol.NodeToClient.Trace
     ( TraceClient )
 import Data.Aeson.Via.Show
-    ( GenericToJsonViaShow (..) )
+    ( ToJSONViaShow (..) )
 import Network.HTTP.Types.Header
     ( hUserAgent )
 import Ouroboros.Network.NodeToClient.Version
@@ -308,7 +308,7 @@ data TraceWebSocket where
         :: { ioException :: IOException }
         -> TraceWebSocket
     deriving stock (Generic, Show)
-    deriving ToJSON via GenericToJsonViaShow TraceWebSocket
+    deriving ToJSON via ToJSONViaShow TraceWebSocket
 
 instance HasSeverityAnnotation TraceWebSocket where
     getSeverityAnnotation = \case

--- a/server/src/Ogmios/Data/Json/Prelude.hs
+++ b/server/src/Ogmios/Data/Json/Prelude.hs
@@ -2,6 +2,9 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingVia #-}
+
 -- This is used to define the 'keepRedundantContraint' helper here where it is
 -- safe to define, and use it in other Json modules where we do not want to turn
 -- -fno-warn-redundant-constraints for the entire module, but still want some
@@ -183,7 +186,8 @@ inefficientEncodingToValue = unsafeDecodeValue . Json.encodingToLazyByteString
 data SerializationMode
     = FullSerialization
     | CompactSerialization
-    deriving (Generic, Show)
+    deriving stock (Generic, Show)
+    deriving anyclass (ToJSON)
 
 --
 -- Basic Types

--- a/server/stack.yaml
+++ b/server/stack.yaml
@@ -9,4 +9,3 @@ packages:
 - modules/git-th
 - modules/hspec-json-schema
 - modules/json-wsp
-- modules/json-via-show


### PR DESCRIPTION
- :round_pushpin: **Attempt to rework json-via-show**
     In the end, it kinda works but it feels *very* hacky and it makes me
   uncomfortable knowing that one of the critical part of the system may
   rely on something which may choke and collapse at the first input.

   It was a fun experiment though, and I wish that the `Show` interface
   was a bit more normalized in Haskell to be actually any useful for
   anything beyond simple human consumption.

- :round_pushpin: **Write JSON encoder for the 'TraceClient' wrapping the ouroboros network traces**
    This is mainly for logging, not perfect but still far better than printing things via show. I've also increased the severity of the handshake traces to Info since this is actually pretty useful to have around hard-forks and, in general. Handshake traces aren't much verbose so it's good to keep anyway.

- :round_pushpin: **Remove use of 'json-via-show', fallback to generically derived JSON**
    Note that, this requires an orphan instance for the 'TraceClient', which is a quite small price to pay in the end compared to the awkwardness of the json-via-show approach. This is overall MUCH cleaner and robust.