### PR TITLE
Unit tests for Ouroboros mini-protocols using simulated IO

### DIFF
--- a/server/modules/cardano-client/src/Cardano/Network/Protocol/NodeToClient.hs
+++ b/server/modules/cardano-client/src/Cardano/Network/Protocol/NodeToClient.hs
@@ -24,6 +24,17 @@ module Cardano.Network.Protocol.NodeToClient
     -- * Connecting
     , connectClient
     , codecs
+    , cChainSyncCodec
+    , cTxSubmissionCodec
+    , cStateQueryCodec
+    , nodeToClientV_Latest
+
+    -- * Running
+    , runPeer
+    , runPipelinedPeer
+    , chainSyncClientPeerPipelined
+    , localStateQueryClientPeer
+    , localTxSubmissionClientPeer
 
     -- * Helpers / Re-exports
     , MuxError (..)
@@ -179,6 +190,9 @@ connectClient tr client vData addr = liftIO $ withIOManager $ \iocp -> do
         { nctMuxTracer = nullTracer
         , nctHandshakeTracer = contramap TrHandshake tr
         }
+
+nodeToClientV_Latest :: NodeToClientVersion
+nodeToClientV_Latest = NodeToClientV_9
 
 -- | Construct a network client
 mkClient

--- a/server/modules/json-wsp/CHANGELOG.md
+++ b/server/modules/json-wsp/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [edge] 
+
+### Added
+
+- Expose `FaultCode`.
+
+### Changed
+
+- Handlers now also provide an extra function to create a `Fault`. It allows for answering with a fault while preserving the reflection value. Seemingly, `Fault` also now have a `mirror` field.
+
+### Removed
+
+ø
+
 ## [1.1.0] -- 2021-05-06
 
 ### Added

--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -172,6 +172,7 @@ library
     , time
     , time-manager
     , typed-protocols
+    , unordered-containers
     , vector
     , wai
     , wai-routes
@@ -236,7 +237,10 @@ test-suite unit
   main-is: Spec.hs
   other-modules:
       Ogmios.App.OptionsSpec
+      Ogmios.App.Protocol.ChainSyncSpec
       Ogmios.Data.JsonSpec
+      Test.App.Protocol.Util
+      Test.Generators
       Paths_ogmios
   hs-source-dirs:
       test/unit
@@ -290,6 +294,8 @@ test-suite unit
     , hedgehog-quickcheck
     , hspec
     , hspec-json-schema
+    , io-sim
+    , io-sim-classes
     , json-wsp
     , ogmios
     , ouroboros-consensus
@@ -298,7 +304,11 @@ test-suite unit
     , ouroboros-consensus-cardano-test
     , ouroboros-consensus-shelley
     , ouroboros-network
+    , ouroboros-network-framework
+    , random
     , relude
     , shelley-spec-ledger
     , shelley-spec-ledger-test
+    , typed-protocols
+    , typed-protocols-examples
   default-language: Haskell2010

--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -238,6 +238,7 @@ test-suite unit
   other-modules:
       Ogmios.App.OptionsSpec
       Ogmios.App.Protocol.ChainSyncSpec
+      Ogmios.App.Protocol.StateQuerySpec
       Ogmios.Data.JsonSpec
       Test.App.Protocol.Util
       Test.Generators
@@ -291,6 +292,7 @@ test-suite unit
     , cardano-ledger-core
     , cardano-slotting
     , generic-arbitrary
+    , generics-sop
     , hedgehog-quickcheck
     , hspec
     , hspec-json-schema

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -128,6 +128,7 @@ tests:
     - cardano-ledger-core
     - cardano-slotting
     - generic-arbitrary
+    - generics-sop
     - hedgehog-quickcheck
     - hspec
     - hspec-json-schema

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -92,6 +92,7 @@ library:
     - time
     - time-manager
     - typed-protocols
+    - unordered-containers
     - vector
     - wai
     - wai-routes
@@ -130,6 +131,8 @@ tests:
     - hedgehog-quickcheck
     - hspec
     - hspec-json-schema
+    - io-sim
+    - io-sim-classes
     - json-wsp
     - ogmios
     - ouroboros-consensus
@@ -138,9 +141,13 @@ tests:
     - ouroboros-consensus-cardano-test
     - ouroboros-consensus-shelley
     - ouroboros-network
+    - ouroboros-network-framework
     - QuickCheck
+    - random
     - relude
     - shelley-spec-ledger
     - shelley-spec-ledger-test
+    - typed-protocols
+    - typed-protocols-examples
     build-tools:
     - hspec-discover

--- a/server/src/Ogmios/App/Options.hs
+++ b/server/src/Ogmios/App/Options.hs
@@ -126,6 +126,7 @@ parserInfo = info (helper <*> parser) $ mempty
                 <*> serverHostOption
                 <*> serverPortOption
                 <*> connectionTimeoutOption
+                <*> maxInFlightOption
                 <*> logLevelOption
             )
         )
@@ -139,6 +140,7 @@ data Options = Options
     , serverHost :: !String
     , serverPort :: !Int
     , connectionTimeout :: !Int
+    , maxInFlight :: !Int
     , logLevel :: !Severity
     } deriving (Generic, Eq, Show)
 
@@ -169,13 +171,22 @@ serverPortOption = option auto $ mempty
     <> value 1337
     <> showDefault
 
--- | [--websocket-timeout], default: 90s
+-- | [--timeout=SECONDS], default: 90s
 connectionTimeoutOption :: Parser Int
 connectionTimeoutOption = option auto $ mempty
     <> long "timeout"
     <> metavar "SECONDS"
     <> help "Number of seconds of inactivity after which the server should close client connections."
     <> value 90
+    <> showDefault
+
+-- | [--max-in-flight=INT], default: 1000
+maxInFlightOption :: Parser Int
+maxInFlightOption = option auto $ mempty
+    <> long "max-in-flight"
+    <> metavar "INT"
+    <> help "Max number of ChainSync requests which can be pipelined at once. Only apply to the chain-sync protocol."
+    <> value 1000
     <> showDefault
 
 -- | [--log-level=SEVERITY], default: Info

--- a/server/src/Ogmios/App/Protocol.hs
+++ b/server/src/Ogmios/App/Protocol.hs
@@ -73,7 +73,7 @@ onUnmatchedMessage
     => ByteString
     -> Json
 onUnmatchedMessage blob = do
-    Wsp.mkFault $ Wsp.clientFault $ T.unpack fault
+    Wsp.mkFault $ Wsp.clientFault Nothing $ T.unpack fault
   where
     fault =
         "Invalid request: " <> modifyAesonFailure details <> "."

--- a/server/src/Ogmios/App/Protocol/ChainSync.hs
+++ b/server/src/Ogmios/App/Protocol/ChainSync.hs
@@ -113,9 +113,6 @@ mkChainSyncClient maxInFlight ChainSyncCodecs{..} queue yield =
     clientStIdle n@(Succ prev) buffer = tryAwait >>= \case
         -- If there's no immediate incoming message, we take this opportunity to
         -- wait and collect one response.
-        Nothing | Seq.null buffer ->
-            clientStIdle n buffer
-
         Nothing ->
             pure $ CollectResponse Nothing (clientStNext prev buffer)
 

--- a/server/src/Ogmios/App/Protocol/StateQuery.hs
+++ b/server/src/Ogmios/App/Protocol/StateQuery.hs
@@ -108,12 +108,12 @@ mkStateQueryClient StateQueryCodecs{..} queue yield =
     clientStIdle
         :: m (LSQ.ClientStIdle block point query m ())
     clientStIdle = await >>= \case
-        MsgAcquire (Acquire pt) toResponse ->
+        MsgAcquire (Acquire pt) toResponse _ ->
             pure $ LSQ.SendMsgAcquire (Just pt) (clientStAcquiring pt toResponse)
-        MsgRelease Release toResponse -> do
+        MsgRelease Release toResponse _ -> do
             yield $ encodeReleaseResponse (toResponse Released)
             clientStIdle
-        MsgQuery query toResponse -> do
+        MsgQuery query toResponse _ -> do
             pure $ LSQ.SendMsgAcquire Nothing (clientStAcquiringTip query toResponse)
 
     clientStAcquiring
@@ -160,12 +160,12 @@ mkStateQueryClient StateQueryCodecs{..} queue yield =
     clientStAcquired
         :: m (LSQ.ClientStAcquired block point query m ())
     clientStAcquired = await >>= \case
-        MsgAcquire (Acquire pt) toResponse ->
+        MsgAcquire (Acquire pt) toResponse _ ->
             pure $ LSQ.SendMsgReAcquire (Just pt) (clientStAcquiring pt toResponse)
