### PR TITLE
refactor: change cardano-node-ogmios database mount point to /db

### DIFF
--- a/docs/content/getting-started/docker.md
+++ b/docs/content/getting-started/docker.md
@@ -29,7 +29,7 @@ Assuming you've pulled or build the image (otherwise, see below), you can start 
 $ docker run -it \
   --name cardano-node-ogmios \
   -p 1337:1337 \
-  -v cardano-node-ogmios-db:db \
+  -v cardano-node-ogmios-db:/db \
   cardanosolutions/cardano-node-ogmios:latest
 ```
 

--- a/scripts/cardano-node-ogmios.sh
+++ b/scripts/cardano-node-ogmios.sh
@@ -15,7 +15,7 @@ set -m
 
 cardano-node run\
   --topology /config/cardano-node/topology.json\
-  --database-path db\
+  --database-path /db\
   --port 3000\
   --host-addr 0.0.0.0\
   --config /config/cardano-node/config.json\


### PR DESCRIPTION
Without this change implementations would need to mount into /root/db.