### PR TITLE
feature: external Haskell node client interoperability with cardano-node-ogmios

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,7 +137,7 @@ RUN wget -q ${CARDANO_CONFIG_URL}/testnet-shelley-genesis.json
 RUN wget -q ${CARDANO_CONFIG_URL}/testnet-topology.json
 
 RUN find . -name "*config*.json" -print0 | xargs -0 sed -i 's/127.0.0.1/0.0.0.0/g' > /dev/null 2>&1
-
+RUN mkdir /ipc
 WORKDIR /root
 COPY scripts/cardano-node-ogmios.sh cardano-node-ogmios.sh
 CMD ["bash", "cardano-node-ogmios.sh" ]

--- a/docs/content/getting-started/docker.md
+++ b/docs/content/getting-started/docker.md
@@ -59,7 +59,11 @@ Let's explore a bit the various options:
 
 ##### -v
 
-`-v` mounts a shared volume with the container on your host machine. In this case, it is the node's blockchain database to make the container more portable. This way, you can more easily restart a container on a newer image while keeping the data readily available (and without having to resync the entire chain!).
+`-v` mounts a shared volume with the container on your host machine, either via bind mounts or named volumes.
+
+###### Mount points
+- `db/{NETWORK_NAME}` - persist the `cardano-node` DB to avoid re-syncing the chain whenever a new container is run. This is done on every version upgrade and is recommended for most use-cases.
+- `/ipc` if this image is used in a multi-container stack with an external Haskell node client.
 
 Find more about run options in the docker user documentation.
 

--- a/docs/content/getting-started/docker.md
+++ b/docs/content/getting-started/docker.md
@@ -6,11 +6,11 @@ weight = 1
 
 ## 🐳 Overview
 
