### PR TITLE
ci: fix network Docker builds on Docker Hub

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -87,6 +87,7 @@ jobs:
       if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
       uses: docker/build-push-action@v2
       with:
+        build-args: NETWORK=${{ matrix.network }}
         context: .
         push: true
         tags: ${{ steps.base-variables.outputs.image }}:${{ steps.tag-variables.outputs.tag }}-${{ matrix.network }}


### PR DESCRIPTION
The build action was missing the network build-args,
so the image tagged as testnet was actually the mainnet
since it's the default.