### PR TITLE
Chore/docker hub tag rework

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu-20.04 ]
         target: [ ogmios, cardano-node-ogmios ]
-        network: [ "", "-testnet" ]
+        network: [ "mainnet", "testnet" ]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -39,30 +39,57 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
-    - name: 🔨 Build and push
+    - name: 📝 Base Variables
+      id: base-variables
+      run: |
+        echo ::set-output name=image::cardanosolutions/${{ matrix.target }}
+
+    - name: 📝 Tag Variables
+      if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
+      id: tag-variables
+      run: |
+        echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
+
+    - name: 🔨 Build and push (default latest)
+      if: ${{ github.event_name == 'push' && matrix.target == 'mainnet' }}
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.base-variables.outputs.image }}:latest
+        target: ${{ matrix.target }}
+        cache-from: type=registry,ref=${{ steps.base-variables.outputs.image }}:latest
+        cache-to: type=inline
+
+    - name: 🔨 Build and push (network latest)
       if: ${{ github.event_name == 'push' }}
       uses: docker/build-push-action@v2
       with:
         context: .
         push: true
-        tags: cardanosolutions/${{ matrix.target }}:latest${{ matrix.network }}
+        tags: ${{ steps.base-variables.outputs.image }}:latest-${{ matrix.network }}
         target: ${{ matrix.target }}
-        cache-from: type=registry,ref=cardanosolutions/${{ matrix.target }}:latest${{ matrix.network }}
+        cache-from: type=registry,ref=${{ steps.base-variables.outputs.image }}:latest-${{ matrix.network }}
         cache-to: type=inline
 
-    - name: 📝 Variables
-      if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
-      id: variables
-      run: |
-        echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
+    - name: 🏷️ Build and push (default tag)
+      if: ${{ github.event_name == 'push' && matrix.target == 'mainnet' && startsWith(github.ref, 'refs/tags') }}
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.base-variables.outputs.image }}:${{ steps.tag-variables.outputs.tag }}
+        target: ${{ matrix.target }}
+        cache-from: type=registry,ref=${{ steps.base-variables.outputs.image }}:latest
+        cache-to: type=inline
 
-    - name: 🏷️ Build and push (tag)
+    - name: 🏷️ Build and push (network tags)
       if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
       uses: docker/build-push-action@v2
       with:
         context: .
         push: true
-        tags: cardanosolutions/${{ matrix.target }}:${{ steps.variables.outputs.tag }}${{ matrix.network }}
+        tags: ${{ steps.base-variables.outputs.image }}:${{ steps.tag-variables.outputs.tag }}-${{ matrix.network }}
         target: ${{ matrix.target }}
-        cache-from: type=registry,ref=cardanosolutions/${{ matrix.target }}:latest${{ matrix.network }}
+        cache-from: type=registry,ref=${{ steps.base-variables.outputs.image }}:latest-${{ matrix.network }}
         cache-to: type=inline

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,8 +104,6 @@ ENTRYPOINT ["ogmios"]
 FROM debian:buster-slim as cardano-node-ogmios
 
 ARG NETWORK=mainnet
-# Temporary for backwards compatibility.
-ENV NETWORK=$NETWORK
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
         max-file: "20"
 
   ogmios:
-    image: cardanosolutions/ogmios:latest
+    image: cardanosolutions/ogmios:latest-${NETWORK:-mainnet}
     build:
       context: .
       target: ogmios

--- a/docs/content/getting-started/docker.md
+++ b/docs/content/getting-started/docker.md
@@ -10,12 +10,14 @@ The easiest way to get started with Ogmios is to use [docker](https://www.docker
 
 Ogmios docker images come in two flavours: `cardano-node-ogmios` and `ogmios`. The former is used to run a single container that bundles both a Cardano-node and an Ogmios server running side-by-side. It is likely the easiest way to get started. The latter is a standalone Ogmios server, and you'll need to run that container in orchestration with a cardano-node; this is made relatively easy with [Docker compose](https://docs.docker.com/compose/).
 
-Images are uploaded to [Dockerhub](https://dockerhub.com/) and can be pulled from the registry at any time. Images are tagged using release versions or with `:latest` if you're living on the edge.
+Images are uploaded to [Dockerhub](https://dockerhub.com/) and are tagged using release versions
+combined with the [supported network name](../../../config/network), or with `:latest` if you're
+living on the edge. If using the `mainnet` image you can omit the network name.
 
 | image               | repository                                                                                      | tags               |
 | ---                 | ---                                                                                             | ---                |
-| cardano-node-ogmios | [cardanosolutions/cardano-node-ogmios](https://hub.docker.com/repository/docker/cardanosolutions/cardano-node-ogmios) | `latest`, `latest-testnet`, `v*.*.*`, `v*.*.*-testnet` |
-| ogmios              | [cardanosolutions/ogmios](https://hub.docker.com/repository/docker/cardanosolutions/ogmios)                           | `latest`, `latest-testnet`, `v*.*.*`, `v*.*.*-testnet` |
+| cardano-node-ogmios | [cardanosolutions/cardano-node-ogmios](https://hub.docker.com/repository/docker/cardanosolutions/cardano-node-ogmios) | `latest`, `latest-{NETWORK}`, `v*.*.*`, `v*.*.*-{NETWORK}` |
+| ogmios              | [cardanosolutions/ogmios](https://hub.docker.com/repository/docker/cardanosolutions/ogmios)                           | `latest`, `latest-{NETWORK}`, `v*.*.*`, `v*.*.*-{NETWORK}` |
 
 ## cardano-node-ogmios (easiest)
 

--- a/docs/content/getting-started/docker.md
+++ b/docs/content/getting-started/docker.md
@@ -29,7 +29,7 @@ Assuming you've pulled or build the image (otherwise, see below), you can start 
 $ docker run -it \
   --name cardano-node-ogmios \
   -p 1337:1337 \
-  -v db/mainnet:db \
+  -v cardano-node-ogmios-db:db \
   cardanosolutions/cardano-node-ogmios:latest
 ```
 


### PR DESCRIPTION
:pushpin:  **remove superfluous ENV export in Dockerfile**

:pushpin: **tag and push mainnet labelled tags**
Aligns the network tagging strategy to make it easier to dynamically
configure the instance.

`latest`, `latest-{NETWORK}`, `v*.*.*`, `v*.*.*-{NETWORK}`

The existing default tags point to the `mainnet` images, e.g.
`latest` == `latest-mainnet`.

:pushpin: **improve the documented volume name for cardano-node-ogmios**