### PR TITLE
Fix/client ts error improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ chapter: false
 pre: "<b>5. </b>"
 ---
 
-### [4.0.0-beta.3] - 2021-06-05
+### [4.0.0-beta.4] - 2021-07-07
 
 #### Added
 
@@ -40,7 +40,14 @@ pre: "<b>5. </b>"
    This behaviour can be bypassed where sequential processsing is not required, by setting the new
    construction option `sequential` to `false`.
 
-- Nested logs are now also structured, in particular those coming from the Handshake or TxSubmission protocols. Before, any message from these layers where actually plain strings with unprocessable gibberish. Now, the submitted transaction payload is shown encoded as hexadecimals and errors are also serialized to json using the same model / codec as the one used for websockets. The handshake is also more verbose now clearly showing what version is being requested and what the node replies / select. All in all, better logs. 
+- Nested logs are now also structured, in particular those coming from the Handshake or TxSubmission protocols. Before, any message from these layers where actually plain strings with unprocessable gibberish. Now, the submitted transaction payload is shown encoded as hexadecimals and errors are also serialized to json using the same model / codec as the one used for websockets. The handshake is also more verbose now clearly showing what version is being requested and what the node replies / select. All in all, better logs.
+
+- The Dockerfile now includes a build definition for including `cardano-node` and `ogmios` in
+  the same image, which is the default and suggested mode of operation. To build an image
+  with only Ogmios, use the build target `ogmios`. Docker Hub now hosts two image
+  repositories: `cardanosolutions/cardano-node-ogmios` and `cardanosolutions/ogmios`.
+- Docker Hub images are now tagged with `-mainnet` to make all network images consistent. This
+  more specific tag is optional, and points to the same build as the defaults.
 
 #### Changed
 

--- a/clients/TypeScript/docker-compose.yml
+++ b/clients/TypeScript/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.5"
+
+services:
+  cardano-node-ogmios:
+    build:
+      args:
+        - NETWORK=${NETWORK:-mainnet}
+      cache_from: [cardanosolutions/ogmios:latest]
+      context: ../..
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "400k"
+        max-file: "20"
+    ports:
+      - ${OGMIOS_PORT:-1337}:1337
+    restart: on-failure
+    volumes:
+      - node-db:/db
+
+volumes:
+  node-db:

--- a/clients/TypeScript/package.json
+++ b/clients/TypeScript/package.json
@@ -18,13 +18,13 @@
     "cleanup": "yarn workspaces run cleanup && shx rm -rf node_modules",
     "generate-schema-types": "yarn workspace @cardano-ogmios/schema run generate-schema-types",
     "lint": "yarn workspaces run lint",
-    "mainnet:up": "docker-compose --project-directory ../.. -p ogmios-mainnet up",
-    "mainnet:down": "docker-compose --project-directory ../.. -p ogmios-mainnet down",
+    "mainnet:up": "DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker-compose -p ogmios-mainnet up",
+    "mainnet:down": "docker-compose -p ogmios-mainnet down",
     "repl:pkg": "yarn workspace @cardano-ogmios/repl run pkg",
     "repl:start": "yarn workspace @cardano-ogmios/repl run start",
     "test": "yarn workspaces run test",
-    "testnet:up": "OGMIOS_PORT=1338 NETWORK=testnet docker-compose --project-directory ../.. -p ogmios-testnet up",
-    "testnet:down": "docker-compose --project-directory ../.. -p ogmios-testnet down"
+    "testnet:up": "DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 OGMIOS_PORT=1338 NETWORK=testnet docker-compose -p ogmios-testnet up",
+    "testnet:down": "docker-compose -p ogmios-testnet down"
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",