-        MsgRelease Release toResponse -> do
+        MsgRelease Release toResponse _ -> do
             yield $ encodeReleaseResponse (toResponse Released)
             pure $ LSQ.SendMsgRelease clientStIdle
-        MsgQuery (Query queryInEra) toResponse ->
+        MsgQuery (Query queryInEra) toResponse _ ->
             withCurrentEra queryInEra $ \case
                 Nothing -> do
                     let response = QueryUnavailableInCurrentEra

--- a/server/src/Ogmios/App/Protocol/TxSubmission.hs
+++ b/server/src/Ogmios/App/Protocol/TxSubmission.hs
@@ -62,7 +62,7 @@ mkTxSubmissionClient TxSubmissionCodecs{..} queue yield =
     clientStIdle
         :: m (LocalTxClientStIdle (SubmitTxPayload block) (SubmitTxError block) m ())
     clientStIdle = await >>= \case
-        MsgSubmitTx SubmitTx{bytes} toResponse -> do
+        MsgSubmitTx SubmitTx{bytes} toResponse _ -> do
             pure $ SendMsgSubmitTx bytes $ \result -> do
                 yield $ encodeSubmitTxResponse $ toResponse result
                 clientStIdle

--- a/server/src/Ogmios/App/Server/WebSocket.hs
+++ b/server/src/Ogmios/App/Server/WebSocket.hs
@@ -144,7 +144,7 @@ newWebSocketApp tr unliftIO = do
     onIOException conn e = do
         logWith tr $ WebSocketFailedToConnect $ show e
         let msg = "Connection with the node lost or failed."
-        close conn $ toStrict $ Json.encode $ Wsp.serverFault msg
+        close conn $ toStrict $ Json.encode $ Wsp.serverFault Nothing msg
 
     onExceptions :: m () -> m ()
     onExceptions
@@ -247,19 +247,19 @@ withOuroborosClients mode maxInFlight sensors conn action = do
                 matched <- Wsp.match bytes
                     (count (totalUnroutedCounter sensors) *> defaultHandler bytes)
                     [ Wsp.Handler decodeRequestNext
-                        (\r -> push chainSyncQ . MsgRequestNext r)
+                        (\r t -> push chainSyncQ . MsgRequestNext r t)
                     , Wsp.Handler decodeFindIntersect
-                        (\r -> push chainSyncQ . MsgFindIntersect r)
+                        (\r t -> push chainSyncQ . MsgFindIntersect r t)
 
                     , Wsp.Handler decodeAcquire
-                        (\r -> push stateQueryQ . MsgAcquire r)
+                        (\r t -> push stateQueryQ . MsgAcquire r t)
                     , Wsp.Handler decodeRelease
-                        (\r -> push stateQueryQ . MsgRelease r)
+                        (\r t -> push stateQueryQ . MsgRelease r t)
                     , Wsp.Handler decodeQuery
-                        (\r -> push stateQueryQ . MsgQuery r)
+                        (\r t -> push stateQueryQ . MsgQuery r t)
 
                     , Wsp.Handler decodeSubmitTx
-                        (\r -> push txSubmissionQ .  MsgSubmitTx r)
+                        (\r t -> push txSubmissionQ .  MsgSubmitTx r t)
                     ]
                 routeMessage matched chainSyncQ stateQueryQ txSubmissionQ
 

--- a/server/src/Ogmios/Data/Json/Prelude.hs
+++ b/server/src/Ogmios/Data/Json/Prelude.hs
@@ -25,6 +25,7 @@ module Ogmios.Data.Json.Prelude
     , choice
     , inefficientEncodingToValue
     , (.:)
+    , at
 
       -- * Re-Exports
     , Coin (..)
@@ -112,6 +113,8 @@ import Data.ByteString.Base64
     ( encodeBase64 )
 import Data.ByteString.Bech32
     ( HumanReadablePart, encodeBech32 )
+import Data.HashMap.Strict
+    ( (!?) )
 import Data.IP
     ( IPv4, IPv6 )
 import Data.Scientific
@@ -150,6 +153,11 @@ decodeWith decoder =
 choice :: (Alternative f, MonadFail f) => String -> [a -> f b] -> a -> f b
 choice entity xs a =
     asum (xs <*> pure a) <|> fail ("invalid " <> entity)
+
+at :: Text -> Json.Value -> Maybe Json.Value
+at key = \case
+    Json.Object m -> m !? key
+    _ -> Nothing
 
 keepRedundantConstraint :: c => Proxy c -> ()
 keepRedundantConstraint _ = ()

--- a/server/src/Ogmios/Data/Json/Query.hs
+++ b/server/src/Ogmios/Data/Json/Query.hs
@@ -20,6 +20,7 @@ module Ogmios.Data.Json.Query
     , encodeNonMyopicMemberRewards
     , encodeOneEraHash
     , encodePoint
+    , encodeEpochNo
 
       -- * Parsers
     , parseGetEraStart

--- a/server/src/Ogmios/Data/Protocol/ChainSync.hs
+++ b/server/src/Ogmios/Data/Protocol/ChainSync.hs
@@ -90,9 +90,11 @@ data ChainSyncMessage block
     = MsgFindIntersect
         (FindIntersect block)
         (Wsp.ToResponse (FindIntersectResponse block))
+        Wsp.ToFault
     | MsgRequestNext
         RequestNext
         (Wsp.ToResponse (RequestNextResponse block))
+        Wsp.ToFault
 
 --
 -- FindIntersect

--- a/server/src/Ogmios/Data/Protocol/StateQuery.hs
+++ b/server/src/Ogmios/Data/Protocol/StateQuery.hs
@@ -4,6 +4,7 @@
 
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- NOTE:
 -- This module uses partial record field accessor to automatically derive
@@ -48,7 +49,7 @@ import Ogmios.Data.Protocol
     ()
 
 import Ouroboros.Network.Block
-    ( Point (..) )
+    ( Point (..), StandardHash )
 import Ouroboros.Network.Protocol.LocalStateQuery.Type
     ( AcquireFailure )
 
@@ -119,6 +120,15 @@ data StateQueryMessage block
         (Query block)
         (Wsp.ToResponse (QueryResponse block))
         Wsp.ToFault
+
+instance StandardHash block => Show (StateQueryMessage block) where
+    showsPrec i = \case
+        MsgAcquire acquire _ _ -> T.showParen (i >= 10)
+            (T.showString $ "MsgAcquire " <> show acquire)
+        MsgRelease release _ _ -> T.showParen (i >= 10)
+            (T.showString $ "MsgRelease " <> show release)
+        MsgQuery{} -> T.showParen (i >= 10)
+            (T.showString "MsgQuery")
 
 --
 -- Acquire

--- a/server/src/Ogmios/Data/Protocol/StateQuery.hs
+++ b/server/src/Ogmios/Data/Protocol/StateQuery.hs
@@ -110,12 +110,15 @@ data StateQueryMessage block
     = MsgAcquire
         (Acquire block)
         (Wsp.ToResponse (AcquireResponse block))
+        Wsp.ToFault
     | MsgRelease
         Release
         (Wsp.ToResponse ReleaseResponse)
+        Wsp.ToFault
     | MsgQuery
         (Query block)
         (Wsp.ToResponse (QueryResponse block))
+        Wsp.ToFault
 
 --
 -- Acquire

--- a/server/src/Ogmios/Data/Protocol/TxSubmission.hs
+++ b/server/src/Ogmios/Data/Protocol/TxSubmission.hs
@@ -76,6 +76,7 @@ data TxSubmissionMessage block
     = MsgSubmitTx
         (SubmitTx block)
         (Wsp.ToResponse (SubmitTxResponse block))
+        Wsp.ToFault
 
 --
 -- SubmitTx

--- a/server/src/Ogmios/Prelude.hs
+++ b/server/src/Ogmios/Prelude.hs
@@ -15,6 +15,7 @@ module Ogmios.Prelude
 import Relude hiding
     ( Nat
     , STM
+    , TMVar
     , TVar
     , atomically
     , newEmptyTMVar

--- a/server/test/unit/Ogmios/App/Protocol/ChainSyncSpec.hs
+++ b/server/test/unit/Ogmios/App/Protocol/ChainSyncSpec.hs
@@ -20,7 +20,7 @@ import Cardano.Network.Protocol.NodeToClient
     , runPipelinedPeer
     )
 import Data.Aeson
-    ( ToJSON (..), Value (..) )
+    ( ToJSON (..) )
 import Network.TypedProtocol.Codec
     ( Codec (..), PeerHasAgency (..), SomeMessage (..), runDecoder )
 import Ogmios.App.Options