-The easiest way to get started with Ogmios is to use [docker](https://www.docker.com/). This guide won't cover installing docker, so make sure you have the Docker daemon installed and running. 
+The easiest way to get started with Ogmios is to use [docker](https://www.docker.com/). This guide won't cover installing docker, so make sure you have the Docker daemon installed and running.
 
-Ogmios docker images come in two flavours: `cardano-node-ogmios` and `ogmios`. The former is used to run a single container that bundles both a Cardano-node and an Ogmios server running side-by-side. It is likely the easiest way to get started. The latter is a standalone Ogmios server, and you'll need to run that container in orchestration with a cardano-node; this is made relatively easy with [Docker compose](https://docs.docker.com/compose/). 
+Ogmios docker images come in two flavours: `cardano-node-ogmios` and `ogmios`. The former is used to run a single container that bundles both a Cardano-node and an Ogmios server running side-by-side. It is likely the easiest way to get started. The latter is a standalone Ogmios server, and you'll need to run that container in orchestration with a cardano-node; this is made relatively easy with [Docker compose](https://docs.docker.com/compose/).
 
-Images are uploaded to [Dockerhub](https://dockerhub.com/) and can be pulled from the registry at any time. Images are tagged using release versions or with `:latest` if you're living on the edge. 
+Images are uploaded to [Dockerhub](https://dockerhub.com/) and can be pulled from the registry at any time. Images are tagged using release versions or with `:latest` if you're living on the edge.
 
 | image               | repository                                                                                      | tags               |
 | ---                 | ---                                                                                             | ---                |
@@ -36,17 +36,17 @@ Let's explore a bit the various options:
 
 ##### --it
 
-`-it` is a shorthand for two options `-i` & `-t` to enable some interactive support with the container. This is necessary to pass OS signals (e.g. SIGINT from CTRL-C) from the host to the container. 
+`-it` is a shorthand for two options `-i` & `-t` to enable some interactive support with the container. This is necessary to pass OS signals (e.g. SIGINT from CTRL-C) from the host to the container.
 
-##### --name 
+##### --name
 
-`--name` gives a name to the container, to easily identify it later in commands such as `docker container ps`. 
+`--name` gives a name to the container, to easily identify it later in commands such as `docker container ps`.
 
 ##### -e
 
-`-e` sets an environment variable inside the container. So far, only `NETWORK` is the only available variable that can take two values: `testnet` or `mainnet`. 
+`-e` sets an environment variable inside the container. So far, only `NETWORK` is the only available variable that can take two values: `testnet` or `mainnet`.
 
-##### -p 
+##### -p
 
 `-p` instruments docker to bind ports of the container to host. The image exposes 4 ports that can be bound to any (available) port of the host system. Here's the complete list of TCP ports exposed by the image:
 
@@ -57,15 +57,15 @@ Let's explore a bit the various options:
 | 12788       | cardano-node's EKG port                                  |
 | 12798       | cardano-node's Prometheus port                           |
 
-##### -v 
+##### -v
 
 `-v` mounts a shared volume with the container on your host machine. In this case, it is the node's blockchain database to make the container more portable. This way, you can more easily restart a container on a newer image while keeping the data readily available (and without having to resync the entire chain!).
 
-Find more about run options in the docker user documentation. 
+Find more about run options in the docker user documentation.
 
 ### Building
 
-To build the image yourself, we encourage you to leverage the existing build-cache layers from the registry. Building the entire image from scratch can take up to an hour! You can 
+To build the image yourself, we encourage you to leverage the existing build-cache layers from the registry. Building the entire image from scratch can take up to an hour! You can
 
 ```console
 $ DOCKER_BUILDKIT=1 docker build \
@@ -114,10 +114,10 @@ Ogmios doesn’t use any form of persistent storage, but cardano-node does. The 
 
 The compose file allows for minimal (albeit useful) configuration parameters via environment variables:
 
-Variable      | Description                                                                                    | Values                 | Default   
----           | ---                                                                                            | ---                    | ---        
-`NETWORK`     | Which Cardano network to connect to. This impacts both Ogmios and the underlying Cardano node. | `mainnet`, `testnet`   | `mainnet`    
-`OGMIOS_PORT` | Which ports to listen to (both for WebSockets and health endpoints)                            | Any valid port number. | `1337`    
+Variable      | Description                                                                                    | Values                 | Default
+---           | ---                                                                                            | ---                    | ---
+`NETWORK`     | Which Cardano network to connect to. This impacts both Ogmios and the underlying Cardano node. | `mainnet`, `testnet`   | `mainnet`
+`OGMIOS_PORT` | Which ports to listen to (both for WebSockets and health endpoints)                            | Any valid port number. | `1337`
 
 {{% notice info %}}
 Ogmios doesn't use any form of persistent storage, but cardano-node does. The mainnet and testnet databases are not compatible, so it is recommended to instrument docker-compose to use different namespaces for different networks (so that you can switch from one another without risking any database conflicts). Compose can do this easily by passing an extra flag: `--project-name`.
@@ -139,7 +139,7 @@ To build the Ogmios image from sources, pass the `--build` flag to compose. This
 $ DOCKER_BUILDKIT=1 docker build \
     --cache-from cardanosolutions/ogmios:latest \
     --tag cardanosolutions/ogmios:latest \
-    --target ogmios \ 
+    --target ogmios \
     https://github.com/cardanosolutions/ogmios.git
 ```
 

--- a/scripts/cardano-node-ogmios.sh
+++ b/scripts/cardano-node-ogmios.sh
@@ -27,7 +27,7 @@ cardano-node run\
   --port 3000\
   --host-addr 0.0.0.0\
   --config /config/$NETWORK-config.json\
-  --socket-path ./node.socket&
+  --socket-path /ipc/node.socket&
 status=$?
 if [ $status -ne 0 ]; then
   echo "Failed to start cardano-node: $status"
@@ -36,7 +36,7 @@ fi
 
 OGMIOS_NETWORK=$NETWORK ogmios \
   --host 0.0.0.0\
-  --node-socket ./node.socket &
+  --node-socket ./ipc/node.socket &
 status=$?
 if [ $status -ne 0 ]; then
   echo "Failed to start ogmios: $status"


### PR DESCRIPTION
- Adds a top-level `ipc` directory for the cardano-node socket
to be created in, which can be mounted for multi-container stacks.
- Documents the mount point, and improve the existing docs.
- Remove trailing spaces as per `.editorconfig`