--- a/clients/TypeScript/package.json
+++ b/clients/TypeScript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-ogmios",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-beta.4",
   "private": true,
   "description": "TypeScript monorepo with client libraries for Cardano Ogmios",
   "engines": {

--- a/clients/TypeScript/packages/client/package.json
+++ b/clients/TypeScript/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cardano-ogmios/client",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-beta.4",
   "description": "TypeScript client library for Cardano Ogmios",
   "engines": {
     "node": "^14"
@@ -51,7 +51,7 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "@cardano-ogmios/schema": "4.0.0-beta.3",
+    "@cardano-ogmios/schema": "4.0.0-beta.4",
     "cross-fetch": "^3.1.4",
     "fastq": "^1.11.0",
     "isomorphic-ws": "^4.0.1",

--- a/clients/TypeScript/packages/client/src/OgmiosHealth.ts
+++ b/clients/TypeScript/packages/client/src/OgmiosHealth.ts
@@ -35,9 +35,9 @@ export interface OgmiosHealth {
 export const getOgmiosHealth = async (
   config?: ConnectionConfig | Connection
 ): Promise<OgmiosHealth> => {
-  const connection = isConnectionObject(config)
+  const connection = config !== undefined && isConnectionObject(config)
     ? config
-    : await createConnectionObject(config)
+    : createConnectionObject(config)
   const response = await fetch(`${connection.address.http}/health`)
   const responseJson = await response.json()
   if (response.ok) {

--- a/clients/TypeScript/packages/client/src/TxSubmission/errors.ts
+++ b/clients/TypeScript/packages/client/src/TxSubmission/errors.ts
@@ -129,7 +129,7 @@ export const errors = {
       Error: class UtxoValidationErrorClass extends CustomError {
         public constructor (rawError: UtxoValidationError) {
           super()
-          this.message = JSON.stringify(rawError.utxoValidationError, null, 2)
+          this.message = JSON.stringify(rawError.utxoValidationError)
         }
       }
     },
@@ -139,7 +139,7 @@ export const errors = {
       Error: class TxValidationErrorClass extends CustomError {
         public constructor (rawError: TxValidationError) {
           super()
-          this.message = JSON.stringify(rawError.txValidationError, null, 2)
+          this.message = JSON.stringify(rawError.txValidationError)
         }
       }
     }
@@ -151,7 +151,7 @@ export const errors = {
       Error: class InvalidWitnessesError extends CustomError {
         public constructor (rawError: InvalidWitnesses) {
           super()
-          this.message = JSON.stringify(rawError.invalidWitnesses, null, 2)
+          this.message = JSON.stringify(rawError.invalidWitnesses)
         }
       }
     },
@@ -161,7 +161,7 @@ export const errors = {
       Error: class MissingVkWitnessesError extends CustomError {
         public constructor (rawError: MissingVkWitnesses) {
           super()
-          this.message = JSON.stringify(rawError.missingVkWitnesses, null, 2)
+          this.message = JSON.stringify(rawError.missingVkWitnesses)
         }
       }
     },
@@ -171,7 +171,7 @@ export const errors = {
       Error: class MissingScriptWitnessesError extends CustomError {
         public constructor (rawError: MissingScriptWitnesses) {
           super()
-          this.message = JSON.stringify(rawError.missingScriptWitnesses, null, 2)
+          this.message = JSON.stringify(rawError.missingScriptWitnesses)
         }
       }
     },
@@ -181,7 +181,7 @@ export const errors = {
       Error: class ScriptWitnessNotValidatingError extends CustomError {
         public constructor (rawError: ScriptWitnessNotValidating) {
           super()
-          this.message = JSON.stringify(rawError.scriptWitnessNotValidating, null, 2)
+          this.message = JSON.stringify(rawError.scriptWitnessNotValidating)
         }
       }
     },
@@ -191,7 +191,7 @@ export const errors = {
       Error: class InsufficientGenesisSignaturesError extends CustomError {
         public constructor (rawError: InsufficientGenesisSignatures) {
           super()
-          this.message = JSON.stringify(rawError.insufficientGenesisSignatures, null, 2)
+          this.message = JSON.stringify(rawError.insufficientGenesisSignatures)
         }
       }
     },
@@ -201,7 +201,7 @@ export const errors = {
       Error: class MissingTxMetadataError extends CustomError {
         public constructor (rawError: MissingTxMetadata) {
           super()
-          this.message = JSON.stringify(rawError.missingTxMetadata, null, 2)
+          this.message = JSON.stringify(rawError.missingTxMetadata)
         }
       }
     },
@@ -211,7 +211,7 @@ export const errors = {
       Error: class MissingTxMetadataHashError extends CustomError {
         public constructor (rawError: MissingTxMetadataHash) {
           super()
-          this.message = JSON.stringify(rawError.missingTxMetadataHash, null, 2)
+          this.message = JSON.stringify(rawError.missingTxMetadataHash)
         }
       }
     },
@@ -221,7 +221,7 @@ export const errors = {
       Error: class TxMetadataHashMismatchError extends CustomError {
         public constructor (rawError: TxMetadataHashMismatch) {
           super()
-          this.message = JSON.stringify(rawError.txMetadataHashMismatch, null, 2)
+          this.message = JSON.stringify(rawError.txMetadataHashMismatch)
         }
       }
     },
@@ -231,7 +231,7 @@ export const errors = {
       Error: class BadInputsError extends CustomError {
         public constructor (rawError: BadInputs) {
           super()
-          this.message = JSON.stringify(rawError.badInputs, null, 2)
+          this.message = JSON.stringify(rawError.badInputs)
         }
       }
     },
@@ -241,7 +241,7 @@ export const errors = {
       Error: class ExpiredUtxoError extends CustomError {
         public constructor (rawError: ExpiredUtxo) {
           super()
-          this.message = JSON.stringify(rawError.expiredUtxo, null, 2)
+          this.message = JSON.stringify(rawError.expiredUtxo)
         }
       }
     },
@@ -251,7 +251,7 @@ export const errors = {
       Error: class TxTooLargeError extends CustomError {
         public constructor (rawError: TxTooLarge) {
           super()
-          this.message = JSON.stringify(rawError.txTooLarge, null, 2)
+          this.message = JSON.stringify(rawError.txTooLarge)
         }
       }
     },
@@ -261,7 +261,7 @@ export const errors = {
       Error: class MissingAtLeastOneInputUtxoError extends CustomError {
         public constructor (rawError: MissingAtLeastOneInputUtxo) {
           super()
-          this.message = JSON.stringify(rawError, null, 2)
+          this.message = JSON.stringify(rawError)
         }
       }
     },
@@ -271,7 +271,7 @@ export const errors = {
       Error: class InvalidMetadataError extends CustomError {
         public constructor (rawError: InvalidMetadata) {
           super()
-          this.message = JSON.stringify(rawError, null, 2)
+          this.message = JSON.stringify(rawError)
         }
       }
     },
@@ -281,7 +281,7 @@ export const errors = {
       Error: class FeeTooSmallError extends CustomError {
         public constructor (rawError: FeeTooSmall) {
           super()
-          this.message = JSON.stringify(rawError.feeTooSmall, null, 2)
+          this.message = JSON.stringify(rawError.feeTooSmall)
         }
       }
     },
@@ -291,7 +291,7 @@ export const errors = {
       Error: class ValueNotConservedError extends CustomError {
         public constructor (rawError: ValueNotConserved) {
           super()
-          this.message = JSON.stringify(rawError.valueNotConserved, null, 2)
+          this.message = JSON.stringify(rawError.valueNotConserved)
         }
       }
     },
@@ -301,7 +301,7 @@ export const errors = {
       Error: class NetworkMismatchError extends CustomError {
         public constructor (rawError: NetworkMismatch) {
           super()
-          this.message = JSON.stringify(rawError.networkMismatch, null, 2)
+          this.message = JSON.stringify(rawError.networkMismatch)
         }
       }
     },
@@ -311,7 +311,7 @@ export const errors = {
       Error: class OutputTooSmallError extends CustomError {
         public constructor (rawError: OutputTooSmall) {
           super()
-          this.message = JSON.stringify(rawError.outputTooSmall, null, 2)
+          this.message = JSON.stringify(rawError.outputTooSmall)
         }
       }
     },
@@ -321,7 +321,7 @@ export const errors = {
       Error: class AddressAttributesTooLargeError extends CustomError {
         public constructor (rawError: AddressAttributesTooLarge) {
           super()
-          this.message = JSON.stringify(rawError.addressAttributesTooLarge, null, 2)
+          this.message = JSON.stringify(rawError.addressAttributesTooLarge)
         }
       }
     },
@@ -331,7 +331,7 @@ export const errors = {
       Error: class DelegateNotRegisteredError extends CustomError {
         public constructor (rawError: DelegateNotRegistered) {
           super()
-          this.message = JSON.stringify(rawError.delegateNotRegistered, null, 2)
+          this.message = JSON.stringify(rawError.delegateNotRegistered)
         }
       }
     },
@@ -341,7 +341,7 @@ export const errors = {
       Error: class UnknownOrIncompleteWithdrawalsError extends CustomError {
         public constructor (rawError: UnknownOrIncompleteWithdrawals) {
           super()
-          this.message = JSON.stringify(rawError.unknownOrIncompleteWithdrawals, null, 2)
+          this.message = JSON.stringify(rawError.unknownOrIncompleteWithdrawals)
         }
       }
     },
@@ -351,7 +351,7 @@ export const errors = {
       Error: class StakePoolNotRegisteredError extends CustomError {
         public constructor (rawError: StakePoolNotRegistered) {
           super()
-          this.message = JSON.stringify(rawError.stakePoolNotRegistered, null, 2)
+          this.message = JSON.stringify(rawError.stakePoolNotRegistered)
         }
       }
     },
@@ -361,7 +361,7 @@ export const errors = {
       Error: class WrongRetirementEpochError extends CustomError {
         public constructor (rawError: WrongRetirementEpoch) {
           super()
-          this.message = JSON.stringify(rawError.wrongRetirementEpoch, null, 2)
+          this.message = JSON.stringify(rawError.wrongRetirementEpoch)
         }
       }
     },
@@ -371,7 +371,7 @@ export const errors = {
       Error: class WrongPoolCertificateError extends CustomError {
         public constructor (rawError: WrongPoolCertificate) {
           super()
-          this.message = JSON.stringify(rawError.wrongPoolCertificate, null, 2)
+          this.message = JSON.stringify(rawError.wrongPoolCertificate)
         }
       }
     },
@@ -381,7 +381,7 @@ export const errors = {
       Error: class StakeKeyAlreadyRegisteredError extends CustomError {
         public constructor (rawError: StakeKeyAlreadyRegistered) {
           super()
-          this.message = JSON.stringify(rawError.stakeKeyAlreadyRegistered, null, 2)
+          this.message = JSON.stringify(rawError.stakeKeyAlreadyRegistered)
         }
       }
     },
@@ -391,7 +391,7 @@ export const errors = {
       Error: class PoolCostTooSmallError extends CustomError {
         public constructor (rawError: PoolCostTooSmall) {
           super()
-          this.message = JSON.stringify(rawError.poolCostTooSmall, null, 2)
+          this.message = JSON.stringify(rawError.poolCostTooSmall)
         }
       }
     },
@@ -401,7 +401,7 @@ export const errors = {
       Error: class StakeKeyNotRegisteredError extends CustomError {
         public constructor (rawError: StakeKeyNotRegistered) {
           super()
-          this.message = JSON.stringify(rawError.stakeKeyNotRegistered, null, 2)
+          this.message = JSON.stringify(rawError.stakeKeyNotRegistered)
         }
       }
     },
@@ -411,7 +411,7 @@ export const errors = {
       Error: class RewardAccountNotExistingError extends CustomError {
         public constructor (rawError: RewardAccountNotExisting) {
           super()
-          this.message = JSON.stringify(rawError, null, 2)
+          this.message = JSON.stringify(rawError)
         }
       }
     },
@@ -421,7 +421,7 @@ export const errors = {
       Error: class RewardAccountNotEmptyError extends CustomError {
         public constructor (rawError: RewardAccountNotEmpty) {
           super()
-          this.message = JSON.stringify(rawError.rewardAccountNotEmpty, null, 2)
+          this.message = JSON.stringify(rawError.rewardAccountNotEmpty)
         }
       }
     },
@@ -431,7 +431,7 @@ export const errors = {
       Error: class WrongCertificateTypeError extends CustomError {
         public constructor (rawError: WrongCertificateType) {
           super()
-          this.message = JSON.stringify(rawError, null, 2)
+          this.message = JSON.stringify(rawError)
         }
       }
     },
@@ -441,7 +441,7 @@ export const errors = {
       Error: class UnknownGenesisKeyError extends CustomError {
         public constructor (rawError: UnknownGenesisKey) {
           super()
-          this.message = JSON.stringify(rawError.unknownGenesisKey, null, 2)
+          this.message = JSON.stringify(rawError.unknownGenesisKey)
         }
       }
     },
@@ -451,7 +451,7 @@ export const errors = {
       Error: class AlreadyDelegatingError extends CustomError {
         public constructor (rawError: AlreadyDelegating) {
           super()
-          this.message = JSON.stringify(rawError.alreadyDelegating, null, 2)
+          this.message = JSON.stringify(rawError.alreadyDelegating)
         }
       }
     },
@@ -461,7 +461,7 @@ export const errors = {
       Error: class InsufficientFundsForMirError extends CustomError {
         public constructor (rawError: InsufficientFundsForMir) {
           super()
-          this.message = JSON.stringify(rawError.insufficientFundsForMir, null, 2)
+          this.message = JSON.stringify(rawError.insufficientFundsForMir)
         }
       }
     },
@@ -471,7 +471,7 @@ export const errors = {
       Error: class TooLateForMirError extends CustomError {
         public constructor (rawError: TooLateForMir) {
           super()
-          this.message = JSON.stringify(rawError.tooLateForMir, null, 2)
+          this.message = JSON.stringify(rawError.tooLateForMir)
         }
       }
     },
@@ -481,7 +481,7 @@ export const errors = {
       Error: class MirTransferNotCurrentlyAllowedError extends CustomError {
         public constructor (rawError: MirTransferNotCurrentlyAllowed) {
           super()
-          this.message = JSON.stringify(rawError, null, 2)
+          this.message = JSON.stringify(rawError)
         }
       }
     },
@@ -491,7 +491,7 @@ export const errors = {
       Error: class MirNegativeTransferNotCurrentlyAllowedError extends CustomError {
         public constructor (rawError: MirNegativeTransferNotCurrentlyAllowed) {
           super()
-          this.message = JSON.stringify(rawError, null, 2)
+          this.message = JSON.stringify(rawError)
         }
       }
     },
@@ -501,7 +501,7 @@ export const errors = {
       Error: class MirProducesNegativeUpdateError extends CustomError {
         public constructor (rawError: MirProducesNegativeUpdate) {
           super()
-          this.message = JSON.stringify(rawError, null, 2)
+          this.message = JSON.stringify(rawError)
         }
       }
     },
@@ -511,7 +511,7 @@ export const errors = {
       Error: class DuplicateGenesisVrfError extends CustomError {
         public constructor (rawError: DuplicateGenesisVrf) {
           super()
-          this.message = JSON.stringify(rawError.duplicateGenesisVrf, null, 2)
+          this.message = JSON.stringify(rawError.duplicateGenesisVrf)
         }
       }
     },
@@ -521,7 +521,7 @@ export const errors = {
       Error: class NonGenesisVotersError extends CustomError {
         public constructor (rawError: NonGenesisVoters) {
           super()
-          this.message = JSON.stringify(rawError.nonGenesisVoters, null, 2)
+          this.message = JSON.stringify(rawError.nonGenesisVoters)
         }
       }
     },
@@ -531,7 +531,7 @@ export const errors = {
       Error: class UpdateWrongEpochError extends CustomError {
         public constructor (rawError: UpdateWrongEpoch) {
           super()
-          this.message = JSON.stringify(rawError.updateWrongEpoch, null, 2)
+          this.message = JSON.stringify(rawError.updateWrongEpoch)
         }
       }
     },
@@ -541,7 +541,7 @@ export const errors = {
       Error: class ProtocolVersionCannotFollowError extends CustomError {
         public constructor (rawError: ProtocolVersionCannotFollow) {
           super()
-          this.message = JSON.stringify(rawError.protocolVersionCannotFollow, null, 2)
+          this.message = JSON.stringify(rawError.protocolVersionCannotFollow)
         }
       }
     },
@@ -551,7 +551,7 @@ export const errors = {
       Error: class OutsideOfValidityIntervalError extends CustomError {
         public constructor (rawError: OutsideOfValidityInterval) {
           super()
-          this.message = JSON.stringify(rawError.outsideOfValidityInterval, null, 2)
+          this.message = JSON.stringify(rawError.outsideOfValidityInterval)
         }
       }
     },
@@ -561,7 +561,7 @@ export const errors = {
       Error: class TriesToForgeAdaError extends CustomError {
         public constructor (rawError: TriesToForgeAda) {
           super()
-          this.message = JSON.stringify(rawError, null, 2)
+          this.message = JSON.stringify(rawError)
         }
       }
     },
@@ -571,7 +571,7 @@ export const errors = {
       Error: class TooManyAssetsInOutputError extends CustomError {
         public constructor (rawError: TooManyAssetsInOutput) {
           super()
-          this.message = JSON.stringify(rawError.tooManyAssetsInOutput, null, 2)
+          this.message = JSON.stringify(rawError.tooManyAssetsInOutput)
         }
       }
     },
@@ -581,7 +581,7 @@ export const errors = {
       Error: class UnredeemableScriptsError extends CustomError {
         public constructor (rawError: UnredeemableScripts) {
           super()
-          this.message = JSON.stringify(rawError.unredeemableScripts, null, 2)
+          this.message = JSON.stringify(rawError.unredeemableScripts)
         }
       }
     },
@@ -591,7 +591,7 @@ export const errors = {
       Error: class DatumsMismatchError extends CustomError {
         public constructor (rawError: DatumsMismatch) {
           super()
-          this.message = JSON.stringify(rawError.datumsMismatch, null, 2)
+          this.message = JSON.stringify(rawError.datumsMismatch)
         }
       }
     },
@@ -601,7 +601,7 @@ export const errors = {
       Error: class ExtraDataMismatchError extends CustomError {
         public constructor (rawError: ExtraDataMismatch) {
           super()
-          this.message = JSON.stringify(rawError.extraDataMismatch, null, 2)
+          this.message = JSON.stringify(rawError.extraDataMismatch)
         }
       }
     },
@@ -611,7 +611,7 @@ export const errors = {
       Error: class MissingRequiredSignaturesError extends CustomError {
         public constructor (rawError: MissingRequiredSignatures) {
           super()
-          this.message = JSON.stringify(rawError.missingRequiredSignatures, null, 2)
+          this.message = JSON.stringify(rawError.missingRequiredSignatures)
         }
       }
     },
@@ -621,7 +621,7 @@ export const errors = {
       Error: class MissingDatumHashesForInputsError extends CustomError {
         public constructor (rawError: MissingDatumHashesForInputs) {
           super()
-          this.message = JSON.stringify(rawError.missingDatumHashesForInputs, null, 2)
+          this.message = JSON.stringify(rawError.missingDatumHashesForInputs)
         }
       }
     },
@@ -631,7 +631,7 @@ export const errors = {
       Error: class MissingCollateralInputsError extends CustomError {
         public constructor (rawError: MissingCollateralInputs) {
           super()
-          this.message = JSON.stringify(rawError, null, 2)
+          this.message = JSON.stringify(rawError)
         }
       }
     },
@@ -641,7 +641,7 @@ export const errors = {
       Error: class CollateralTooSmallError extends CustomError {
         public constructor (rawError: CollateralTooSmall) {
           super()
-          this.message = JSON.stringify(rawError.collateralTooSmall, null, 2)
+          this.message = JSON.stringify(rawError.collateralTooSmall)
         }
       }
     },
@@ -651,7 +651,7 @@ export const errors = {
       Error: class CollateralIsScriptError extends CustomError {
         public constructor (rawError: CollateralIsScript) {
           super()
-          this.message = JSON.stringify(rawError.collateralIsScript, null, 2)
+          this.message = JSON.stringify(rawError.collateralIsScript)
         }
       }
     },
@@ -661,7 +661,7 @@ export const errors = {
       Error: class CollateralHasNonAdaAssetsError extends CustomError {
         public constructor (rawError: CollateralHasNonAdaAssets) {
           super()
-          this.message = JSON.stringify(rawError.collateralHasNonAdaAssets, null, 2)
+          this.message = JSON.stringify(rawError.collateralHasNonAdaAssets)
         }
       }
     },
@@ -671,7 +671,7 @@ export const errors = {
       Error: class TooManyCollateralInputsError extends CustomError {
         public constructor (rawError: TooManyCollateralInputs) {
           super()
-          this.message = JSON.stringify(rawError.tooManyCollateralInputs, null, 2)
+          this.message = JSON.stringify(rawError.tooManyCollateralInputs)
         }
       }
     },
@@ -681,7 +681,7 @@ export const errors = {
       Error: class ExecutionUnitsTooLargeError extends CustomError {
         public constructor (rawError: ExecutionUnitsTooLarge) {
           super()
-          this.message = JSON.stringify(rawError.executionUnitsTooLarge, null, 2)
+          this.message = JSON.stringify(rawError.executionUnitsTooLarge)
         }
       }
     },
@@ -691,7 +691,7 @@ export const errors = {
       Error: class OutsideForecastError extends CustomError {
         public constructor (rawError: OutsideForecast) {
           super()
-          this.message = JSON.stringify(rawError.outsideForecast, null, 2)
+          this.message = JSON.stringify(rawError.outsideForecast)
         }
       }
     },
@@ -701,7 +701,7 @@ export const errors = {
       Error: class ValidationTagMismatchError extends CustomError {
         public constructor (rawError: ValidationTagMismatch) {
           super()
-          this.message = JSON.stringify(rawError, null, 2)
+          this.message = JSON.stringify(rawError)
         }
       }
     },
@@ -711,7 +711,7 @@ export const errors = {
       Error: class CollectErrorsError extends CustomError {
         public constructor (rawError: CollectErrors) {
           super()
-          this.message = JSON.stringify(rawError.collectErrors, null, 2)
+          this.message = JSON.stringify(rawError.collectErrors)
         }
       }
     }

--- a/clients/TypeScript/packages/client/test/OgmiosHealth.test.ts
+++ b/clients/TypeScript/packages/client/test/OgmiosHealth.test.ts
@@ -16,6 +16,10 @@ const expectHealth = (obj: any): void => {
 
 describe('OgmiosHealth', () => {
   describe('getOgmiosHealth', () => {
+    // This test requires a mainnet instance, so is currently disabled.
+    // it('fetches the service metadata using default connection config by default', async () => {
+    //   expectHealth(await getOgmiosHealth())
+    // })
     it('fetches the service metadata when passed a ConnectionConfig', async () => {
       expectHealth(await getOgmiosHealth({ port: 1338 }))
     })

--- a/clients/TypeScript/packages/repl/package.json
+++ b/clients/TypeScript/packages/repl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cardano-ogmios/repl",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-beta.4",
   "description": "REPL for Cardano Ogmios",
   "engines": {
     "node": "^14"
@@ -39,7 +39,7 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "@cardano-ogmios/client": "4.0.0-beta.3",
+    "@cardano-ogmios/client": "4.0.0-beta.4",
     "chalk": "^4.1.0",
     "yargs-parser": "^20.2.7"
   },

--- a/clients/TypeScript/packages/schema/package.json
+++ b/clients/TypeScript/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cardano-ogmios/schema",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-beta.4",
   "description": "Generated TypeScript from the Cardano Ogmios schema",
   "engines": {
     "node": "^14"


### PR DESCRIPTION
:pushpin:  **chore: depend on cardano-node-ogmios for TypeScript client tests**
Retains the use of docker-compose to retain the project-scoped volumes
and up/down behaviour.

:pushpin: **chore: remove whitespace from transaction error messages**

Based on #77