@@ -57,6 +57,7 @@ import System.Random
     ( StdGen, random )
 import Test.App.Protocol.Util
     ( PeerTerminatedUnexpectedly (..)
+    , expectWSPFault
     , expectWSPResponse
     , prop_inIOSim
     , withMockChannel
@@ -68,28 +69,86 @@ import Test.Hspec
 import Test.Hspec.QuickCheck
     ( prop )
 import Test.QuickCheck
-    ( Gen, forAll, frequency )
+    ( Gen, Property, checkCoverage, choose, cover, forAll, frequency, oneof )
 
+import qualified Codec.Json.Wsp as Wsp
 import qualified Codec.Json.Wsp.Handler as Wsp
 import qualified Ouroboros.Network.Protocol.ChainSync.Type as ChainSync
 
+type Protocol = ChainSync Block (Point Block) (Tip Block)
+
 maxInFlight :: MaxInFlight
-maxInFlight = 10
+maxInFlight = 3
 
 spec :: Spec
 spec = parallel $ do
     context "ChainSync" $ do
-        prop "Basic scenario"
-            $ forAll genMirror $ \mirror -> prop_inIOSim
-            $ withChainSyncClient $ \send receive -> do
-                send $ MsgRequestNext RequestNext (Wsp.Response mirror)
+        parallel $ prop "Basic send/recv" prop_basicSendRecv
+        parallel $ prop "Saturate in-flight queue" prop_manyInFlight
+        parallel $ prop "Interleave findIntersect with requestNext" prop_interleave
+  where
+    -- We expect that client can submit request (either 'RequestNext' or
+    -- 'FindIntersect') and receive a corresponding response, preseving the
+    -- reflection value (a.k.a mirror).
+    prop_basicSendRecv :: Property
+    prop_basicSendRecv = forAll genMirror $ \mirror ->
+        cover 30 (isJust mirror) "with mirror" $
+        cover 30 (isNothing mirror) "without mirror" $
+        checkCoverage (p mirror)
+      where
+        p mirror = prop_inIOSim $ withChainSyncClient $ \send receive -> do
+            send $ requestNext mirror
+            expectWSPResponse @"RequestNext" receive (toJSON mirror)
+
+            send $ findIntersect mirror []
+            expectWSPResponse @"FindIntersect" receive (toJSON mirror)
+
+    -- The chain-sync client will pipeline requests up to a certain point.
+    -- Indeed, WebSockets do allow for (theorically) infinite pipelining,
+    -- whereas the Ouroboros framework only allow for finite one. This means
+    -- that the application client has to keep track of the pipelined requests,
+    -- and choose whether to collect response for previously sent requests, or
+    -- to continue pipelining new incoming requests.
+    --
+    -- There's therefore a different behavior depending on the number of requests
+    -- in flight, which this property captures.
+    prop_manyInFlight :: Property
+    prop_manyInFlight = forAll genMaxInFlight $ \nMax ->
+        cover 20 (nMax > maxInFlight) "> maxInFlight" $
+        cover 20 (nMax >= maxInFlight - 1 && nMax <= maxInFlight + 1) "=~ maxInFlight" $
+        cover 20 (nMax < maxInFlight) "< maxInFlight" $
+        checkCoverage (p nMax)
+      where
+        p nMax = prop_inIOSim $ withChainSyncClient $ \send receive -> do
+            mirrors <- forM [0 .. nMax] $ \(i :: Int) -> do
+                let mirror = Just $ toJSON i
+                mirror <$ send (requestNext mirror)
+            forM_ mirrors $ \mirror -> do
                 expectWSPResponse @"RequestNext" receive (toJSON mirror)
 
-                send $ MsgFindIntersect (FindIntersect []) (Wsp.Response mirror)
-                expectWSPResponse @"FindIntersect" receive (toJSON mirror)
+        genMaxInFlight :: Gen MaxInFlight
+        genMaxInFlight = oneof
+            [ choose (0, maxInFlight - 1)
+            , choose (maxInFlight - 1, maxInFlight + 1)
+            , choose (maxInFlight + 1, 2 * maxInFlight)
+            ]
 
-
-type Protocol = ChainSync Block (Point Block) (Tip Block)
+    -- The Ouroboros typed protocol follows a strategy of correct-by-construction
+    -- and represents protocol as state machines, fully captured at the
+    -- type-level. We can't model this through a WebSocket, and clients may
+    -- therefore produce invalid transitions. One of them is for instance,
+    -- asking for an intersection while they are still requests in flight that
+    -- haven't been collected. In this case, Ogmios returns a client error.
+    prop_interleave :: Property
+    prop_interleave = forAll genMirror $ \mirror ->
+        cover 30 (isJust mirror) "with mirror" $
+        cover 30 (isNothing mirror) "without mirror" $
+        checkCoverage (p mirror)
+      where
+        p mirror = prop_inIOSim $ withChainSyncClient $ \send receive -> do
+            send $ requestNext Nothing
+            send $ findIntersect mirror []
+            expectWSPFault receive Wsp.FaultClient (toJSON mirror)
 
 withChainSyncClient
     :: (MonadSTM m, MonadOuroboros m)
@@ -151,3 +210,15 @@ chainSyncMockPeer seed codec (recv, send) = flip evalStateT seed $ forever $ do
         [ (10, ChainSync.MsgIntersectFound <$> genPoint <*> genTip)
         , ( 1, ChainSync.MsgIntersectNotFound <$> genTip)
         ]
+
+--
+-- Helpers
+--
+
+requestNext :: Wsp.Mirror -> ChainSyncMessage Block
+requestNext mirror =
+    MsgRequestNext RequestNext (Wsp.Response mirror) (Wsp.Fault mirror)
+
+findIntersect :: Wsp.Mirror -> [Point Block] -> ChainSyncMessage Block
+findIntersect mirror points =
+    MsgFindIntersect (FindIntersect points) (Wsp.Response mirror) (Wsp.Fault mirror)

--- a/server/test/unit/Ogmios/App/Protocol/ChainSyncSpec.hs
+++ b/server/test/unit/Ogmios/App/Protocol/ChainSyncSpec.hs
@@ -1,0 +1,153 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Ogmios.App.Protocol.ChainSyncSpec
+    ( spec
+    ) where
+
+import Ogmios.Prelude
+
+import Cardano.Network.Protocol.NodeToClient
+    ( Block
+    , cChainSyncCodec
+    , chainSyncClientPeerPipelined
+    , codecs
+    , nodeToClientV_Latest
+    , runPipelinedPeer
+    )
+import Data.Aeson
+    ( ToJSON (..), Value (..) )
+import Network.TypedProtocol.Codec
+    ( Codec (..), PeerHasAgency (..), SomeMessage (..), runDecoder )
+import Ogmios.App.Options
+    ( defaultSlotsPerEpoch )
+import Ogmios.App.Protocol.ChainSync
+    ( mkChainSyncClient )
+import Ogmios.Control.Exception
+    ( MonadThrow (..) )
+import Ogmios.Control.MonadAsync
+    ( race )
+import Ogmios.Control.MonadLog
+    ( nullTracer )
+import Ogmios.Control.MonadOuroboros
+    ( MonadOuroboros )
+import Ogmios.Control.MonadSTM
+    ( MonadSTM (..), newTQueue, readTQueue, writeTQueue )
+import Ogmios.Data.Json
+    ( Json, SerializationMode (..), encodeBlock, encodePoint, encodeTip )
+import Ogmios.Data.Protocol.ChainSync
+    ( ChainSyncMessage (..)
+    , FindIntersect (..)
+    , RequestNext (..)
+    , mkChainSyncCodecs
+    )
+import Ouroboros.Network.Block
+    ( Point (..), Tip (..) )
+import Ouroboros.Network.Protocol.ChainSync.Type
+    ( ChainSync (..)
+    , ClientHasAgency (..)
+    , ServerHasAgency (..)
+    , TokNextKind (..)
+    )
+import System.Random
+    ( StdGen, random )
+import Test.App.Protocol.Util
+    ( PeerTerminatedUnexpectedly (..)
+    , expectWSPResponse
+    , prop_inIOSim
+    , withMockChannel
+    )
+import Test.Generators
+    ( genBlock, genPoint, genTip, generateWith )
+import Test.Hspec
+    ( Spec, context, parallel, specify )
+import Test.QuickCheck
+    ( Gen, frequency )
+
+import qualified Codec.Json.Wsp.Handler as Wsp
+import qualified Ouroboros.Network.Protocol.ChainSync.Type as ChainSync
+
+spec :: Spec
+spec = parallel $ do
+    context "ChainSync" $ do
+        specify "Basic scenario" $ prop_inIOSim $ withChainSyncClient $ \send receive -> do
+            let mirror = toJSON (14 :: Int)
+
+            send $ MsgRequestNext RequestNext (Wsp.Response Nothing)
+            expectWSPResponse @"RequestNext" receive Null
+
+            send $ MsgRequestNext RequestNext (Wsp.Response $ Just mirror)
+            expectWSPResponse @"RequestNext" receive mirror
+
+            send $ MsgFindIntersect (FindIntersect []) (Wsp.Response Nothing)
+            expectWSPResponse @"FindIntersect" receive Null
+
+            send $ MsgFindIntersect (FindIntersect []) (Wsp.Response $ Just mirror)
+            expectWSPResponse @"FindIntersect" receive mirror
+
+type Protocol = ChainSync Block (Point Block) (Tip Block)
+
+withChainSyncClient
+    :: (MonadSTM m, MonadOuroboros m)
+    => ((ChainSyncMessage Block -> m ()) ->  m Json -> m a)
+    -> StdGen
+    -> m a
+withChainSyncClient action seed = do
+    (recvQ, sendQ) <- atomically $ (,) <$> newTQueue <*> newTQueue
+    let mode = CompactSerialization
+    let innerCodecs = mkChainSyncCodecs (encodeBlock mode) encodePoint encodeTip
+    let client = mkChainSyncClient innerCodecs recvQ (atomically . writeTQueue sendQ)
+    let codec = codecs defaultSlotsPerEpoch nodeToClientV_Latest & cChainSyncCodec
+    withMockChannel (chainSyncMockPeer seed codec) $ \channel -> do
+        result <- race
+            (runPipelinedPeer nullTracer codec channel (chainSyncClientPeerPipelined client))
+            (action (atomically . writeTQueue recvQ) (atomically $ readTQueue sendQ))
+        case result of
+            Left{}  -> throwIO PeerTerminatedUnexpectedly
+            Right a -> pure a
+
+chainSyncMockPeer
+    :: forall m failure. (MonadSTM m, Show failure)
+    => StdGen
+        -- ^ Random generator
+    -> Codec Protocol failure m LByteString
+        -- ^ Codec for the given protocol
+    -> (m LByteString, LByteString -> m ())
+        -- ^ Read/Write from/To the channel
+    -> m ()
+chainSyncMockPeer seed codec (recv, send) = flip evalStateT seed $ forever $ do
+    req <- lift recv
+    res <- lift (decodeOrThrow req) >>= \case
+        SomeMessage ChainSync.MsgRequestNext -> do
+            msg <- generateWith genRequestNextResponse <$> state random
+            pure $ encode codec (ServerAgency $ TokNext TokCanAwait) msg
+        SomeMessage ChainSync.MsgFindIntersect{} -> do
+            msg <- generateWith genFindIntersectResponse <$> state random
+            pure $ encode codec (ServerAgency TokIntersect) msg
+        SomeMessage ChainSync.MsgDone ->
+            error "MsgDone"
+    lift $ send res
+  where
+    decodeOrThrow bytes = do
+        decoder <- decode codec (ClientAgency TokIdle)
+        runDecoder [bytes] decoder >>= \case
+            Left failure -> error (show failure)
+            Right msg -> pure msg
+
+    genRequestNextResponse
+        :: Gen (ChainSync.Message Protocol ('StNext any) 'StIdle)
+    genRequestNextResponse = frequency
+        [ (10, ChainSync.MsgRollForward <$> genBlock <*> genTip)
+        , ( 1, ChainSync.MsgRollBackward <$> genPoint <*> genTip)
+        ]
+
+    genFindIntersectResponse
+        :: Gen (ChainSync.Message Protocol 'StIntersect 'StIdle)
+    genFindIntersectResponse = frequency
+        [ (10, ChainSync.MsgIntersectFound <$> genPoint <*> genTip)
+        , ( 1, ChainSync.MsgIntersectNotFound <$> genTip)
+        ]

--- a/server/test/unit/Ogmios/App/Protocol/ChainSyncSpec.hs
+++ b/server/test/unit/Ogmios/App/Protocol/ChainSyncSpec.hs
@@ -26,7 +26,7 @@ import Network.TypedProtocol.Codec
 import Ogmios.App.Options
     ( defaultSlotsPerEpoch )
 import Ogmios.App.Protocol.ChainSync
-    ( mkChainSyncClient )
+    ( MaxInFlight, mkChainSyncClient )
 import Ogmios.Control.Exception
     ( MonadThrow (..) )
 import Ogmios.Control.MonadAsync
@@ -100,7 +100,7 @@ withChainSyncClient action seed = do
     (recvQ, sendQ) <- atomically $ (,) <$> newTQueue <*> newTQueue
     let mode = CompactSerialization
     let innerCodecs = mkChainSyncCodecs (encodeBlock mode) encodePoint encodeTip
-    let client = mkChainSyncClient innerCodecs recvQ (atomically . writeTQueue sendQ)
+    let client = mkChainSyncClient maxInFlight innerCodecs recvQ (atomically . writeTQueue sendQ)
     let codec = codecs defaultSlotsPerEpoch nodeToClientV_Latest & cChainSyncCodec
     withMockChannel (chainSyncMockPeer seed codec) $ \channel -> do
         result <- race

--- a/server/test/unit/Ogmios/App/Protocol/StateQuerySpec.hs
+++ b/server/test/unit/Ogmios/App/Protocol/StateQuerySpec.hs
@@ -1,0 +1,307 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Ogmios.App.Protocol.StateQuerySpec
+    ( spec
+    ) where
+
+import Ogmios.Prelude
+
+import Cardano.Network.Protocol.NodeToClient
+    ( Block
+    , cStateQueryCodec
+    , codecs
+    , localStateQueryClientPeer
+    , nodeToClientV_Latest
+    , runPeer
+    )
+import Data.Aeson
+    ( ToJSON (..) )
+import Data.SOP.Strict
+    ( NS (..) )
+import Generics.SOP
+    ( K (..) )
+import GHC.TypeLits
+    ( KnownSymbol )
+import Network.TypedProtocol.Codec
+    ( Codec (..), PeerHasAgency (..), SomeMessage (..), runDecoder )
+import Ogmios.App.Options
+    ( defaultSlotsPerEpoch )
+import Ogmios.App.Protocol.StateQuery
+    ( mkStateQueryClient )
+import Ogmios.Control.Exception
+    ( MonadCatch (..), MonadThrow (..) )
+import Ogmios.Control.MonadAsync
+    ( race )
+import Ogmios.Control.MonadLog
+    ( nullTracer )
+import Ogmios.Control.MonadOuroboros
+    ( MonadOuroboros )
+import Ogmios.Control.MonadSTM
+    ( MonadSTM (..), newTQueue, readTQueue, writeTQueue )
+import Ogmios.Data.Json
+    ( Json, encodeAcquireFailure, encodePoint )
+import Ogmios.Data.Json.Query
+    ( SomeQuery (..), encodeEpochNo, encodeMismatchEraInfo )
+import Ogmios.Data.Protocol.StateQuery
+    ( Acquire (..)
+    , Query (Query)
+    , Release (..)
+    , StateQueryMessage (..)
+    , mkStateQueryCodecs
+    )
+import Ouroboros.Consensus.Byron.Ledger.Block
+    ( ByronBlock )
+import Ouroboros.Consensus.Cardano.Block
+    ( AllegraEra
+    , AlonzoEra
+    , BlockQuery (..)
+    , CardanoEras
+    , MaryEra
+    , ShelleyEra
+    )
+import Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock
+    ( EraIndex (..) )
+import Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
+    ( QueryHardFork (..) )
+import Ouroboros.Consensus.Shelley.Ledger
+    ( ShelleyBlock )
+import Ouroboros.Consensus.Shelley.Ledger.Query
+    ( BlockQuery (..) )
+import Ouroboros.Network.Block
+    ( Point (..) )
+import Ouroboros.Network.Protocol.LocalStateQuery.Type
+    ( ClientHasAgency (..), LocalStateQuery (..), ServerHasAgency (..) )
+import System.Random
+    ( StdGen, random )
+import Test.App.Protocol.Util
+    ( FailedToDecodeMsg (..)
+    , PeerTerminatedUnexpectedly (..)
+    , expectWSPResponse
+    , prop_inIOSim
+    , withMockChannel
+    )
+import Test.Generators
+    ( genAcquireFailure, genEpochResult, genMirror, genPoint, generateWith )
+import Test.Hspec
+    ( Spec, context, parallel )
+import Test.Hspec.QuickCheck
+    ( prop )
+import Test.QuickCheck
+    ( Gen
+    , Property
+    , checkCoverage
+    , cover
+    , elements
+    , forAll
+    , frequency
+    , listOf1
+    )
+
+import qualified Codec.Json.Wsp as Wsp
+import qualified Codec.Json.Wsp.Handler as Wsp
+import qualified Ouroboros.Consensus.Ledger.Query as Ledger
+import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type as LSQ
+
+spec :: Spec
+spec = parallel $ do
+    context "StateQuery" $ do
+        parallel $ prop "Random sequence of messages" prop_anyRandomSequence
+  where
+    -- There isn't much which can go wrong with the local-state query. So, this
+    -- property simply hammer it down by trying some random sequences of
+    -- messages (Acquire, Query, Release), in any order, making sure that Ogmios
+    -- replies with a corresponding response and mirror.
+    --
+    -- The property also checks for various cases of particular interest, to
+    -- make sure they are covered in the generated sequence.
+    prop_anyRandomSequence :: Property
+    prop_anyRandomSequence = forAll genMessages $ \messages ->
+        cover 5 (isAcquireThenQuery False messages) "Acquire then query" $
+        cover 5 (isDirectQuery False messages) "Direct query" $
+        cover 5 (isManyQueries (0 :: Int) messages) "Many queries" $
+        cover 5 (isDoubleRelease False messages) "Double release" $
+        cover 5 (isDoubleAcquire False messages) "Double acquire" $
+        checkCoverage $ prop_inIOSim $ withStateQueryClient $ \send receive -> do
+            forM_ messages $ \(msg, mirror, SomeProxy proxy) -> do
+                send msg >> expectWSPResponse proxy receive (toJSON mirror)
+      where
+        isDirectQuery hasAcquired = \case
+            [] -> False
+            ((MsgQuery{},_,_):q) -> not hasAcquired || isDirectQuery hasAcquired q
+            ((MsgRelease{},_,_):q) -> isDirectQuery False q
+            ((MsgAcquire{},_,_):q) -> isDirectQuery True q
+
+        isManyQueries nQuery = \case
+            [] -> False
+            ((MsgQuery{},_,_):q) -> nQuery >= 3 || isManyQueries (nQuery + 1) q
+            ((MsgRelease{},_,_):q) -> isManyQueries 0 q
+            ((MsgAcquire{},_,_):q) -> isManyQueries 0 q
+
+        isAcquireThenQuery hasAcquired = \case
+            [] -> False
+            ((MsgQuery{},_,_):q) -> hasAcquired || isAcquireThenQuery False q
+            ((MsgRelease{},_,_):q) -> isAcquireThenQuery False q
+            ((MsgAcquire{},_,_):q) -> isAcquireThenQuery True q
+
+        isDoubleRelease hasReleased = \case
+            [] -> False
+            ((MsgQuery{},_,_):q) -> isDoubleRelease False q
+            ((MsgRelease{},_,_):q) -> hasReleased || isDoubleRelease True q
+            ((MsgAcquire{},_,_):q) -> isDoubleRelease False q
+
+        isDoubleAcquire hasAcquired = \case
+            [] -> False
+            ((MsgQuery{},_,_):q) -> isDoubleAcquire False q
+            ((MsgRelease{},_,_):q) -> isDoubleAcquire False q
+            ((MsgAcquire{},_,_):q) -> hasAcquired || isDoubleAcquire True q
+
+type Protocol = LocalStateQuery Block (Point Block) (Ledger.Query Block)
+
+withStateQueryClient
+    :: (MonadSTM m, MonadCatch m, MonadOuroboros m)
+    => ((StateQueryMessage Block -> m ()) ->  m Json -> m a)
+    -> StdGen
+    -> m a
+withStateQueryClient action seed = do
+    (recvQ, sendQ) <- atomically $ (,) <$> newTQueue <*> newTQueue
+    let innerCodecs = mkStateQueryCodecs encodePoint encodeAcquireFailure
+    let client = mkStateQueryClient innerCodecs recvQ (atomically . writeTQueue sendQ)
+    let codec = codecs defaultSlotsPerEpoch nodeToClientV_Latest & cStateQueryCodec
+    withMockChannel (stateQueryMockPeer seed codec) $ \channel -> do
+        result <- race
+            (runPeer nullTracer codec channel (localStateQueryClientPeer client))
+            (action (atomically . writeTQueue recvQ) (atomically $ readTQueue sendQ))
+        case result of
+            Left{}  -> throwIO PeerTerminatedUnexpectedly
+            Right a -> pure a
+
+data SomeResponse from =
+    forall to. SomeResponse (LSQ.Message Protocol from to)
+
+stateQueryMockPeer
+    :: forall m failure. (MonadSTM m, MonadCatch m, Show failure)
+    => StdGen
+        -- ^ Random generator
+    -> Codec Protocol failure m LByteString
+        -- ^ Codec for the given protocol
+    -> (m LByteString, LByteString -> m ())
+        -- ^ Read/Write from/To the channel
+    -> m ()
+stateQueryMockPeer seed codec (recv, send) = flip evalStateT seed $ forever $ do
+    req <- lift recv
+
+    msg <- lift (try @_ @SomeException (decodeOrThrow TokIdle req)) >>= \case
+        (Right (SomeMessage LSQ.MsgDone)) ->
+            pure Nothing
+        (Right (SomeMessage LSQ.MsgAcquire{})) -> do
+            SomeResponse msg <- generateWith genAcquireResponse <$> state random
+            pure $ Just $ encode codec (ServerAgency TokAcquiring) msg
+        (Left{}) -> lift (decodeOrThrow TokAcquired req) >>= \case
+            SomeMessage (LSQ.MsgQuery query) -> do
+                SomeResponse msg <- generateWith (genQueryResponse query) <$> state random
+                pure $ Just $ encode codec (ServerAgency $ TokQuerying query) msg
+            SomeMessage LSQ.MsgReAcquire{} -> do
+                SomeResponse msg <- generateWith genAcquireResponse <$> state random
+                pure $ Just $ encode codec (ServerAgency TokAcquiring) msg
+            SomeMessage LSQ.MsgRelease{} -> do
+                pure Nothing
+
+    lift $ maybe (pure ()) send msg
+  where
+    decodeOrThrow :: forall (st :: Protocol). ClientHasAgency st -> LByteString -> m (SomeMessage st)
+    decodeOrThrow agency bytes = do
+        decoder <- decode codec (ClientAgency agency)
+        runDecoder [bytes] decoder >>= \case
+            Left failure -> throwIO $ FailedToDecodeMsg (show failure)
+            Right msg -> pure msg
+
+    genAcquireResponse
+        :: Gen (SomeResponse 'StAcquiring)
+    genAcquireResponse = frequency
+        [ (10, pure (SomeResponse LSQ.MsgAcquired))
+        , ( 1, SomeResponse . LSQ.MsgFailure <$> genAcquireFailure)
+        ]
+
+    genQueryResponse
+        :: Ledger.Query Block result
+        -> Gen (SomeResponse ('StQuerying result))
+    genQueryResponse query = case query of
+        Ledger.BlockQuery (QueryIfCurrentShelley GetEpochNo) ->
+            SomeResponse . LSQ.MsgResult query <$> genEpochResult Proxy
+        Ledger.BlockQuery (QueryIfCurrentAllegra GetEpochNo) ->
+            SomeResponse . LSQ.MsgResult query <$> genEpochResult Proxy
+        Ledger.BlockQuery (QueryIfCurrentMary GetEpochNo) ->
+            SomeResponse . LSQ.MsgResult query <$> genEpochResult Proxy
+        Ledger.BlockQuery (QueryIfCurrentAlonzo GetEpochNo) ->
+            SomeResponse . LSQ.MsgResult query <$> genEpochResult Proxy
+
+        Ledger.BlockQuery (QueryHardFork GetCurrentEra) -> elements
+            [ SomeResponse $ LSQ.MsgResult query (EraIndex (IxByron   (K ())))
+            , SomeResponse $ LSQ.MsgResult query (EraIndex (IxShelley (K ())))
+            , SomeResponse $ LSQ.MsgResult query (EraIndex (IxAllegra (K ())))
+            , SomeResponse $ LSQ.MsgResult query (EraIndex (IxMary    (K ())))
+            , SomeResponse $ LSQ.MsgResult query (EraIndex (IxAlonzo  (K ())))
+            ]
+        Ledger.BlockQuery _ ->
+            error $ "No generator for query: " <> show query
+
+--
+-- Constructing EraIndex, shameless copied from: Ouroboros.Consensus.Cardano.Block
+--
+
+pattern IxByron   :: f ByronBlock                    -> NS f (CardanoEras c)
+pattern IxShelley :: f (ShelleyBlock (ShelleyEra c)) -> NS f (CardanoEras c)
+pattern IxAllegra :: f (ShelleyBlock (AllegraEra c)) -> NS f (CardanoEras c)
+pattern IxMary    :: f (ShelleyBlock (MaryEra    c)) -> NS f (CardanoEras c)
+pattern IxAlonzo  :: f (ShelleyBlock (AlonzoEra  c)) -> NS f (CardanoEras c)
+
+pattern IxByron   x =             Z x
+pattern IxShelley x =          S (Z x)
+pattern IxAllegra x =       S (S (Z x))
+pattern IxMary    x =    S (S (S (Z x)))
+pattern IxAlonzo  x = S (S (S (S (Z x))))
+
+--
+-- Command Generator
+--
+
+data SomeProxy = forall method. KnownSymbol method => SomeProxy (Proxy method)
+deriving instance Show SomeProxy
+
+genMessages :: Gen [(StateQueryMessage Block, Wsp.Mirror, SomeProxy)]
+genMessages = do
+    mirror <- genMirror
+    point  <- genPoint
+    listOf1 $ elements
+        [ (acquire  mirror point, mirror, SomeProxy (Proxy :: Proxy "Acquire"))
+        , (release  mirror      , mirror, SomeProxy (Proxy :: Proxy "Release"))
+        , (queryAny mirror      , mirror, SomeProxy (Proxy :: Proxy "Query"))
+        ]
+
+--
+-- Helpers
+--
+
+acquire :: Wsp.Mirror -> Point Block -> StateQueryMessage Block
+acquire mirror point =
+    MsgAcquire Acquire{point} (Wsp.Response mirror) (Wsp.Fault mirror)
+
+release :: Wsp.Mirror -> StateQueryMessage Block
+release mirror =
+    MsgRelease Release (Wsp.Response mirror) (Wsp.Fault mirror)
+
+queryAny :: Wsp.Mirror -> StateQueryMessage Block
+queryAny mirror =
+    MsgQuery (Query q) (Wsp.Response mirror) (Wsp.Fault mirror)
+  where
+    q _ = Just $ SomeQuery
+        { query = Ledger.BlockQuery $ QueryIfCurrentAlonzo GetEpochNo
+        , genResult = const Proxy
+        , encodeResult = either encodeMismatchEraInfo encodeEpochNo
+        }

--- a/server/test/unit/Test/App/Protocol/Util.hs
+++ b/server/test/unit/Test/App/Protocol/Util.hs
@@ -1,0 +1,110 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.App.Protocol.Util
+    ( prop_inIOSim
+    , expectWSPResponse
+    , withMockChannel
+
+      -- * Exceptions
+    , PeerTerminatedUnexpectedly (..)
+    , UnexpectedResponse (..)
+    ) where
+
+import Ogmios.Prelude
+
+import Control.Exception
+    ( evaluate )
+import Control.Monad.IOSim
+    ( runSimOrThrow )
+import GHC.TypeLits
+    ( KnownSymbol, Symbol, symbolVal )
+import Ogmios.Control.Exception
+    ( MonadThrow (..) )
+import Ogmios.Control.MonadAsync
+    ( race )
+import Ogmios.Control.MonadOuroboros
+    ( MonadOuroboros )
+import Ogmios.Control.MonadSTM
+    ( MonadSTM (..), newTQueue, readTQueue, writeTQueue )
+import Ogmios.Data.Json.Prelude
+    ( at, inefficientEncodingToValue )
+import Ouroboros.Network.Channel
+    ( Channel (..) )
+import System.Random
+    ( StdGen, mkStdGen )
+import Test.QuickCheck
+    ( Property, arbitrary )
+import Test.QuickCheck.Monadic
+    ( monadicIO, pick, run )
+
+import qualified Data.Aeson as Json
+
+-- | Run a function in IOSim, with a 'StdGen' input which can used to compute
+-- random numbers deterministically within the simulation. The random generator
+-- is however randomly seeded for each property run.
+prop_inIOSim
+    :: (forall m. (MonadSTM m, MonadOuroboros m) => StdGen -> m ())
+    -> Property
+prop_inIOSim action = monadicIO $ do
+    seed <- mkStdGen <$> pick arbitrary
+    run $ evaluate $ runSimOrThrow $ action seed
+
+-- Run an action concurrently with a peer, and a 'fake' channel connected to
+-- TQueue. The peer is expected to consume and produce values from and to the
+-- TQueue to drive the channel communication.
+withMockChannel
+    :: forall m a. (MonadSTM m, MonadOuroboros m)
+    => ((m LByteString, LByteString -> m ()) -> m ())
+        -- ^ A mock peer for consuming the data.
+    -> (Channel m LByteString -> m a)
+        -- ^ Callback using the channel
+    -> m a
+withMockChannel mockPeer action = do
+    (readBuffer, writeBuffer) <- atomically $ (,) <$> newTQueue <*> newTQueue
+    let send = atomically . writeTQueue writeBuffer
+    let recv = Just <$> atomically (readTQueue readBuffer)
+    let channel = Channel{send,recv}
+    let sendDual = atomically (readTQueue writeBuffer)
+    let recvDual = atomically . writeTQueue readBuffer
+    result <- race (mockPeer (sendDual, recvDual)) (action channel)
+    either (const $ error "mockNode terminated?") pure result
+
+-- | Assert that a given JSON object is a JSON-WSP response for the given
+-- method.
+--
+-- >>> expectWSPResponse @"RequestNext" recv Nothing
+-- ()
+expectWSPResponse
+    :: forall (method :: Symbol) m. (MonadThrow m, KnownSymbol method)
+    => m Json.Encoding
+    -> Json.Value
+    -> m ()
+expectWSPResponse recv wantMirror = do
+    json <- inefficientEncodingToValue <$> recv
+
+    let gotMethod = "methodname" `at` json
+    let wantMethod = Json.toJSON $ symbolVal (Proxy @method)
+    when (gotMethod /= Just wantMethod) $
+        throwIO $ UnexpectedResponse gotMethod wantMethod
+
+    let gotMirror = "reflection" `at` json
+    when (gotMirror /= Just wantMirror) $
+        throwIO $ UnexpectedResponse gotMirror wantMirror
+
+--
+-- Exceptions
+--
+
+data PeerTerminatedUnexpectedly = PeerTerminatedUnexpectedly deriving Show
+instance Exception PeerTerminatedUnexpectedly
+
+data UnexpectedResponse = UnexpectedResponse
+    { gotResponse :: Maybe Json.Value
+    , expectedResponse :: Json.Value
+    } deriving Show
+instance Exception UnexpectedResponse

--- a/server/test/unit/Test/Generators.hs
+++ b/server/test/unit/Test/Generators.hs
@@ -80,6 +80,7 @@ import Test.Consensus.Cardano.Generators
     ()
 
 import qualified Cardano.Ledger.Core as Core
+import qualified Data.Aeson as Json
 import qualified Ouroboros.Network.Point as Point
 import qualified Shelley.Spec.Ledger.BlockChain as Spec
 
@@ -432,6 +433,13 @@ genCompactGenesisResult _ _ =
                     ]
             Nothing ->
                 Nothing
+
+genMirror
+    :: Gen (Maybe Json.Value)
+genMirror = oneof
+    [ pure Nothing
+    , Just . Json.toJSON <$> arbitrary @Int
+    ]
 
 --
 -- Helpers

--- a/server/test/unit/Test/Generators.hs
+++ b/server/test/unit/Test/Generators.hs
@@ -1,0 +1,444 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Generators where
+
+import Ogmios.Prelude
+
+import Cardano.Ledger.Era
+    ( Crypto, Era, SupportsSegWit (..) )
+import Cardano.Ledger.Serialization
+    ( ToCBORGroup )
+import Cardano.Network.Protocol.NodeToClient
+    ( Block )
+import Cardano.Slotting.Slot
+    ( EpochNo (..) )
+import Data.SOP.Strict
+    ( NS (..) )
+import Data.Type.Equality
+    ( (:~:) (..), testEquality )
+import Ogmios.Data.Json.Query
+    ( Delegations, QueryResult, RewardAccounts )
+import Ouroboros.Consensus.Byron.Ledger.Block
+    ( ByronBlock )
+import Ouroboros.Consensus.Cardano.Block
+    ( AllegraEra
+    , AlonzoEra
+    , CardanoEras
+    , HardForkApplyTxErr (..)
+    , HardForkBlock (..)
+    , MaryEra
+    , ShelleyEra
+    )
+import Ouroboros.Consensus.HardFork.Combinator
+    ( LedgerEraInfo (..), Mismatch (..), MismatchEraInfo (..), singleEraInfo )
+import Ouroboros.Consensus.HardFork.Combinator.Mempool
+    ( HardForkApplyTxErr (..) )
+import Ouroboros.Consensus.HardFork.History.Summary
+    ( Bound (..) )
+import Ouroboros.Consensus.Shelley.Eras
+    ( StandardAllegra, StandardAlonzo, StandardMary, StandardShelley )
+import Ouroboros.Consensus.Shelley.Ledger.Block
+    ( ShelleyBlock (..) )
+import Ouroboros.Consensus.Shelley.Ledger.Config
+    ( CompactGenesis, compactGenesis )
+import Ouroboros.Consensus.Shelley.Ledger.Query
+    ( NonMyopicMemberRewards (..) )
+import Ouroboros.Consensus.Shelley.Protocol
+    ( StandardCrypto )
+import Ouroboros.Network.Block
+    ( BlockNo (..), HeaderHash, Point (..), SlotNo (..), Tip (..) )
+import Ouroboros.Network.Protocol.LocalStateQuery.Type
+    ( AcquireFailure (..) )
+import Ouroboros.Network.Protocol.LocalTxSubmission.Type
+    ( SubmitResult (..) )
+import Shelley.Spec.Ledger.Delegation.Certificates
+    ( PoolDistr )
+import Shelley.Spec.Ledger.PParams
+    ( ProposedPPUpdates )
+import Shelley.Spec.Ledger.UTxO
+    ( UTxO )
+import Test.QuickCheck
+    ( Arbitrary (..), Gen, choose, elements, frequency, oneof, scale )
+import Test.QuickCheck.Gen
+    ( Gen (..) )
+import Test.QuickCheck.Hedgehog
+    ( hedgehog )
+import Test.QuickCheck.Random
+    ( mkQCGen )
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+    ( Mock )
+import Test.Shelley.Spec.Ledger.Serialisation.Generators.Genesis
+    ( genPParams )
+import Type.Reflection
+    ( typeRep )
+
+import Test.Consensus.Cardano.Generators
+    ()
+
+import qualified Cardano.Ledger.Core as Core
+import qualified Ouroboros.Network.Point as Point
+import qualified Shelley.Spec.Ledger.BlockChain as Spec
+
+genBlock :: Gen Block
+genBlock = reasonablySized $ oneof
+    [ BlockByron <$> arbitrary
+    , BlockShelley <$> genBlockFrom @(ShelleyEra StandardCrypto)
+    , BlockAllegra <$> genBlockFrom @(AllegraEra StandardCrypto)
+    , BlockMary <$> genBlockFrom @(MaryEra StandardCrypto)
+    , BlockAlonzo <$> genBlockFrom @(AlonzoEra StandardCrypto)
+    ]
+  where
+    genBlockFrom
+        :: forall era.
+            ( Era era
+            , ToCBORGroup (TxSeq era)
+            , Mock (Crypto era)
+            , Arbitrary (TxInBlock era)
+            )
+        => Gen (ShelleyBlock era)
+    genBlockFrom = ShelleyBlock
+        <$> (Spec.Block <$> arbitrary <*> (toTxSeq @era <$> arbitrary))
+        <*> arbitrary
+
+genPoint :: Gen (Point Block)
+genPoint = frequency
+    [ (1, pure (Point Point.Origin))
+    , (10, Point . Point.At <$> genPointBlock)
+    ]
+
+genTip :: Gen (Tip Block)
+genTip = frequency
+    [ (1, pure TipGenesis)
+    , (10, Tip <$> genSlotNo <*> genHeaderHash <*> genBlockNo)
+    ]
+
+genHardForkApplyTxErr :: Gen (SubmitResult (HardForkApplyTxErr (CardanoEras StandardCrypto)))
+genHardForkApplyTxErr = frequency
+    [ ( 1, pure SubmitSuccess)
+    , ( 1, SubmitFail . HardForkApplyTxErrWrongEra <$> genMismatchEraInfo)
+    , (10, SubmitFail . ApplyTxErrShelley <$> reasonablySized arbitrary)
+    , (10, SubmitFail . ApplyTxErrAllegra <$> reasonablySized arbitrary)
+    , (10, SubmitFail . ApplyTxErrMary <$> reasonablySized arbitrary)
+    , (10, SubmitFail . ApplyTxErrAlonzo <$> reasonablySized arbitrary)
+    ]
+
+genAcquireFailure :: Gen AcquireFailure
+genAcquireFailure = elements
+    [ AcquireFailurePointTooOld
+    , AcquireFailurePointNotOnChain
+    ]
+
+genEpochNo :: Gen EpochNo
+genEpochNo = EpochNo <$> arbitrary
+
+genSlotNo :: Gen SlotNo
+genSlotNo = SlotNo <$> choose (1, 100000)
+
+genBlockNo :: Gen BlockNo
+genBlockNo = BlockNo <$> arbitrary
+
+genHeaderHash :: Gen (HeaderHash Block)
+genHeaderHash = arbitrary
+
+genPointBlock :: Gen (Point.Block SlotNo (HeaderHash Block))
+genPointBlock = Point.Block <$> genSlotNo <*> genHeaderHash
+
+genMismatchEraInfo
+    :: Gen (MismatchEraInfo (CardanoEras StandardCrypto))
+genMismatchEraInfo = MismatchEraInfo <$> elements
+    [ ML eraInfoByron (Z (LedgerEraInfo eraInfoShelley))
+    , MR (Z eraInfoShelley) (LedgerEraInfo eraInfoByron)
+    ]
+  where
+    eraInfoByron =
+        singleEraInfo (Proxy @ByronBlock)
+    eraInfoShelley =
+        singleEraInfo (Proxy @(ShelleyBlock StandardShelley))
+
+genBoundResult
+    :: Proxy (Maybe Bound)
+    -> Gen (Maybe Bound)
+genBoundResult _ =
+    Just <$> arbitrary -- NOTE: Can't be 'Nothing' with Ogmios.
+
+genPointResult
+    :: forall crypto era. (crypto ~ StandardCrypto, Typeable era)
+    => Proxy era
+    -> Proxy (QueryResult crypto (Point (ShelleyBlock era)))
+    -> Gen (QueryResult crypto (Point (ShelleyBlock era)))
+genPointResult _era _result =
+    fromMaybe (error "genPointResult: unsupported era")
+        (genShelley <|> genAllegra <|> genMary <|> genAlonzo)
+  where
+    genShelley =
+        case testEquality (typeRep @era) (typeRep @StandardShelley) of
+            Just Refl{} ->
+                Just $ frequency
+                    [ (1, Left <$> genMismatchEraInfo)
+                    , (10, Right <$> arbitrary)
+                    ]
+            Nothing ->
+                Nothing
+    genAllegra =
+        case testEquality (typeRep @era) (typeRep @StandardAllegra) of
+            Just Refl{} ->
+                Just $ frequency
+                    [ (1, Left <$> genMismatchEraInfo)
+                    , (10, Right <$> arbitrary)
+                    ]
+            Nothing ->
+                Nothing
+    genMary =
+        case testEquality (typeRep @era) (typeRep @StandardMary) of
+            Just Refl{} ->
+                Just $ frequency
+                    [ (1, Left <$> genMismatchEraInfo)
+                    , (10, Right <$> arbitrary)
+                    ]
+            Nothing ->
+                Nothing
+    genAlonzo =
+        case testEquality (typeRep @era) (typeRep @StandardAlonzo) of
+            Just Refl{} ->
+                Just $ frequency
+                    [ (1, Left <$> genMismatchEraInfo)
+                    , (10, Right <$> arbitrary)
+                    ]
+            Nothing ->
+                Nothing
+
+genEpochResult
+    :: forall crypto. (crypto ~ StandardCrypto)
+    => Proxy (QueryResult crypto EpochNo)
+    -> Gen (QueryResult crypto EpochNo)
+genEpochResult _ = frequency
+    [ (1, Left <$> genMismatchEraInfo)
+    , (10, Right <$> genEpochNo)
+    ]
+
+genNonMyopicMemberRewardsResult
+    :: forall crypto. (crypto ~ StandardCrypto)
+    => Proxy (QueryResult crypto (NonMyopicMemberRewards crypto))
+    -> Gen (QueryResult crypto (NonMyopicMemberRewards crypto))
+genNonMyopicMemberRewardsResult _ = frequency
+    [ (1, Left <$> genMismatchEraInfo)
+    , (10, Right <$> reasonablySized arbitrary)
+    ]
+
+genDelegationAndRewardsResult
+    :: forall crypto. (crypto ~ StandardCrypto)
+    => Proxy (QueryResult crypto (Delegations crypto, RewardAccounts crypto))
+    -> Gen (QueryResult crypto (Delegations crypto, RewardAccounts crypto))
+genDelegationAndRewardsResult _ = frequency
+    [ (1, Left <$> genMismatchEraInfo)
+    , (10, Right <$> reasonablySized arbitrary)
+    ]
+
+genPParamsResult
+    :: forall crypto era. (crypto ~ StandardCrypto, Typeable era)
+    => Proxy era
+    -> Proxy (QueryResult crypto (Core.PParams era))
+    -> Gen (QueryResult crypto (Core.PParams era))
+genPParamsResult _ _ =
+    maybe (error "genPParamsResult: unsupported era") reasonablySized
+        (genShelley <|> genAllegra <|> genMary <|> genAlonzo)
+  where
+    genShelley =
+        case testEquality (typeRep @era) (typeRep @StandardShelley) of
+            Just Refl{} ->
+                Just $ frequency
+                    [ (1, Left <$> genMismatchEraInfo)
+                    , (10, Right <$> hedgehog (genPParams @era))
+                    ]
+            Nothing ->
+                Nothing
+    genAllegra =
+        case testEquality (typeRep @era) (typeRep @StandardAllegra) of
+            Just Refl{} ->
+                Just $ frequency
+                    [ (1, Left <$> genMismatchEraInfo)
+                    , (10, Right <$> hedgehog (genPParams @era))
+                    ]
+            Nothing ->
+                Nothing
+    genMary =
+        case testEquality (typeRep @era) (typeRep @StandardMary) of
+            Just Refl{} ->
+                Just $ frequency
+                    [ (1, Left <$> genMismatchEraInfo)
+                    , (10, Right <$> hedgehog (genPParams @era))
+                    ]
+            Nothing ->
+                Nothing
+    genAlonzo =
+        case testEquality (typeRep @era) (typeRep @StandardAlonzo) of
+            Just Refl{} ->
+                Just $ frequency
+                    [ (1, Left <$> genMismatchEraInfo)
+                    , (10, Right <$> arbitrary)
+                    ]
+            Nothing ->
+                Nothing
+
+
+genProposedPParamsResult
+    :: forall crypto era. (crypto ~ StandardCrypto, Typeable era)
+    => Proxy era
+    -> Proxy (QueryResult crypto (ProposedPPUpdates era))
+    -> Gen (QueryResult crypto (ProposedPPUpdates era))
+genProposedPParamsResult _ _ =
+    maybe (error "genProposedPParamsResult: unsupported era") reasonablySized
+        (genShelley <|> genAllegra <|> genMary <|> genAlonzo)
+  where
+    genShelley =
+        case testEquality (typeRep @era) (typeRep @StandardShelley) of
+            Just Refl{} ->
+                Just $ frequency
+                    [ (1, Left <$> genMismatchEraInfo)
+                    , (10, Right <$> arbitrary)
+                    ]
+            Nothing ->
+                Nothing
+    genAllegra =
+        case testEquality (typeRep @era) (typeRep @StandardAllegra) of
+            Just Refl{} ->
+                Just $ frequency
+                    [ (1, Left <$> genMismatchEraInfo)
+                    , (10, Right <$> arbitrary)
+                    ]
+            Nothing ->
+                Nothing
+    genMary =
+        case testEquality (typeRep @era) (typeRep @StandardMary) of
+            Just Refl{} ->
+                Just $ frequency
+                    [ (1, Left <$> genMismatchEraInfo)
+                    , (10, Right <$> arbitrary)
+                    ]
+            Nothing ->
+                Nothing
+    genAlonzo =
+        case testEquality (typeRep @era) (typeRep @StandardAlonzo) of
+            Just Refl{} ->
+                Just $ frequency
+                    [ (1, Left <$> genMismatchEraInfo)
+                    , (10, Right <$> arbitrary)
+                    ]
+            Nothing ->
+                Nothing
+
+genPoolDistrResult
+    :: forall crypto. (crypto ~ StandardCrypto)
+    => Proxy (QueryResult crypto (PoolDistr crypto))
+    -> Gen (QueryResult crypto (PoolDistr crypto))
+genPoolDistrResult _ = frequency
+    [ (1, Left <$> genMismatchEraInfo)
+    , (10, Right <$> reasonablySized arbitrary)
+    ]
+
+genUTxOResult
+    :: forall crypto era. (crypto ~ StandardCrypto, Typeable era)
+    => Proxy era
+    -> Proxy (QueryResult crypto (UTxO era))
+    -> Gen (QueryResult crypto (UTxO era))
+genUTxOResult _ _ =
+    maybe (error "genProposedPParamsResult: unsupported era") reasonablySized
+        (genShelley <|> genAllegra <|> genMary <|> genAlonzo)
+  where
+    genShelley =
+        case testEquality (typeRep @era) (typeRep @StandardShelley) of
+            Just Refl{} ->
+                Just $ frequency
+                    [ (1, Left <$> genMismatchEraInfo)
+                    , (10, Right <$> arbitrary)
+                    ]
+            Nothing ->
+                Nothing
+    genAllegra =
+        case testEquality (typeRep @era) (typeRep @StandardAllegra) of
+            Just Refl{} ->
+                Just $ frequency
+                    [ (1, Left <$> genMismatchEraInfo)
+                    , (10, Right <$> arbitrary)
+                    ]
+            Nothing ->
+                Nothing
+    genMary =
+        case testEquality (typeRep @era) (typeRep @StandardMary) of
+            Just Refl{} ->
+                Just $ frequency
+                    [ (1, Left <$> genMismatchEraInfo)
+                    , (10, Right <$> arbitrary)
+                    ]
+            Nothing ->
+                Nothing
+    genAlonzo =
+        case testEquality (typeRep @era) (typeRep @StandardAlonzo) of
+            Just Refl{} ->
+                Just $ frequency
+                    [ (1, Left <$> genMismatchEraInfo)
+                    , (10, Right <$> arbitrary)
+                    ]
+            Nothing ->
+                Nothing
+
+
+genCompactGenesisResult
+    :: forall crypto era. (crypto ~ StandardCrypto, Typeable era)
+    => Proxy era
+    -> Proxy (QueryResult crypto (CompactGenesis era))
+    -> Gen (QueryResult crypto (CompactGenesis era))
+genCompactGenesisResult _ _ =
+    maybe (error "genCompactGenesisResult: unsupported era") reasonablySized
+        (genShelley <|> genAllegra <|> genMary <|> genAlonzo)
+  where
+    genShelley =
+        case testEquality (typeRep @era) (typeRep @StandardShelley) of
+            Just Refl{} ->
+                Just $ frequency
+                    [ (1, Left <$> genMismatchEraInfo)
+                    , (10, Right . compactGenesis <$> arbitrary)
+                    ]
+            Nothing ->
+                Nothing
+    genAllegra =
+        case testEquality (typeRep @era) (typeRep @StandardAllegra) of
+            Just Refl{} ->
+                Just $ frequency
+                    [ (1, Left <$> genMismatchEraInfo)
+                    , (10, Right . compactGenesis <$> arbitrary)
+                    ]
+            Nothing ->
+                Nothing
+    genMary =
+        case testEquality (typeRep @era) (typeRep @StandardMary) of
+            Just Refl{} ->
+                Just $ frequency
+                    [ (1, Left <$> genMismatchEraInfo)
+                    , (10, Right . compactGenesis <$> arbitrary)
+                    ]
+            Nothing ->
+                Nothing
+    genAlonzo =
+        case testEquality (typeRep @era) (typeRep @StandardAlonzo) of
+            Just Refl{} ->
+                Just $ frequency
+                    [ (1, Left <$> genMismatchEraInfo)
+                    , (10, Right . compactGenesis <$> arbitrary)
+                    ]
+            Nothing ->
+                Nothing
+
+--
+-- Helpers
+--
+
+reasonablySized :: Gen a -> Gen a
+reasonablySized = scale (ceiling . sqrt @Double . fromIntegral)
+
+generateWith :: Gen a -> Int -> a
+generateWith (MkGen run) seed = run (mkQCGen seed) 30


### PR DESCRIPTION
- :round_pushpin: **Write unit test using io-sim for the ChainSync protocol.**
    For now, it only covers basic scenario but, the instrumentation behind the scene is pretty heavy. In particular, it could (would) be used to generate a random sequence of input chain sync messages, for then we can ensure some properties like: order preservation, expected response, no deadlock / errors etc... It'd be interesting to also do it for the local state query and the health check, to make sure that all cases are properly handled by the logic. Everything runs in IO-sim, so it's blazing fast and doesn't require any real networking setup :tada:

- :round_pushpin: **Make max in flight (a.k.a. pipelined) chain-sync requests configurable**
    This is mainly for enabling unit test scenarios which saturate the queue without having to generate thousands of events.

- :round_pushpin: **Generate arbitrary mirror values of chain-sync spec instead of hard-coding them.**
  
- :round_pushpin: **Allow WSP handlers to reply with a fault and preserve reflection value**
  
- :round_pushpin: **Add property for checking interleaves of requestNext and findIntersect**
  
- :round_pushpin: **Remove redundant code identified with property tests.**
  
- :round_pushpin: **Lower down a bit QC confidence for faster chain-sync unit tests**
    The property are really generating two cases (Nothing or Just _), the value in Just can really be anything, so in the end, running the property a 100 times is _overkill_

- :round_pushpin: **Also cover the state-query client through property testing in IO-sim**


TODO: 

- [ ] Test the health check and tip sync with the same approach
