### PR TITLE
Upgrade dependencies to 1.28.0

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -16,7 +16,7 @@ jobs:
   #  _____| ||   |___ |   |  | | |     | |   |___ |   |  | |
   # |_______||_______||___|  |_|  |___|  |_______||___|  |_|
   #
-  server:
+  server_build:
     strategy:
       matrix:
         os: [ubuntu-20.04]
@@ -49,7 +49,49 @@ jobs:
       run: |
         stack --no-terminal build --only-snapshot --haddock --no-haddock-deps
 
-    - name: 🔨 Build & Test
+    - name: 🔨 Build
+      working-directory: server
+      shell: bash
+      run: |
+        stack --no-terminal install --flag ogmios:production ogmios
+        mv $(stack path --local-bin)/ogmios ogmios
+
+    - name: 📤 Upload binary
+      uses: actions/upload-artifact@v2
+      with:
+        name: ogmios
+        path: |
+          server/ogmios
+
+  server_test:
+    needs: [server_build]
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: 💽 Install OS Packages
+      uses: mstksg/get-package@2a4b48d55d72d43ca89ae58ec9ca1397d34a1c35
+      with:
+        apt-get: libgmp-dev libssl-dev libsystemd-dev libsodium-dev zlib1g-dev
+
+    - name: 📥 Checkout repository
+      uses: actions/checkout@v2.3.3
+      with:
+        submodules: true
+
+    - name: 🧰 Setup Stack
+      uses: timbod7/setup-stack@1f68f27c99094a718fe60a2790550aafd042f729
+
+    - name: 💾 Cache Dependencies
+      id: cache
+      uses: actions/cache@v2.1.1
+      with:
+        path: ~/.stack
+        key: ${{ matrix.os }}-${{ hashFiles('server/resolver.yaml') }}
+
+    - name: 🔨 Test
       working-directory: server
       run: |
         stack --no-terminal test --flag ogmios:production --no-run-tests
@@ -105,52 +147,6 @@ jobs:
             exit 1
         fi
 
-  #  _______  __    _  ______   _______  _______  _______  __    _  ______           _______  ______    _______
-  # |       ||  |  | ||      | |       ||       ||       ||  |  | ||      |         |       ||    _ |  |       |
-  # |    ___||   |_| ||  _    ||_     _||   _   ||    ___||   |_| ||  _    |        |    _  ||   | ||  |    ___|
-  # |   |___ |       || | |   |  |   |  |  | |  ||   |___ |       || | |   |        |   |_| ||   |_||_ |   |___
-  # |    ___||  _    || |_|   |  |   |  |  |_|  ||    ___||  _    || |_|   |        |    ___||    __  ||    ___|
-  # |   |___ | | |   ||       |  |   |  |       ||   |___ | | |   ||       | _____  |   |    |   |  | ||   |___
-  # |_______||_|  |__||______|   |___|  |_______||_______||_|  |__||______| |_____| |___|    |___|  |_||_______|
-  #
-  pre_endToEnd:
-    strategy:
-      matrix:
-        os: [ ubuntu-20.04 ]
-
-    runs-on: ${{ matrix.os }}
-    steps:
-    - name: 📥 Checkout repository
-      uses: actions/checkout@v2.3.3
-      with:
-        submodules: true
-
-    - name: 🧰 Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-
-    - name: 🐳 Login to DockerHub
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-
-    - name: 🔨 Build cardano-node-ogmios testnet
-      uses: docker/build-push-action@v2
-      with:
-        build-args: NETWORK=testnet
-        context: .
-        push: false
-        tags: cardanosolutions/cardano-node-ogmios:${{ github.sha }}-testnet
-        cache-from: type=registry,ref=cardanosolutions/cardano-node-ogmios:latest-testnet
-        cache-to: type=inline
-        outputs: type=docker,dest=/tmp/cardano-node-ogmios-${{ github.sha }}-testnet.tar
-
-    - name: Upload Docker image artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: cardano-node-ogmios-${{ github.sha }}-testnet
-        path: /tmp/cardano-node-ogmios-${{ github.sha }}-testnet.tar
-
   #  _______  ___      ___   _______  __    _  _______  _______          _______  __   __  _______  _______  _______  _______  ______    ___   _______  _______
   # |       ||   |    |   | |       ||  |  | ||       ||       |        |       ||  | |  ||       ||       ||       ||       ||    _ |  |   | |       ||       |
   # |       ||   |    |   | |    ___||   |_| ||_     _||  _____|        |_     _||  |_|  ||    _  ||    ___||  _____||       ||   | ||  |   | |    _  ||_     _|
@@ -160,13 +156,19 @@ jobs:
   # |_______||_______||___| |_______||_|  |__|  |___|  |_______||_____|   |___|    |___|  |___|    |_______||_______||_______||___|  |_||___| |___|      |___|
   #
   clients_TypeScript:
-    needs: [pre_endToEnd]
+    needs: [server_build]
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
         network: [ testnet ]
+        cardanoNodeVersion: [1.28.0]
     runs-on: ${{ matrix.os }}
     steps:
+    - name: 💽 Install OS Packages
+      uses: mstksg/get-package@2a4b48d55d72d43ca89ae58ec9ca1397d34a1c35
+      with:
+        apt-get: libgmp-dev libssl-dev libsystemd-dev libsodium-dev zlib1g-dev
+
     - name: 📥 Checkout repository
       uses: actions/checkout@v2.3.3
       with:
@@ -183,26 +185,6 @@ jobs:
       with:
         node-version: 14.4
 
-    - name: Download Docker image artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: cardano-node-ogmios-${{ github.sha }}-${{ matrix.network }}
-        path: /tmp
-
-    - name: Load Docker image
-      run: |
-        docker load --input /tmp/cardano-node-ogmios-${{ github.sha }}-${{ matrix.network }}.tar
-        docker image ls -a
-
-    - name: 💾 Cache cardano-node DB
-      id: cache
-      uses: actions/cache@v2.1.1
-      with:
-        path: ${{ runner.temp }}/db-${{ matrix.network }}
-        key: cardano-node-ogmios-${{ matrix.network }}-${{ steps.date-time.outputs.value }}
-        restore-keys: |
-          cardano-node-ogmios-${{ matrix.network }}-
-
     - name: ↪ Set package version
       id: package-version
       uses: martinbeentjes/npm-get-version-action@master
@@ -217,15 +199,44 @@ jobs:
         yarn build
         yarn lint
 
+    - name: 📥 Download
+      uses: actions/download-artifact@v2
+      with:
+        name: ogmios
+        path: server
+
+    - name: 💾 Cache cardano-node DB
+      id: cache
+      uses: actions/cache@v2.1.1
+      with:
+        path: ${{ runner.temp }}/db-${{ matrix.network }}
+        key: cardano-node-ogmios-${{ matrix.network }}-${{ steps.date-time.outputs.value }}
+        restore-keys: |
+          cardano-node-ogmios-${{ matrix.network }}-
+
     - name: 🔬 Test
       if: matrix.network == 'testnet'
       working-directory: clients/TypeScript
+      shell: bash
+      env:
+        CONFDIR: /home/runner/work/ogmios/ogmios/server/config/network/${{ matrix.network }}
       run: |
-        docker run -d --name cardano-node-ogmios -p 1338:1337 -v ${{ runner.temp }}/db-${{ matrix.network }}:/db cardanosolutions/cardano-node-ogmios:${{ github.sha }}-${{ matrix.network }}
+        chmod +x ../../server/ogmios
+        sudo ../../server/ogmios --port 1338 --log-level error --node-socket ${{ runner.temp }}/ipc/node.socket --node-config $CONFDIR/cardano-node/config.json &
+
+        docker pull inputoutput/cardano-node:${{ matrix.cardanoNodeVersion }}
+        docker run -d --name cardano-node \
+          -v ${{ runner.temp }}/db-${{ matrix.network }}:/db \
+          -v ${{ runner.temp }}/ipc:/ipc \
+          -v $CONFDIR/cardano-node:/config \
+          -v $CONFDIR/genesis:/genesis \
+          inputoutput/cardano-node:${{ matrix.cardanoNodeVersion }} run --config /config/config.json --database-path /db --socket-path /ipc/node.socket --topology /config/topology.json
+
         ../../scripts/wait-for-sync.sh 1338 1
+
         yarn test
-        docker stop cardano-node-ogmios
-        docker rm cardano-node-ogmios
+        docker stop cardano-node
+        docker rm cardano-node
 
     - name: 📦 Pack
       working-directory: clients/TypeScript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ chapter: false
 pre: "<b>5. </b>"
 ---
 
+### [4.0.0] - 2021-07-XX
+
+#### Added
+
+- Integrated with the Cardano eco-system corresponding to cardano-node@1.28.0. Bumped the docker-compose installation accordingly.
+- New possible errors from the transaction submission:
+  - `poolMetadataHashTooBig`
+  - `missingRequiredDatums`
+  - `unspendableDatums`
+  - `unspendableScriptInputsWithoutDatum`
+
+#### Changed
+
+- The `memory` and `steps` JSON representations for `prices` are no longer coins, but ratio (represented as strings in the API).
+- `lovelacePerUtxoWord` has been renamed into `coinsPerUtxoWord` in the AlonzoGenesis.
+
+#### Removed
+
+- A previous introduced error from the transaction submission has been removed / replaced:
+  - `datumsMismatch`
+
 ### [4.0.0-beta.4] - 2021-07-07
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,27 @@ pre: "<b>5. </b>"
   - `missingRequiredDatums`
   - `unspendableDatums`
   - `unspendableScriptInputs`
+- Added missing properties in Byron's protocol parameters update. Somehow, an `additionalProperties: true` had slipped through and caused the tests to pass with an incomplete schema.
 
 #### Changed
 
 - The `memory` and `steps` JSON representations for `prices` are no longer coins, but ratio (represented as strings in the API).
 - `lovelacePerUtxoWord` has been renamed into `coinsPerUtxoWord` in the AlonzoGenesis.
+- Changes in the TypeScript's client:
+  - `Tip` & `Point` have been renamed to `TipOrOrigin` and `PointOrOrigin`. As a consequence, `Tip1` and `Point1` are now simply `Tip` and `Point`.
+  - `Origin` is now a standalone type, merged with `Origin1`.
+  - `SubmitTx` no-longer returns Byron errors. Consequently, submit errors are no longer scoped under `errors.byron` or `errors.shelley` but simply `errors`.
+  - Fixed `proposedProtocolParameters` query. All fields are actually required AND, more importantly, it can now return either Shelley protocol parameters or, Alonzo protocol parameters.
 
 #### Removed
 
 - A previous introduced error from the transaction submission has been removed / replaced:
   - `datumsMismatch`
+
+- `SubmitTx` can no longer return `SubmitTxError[Byron]`. All the child error types have been removed accordingly, namely:
+  - `UtxoValidationError`
+  - `TxValidationError`
+  - `LovelaceError`
 
 ### [4.0.0-beta.4] - 2021-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ pre: "<b>5. </b>"
   - `poolMetadataHashTooBig`
   - `missingRequiredDatums`
   - `unspendableDatums`
-  - `unspendableScriptInputsWithoutDatum`
+  - `unspendableScriptInputs`
 
 #### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-ARG CARDANO_NODE_REV=8fe46140a52810b6ca456be01d652ca08fe730bf
-ARG OGMIOS_SNAPSHOT=2e014ab79c5abce5f3cea2db09200fe3c00bc117
+ARG CARDANO_NODE_REV=48429531f0d3d71fadce9a5971bf56a6df396f2d
+ARG OGMIOS_SNAPSHOT=a7bab073220caad8b98351515e3d68f5eb605383
 ARG IOHK_LIBSODIUM_GIT_REV=66f017f16633f2060db25e17c170c2afa0f2a8a1
 
 #                                                                              #

--- a/clients/TypeScript/packages/client/src/ChainSync/ChainSyncClient.ts
+++ b/clients/TypeScript/packages/client/src/ChainSync/ChainSyncClient.ts
@@ -1,4 +1,4 @@
-import { Block, Ogmios, Point, Tip } from '@cardano-ogmios/schema'
+import { Block, Ogmios, PointOrOrigin, TipOrOrigin } from '@cardano-ogmios/schema'
 import {
   ConnectionConfig,
   createInteractionContext,
@@ -15,7 +15,7 @@ export interface ChainSyncClient {
   context: InteractionContext
   shutdown: () => Promise<void>
   startSync: (
-    points?: Point[],
+    points?: PointOrOrigin[],
     inFlight?: number
   ) => Promise<Intersection>
 }
@@ -23,15 +23,15 @@ export interface ChainSyncClient {
 export interface ChainSyncMessageHandlers {
   rollBackward: (
     response: {
-      point: Point,
-      tip: Tip
+      point: PointOrOrigin,
+      tip: TipOrOrigin
     },
     requestNext: () => void
   ) => Promise<void>
   rollForward: (
     response: {
       block: Block,
-      tip: Tip
+      tip: TipOrOrigin
     },
     requestNext: () => void
   ) => Promise<void>

--- a/clients/TypeScript/packages/client/src/ChainSync/findIntersect.ts
+++ b/clients/TypeScript/packages/client/src/ChainSync/findIntersect.ts
@@ -1,13 +1,13 @@
-import { Ogmios, Point, Tip } from '@cardano-ogmios/schema'
+import { Ogmios, PointOrOrigin, TipOrOrigin } from '@cardano-ogmios/schema'
 import { IntersectionNotFoundError, UnknownResultError } from '../errors'
 import { ConnectionConfig, InteractionContext } from '../Connection'
 import { Query } from '../StateQuery/'
 
 // type Intersection = Ogmios['FindIntersectResponse']['result']['IntersectionFound']
-export type Intersection = { point: Point, tip: Tip }
+export type Intersection = { point: PointOrOrigin, tip: TipOrOrigin }
 
 export const findIntersect = (
-  points: Point[],
+  points: PointOrOrigin[],
   config?: ConnectionConfig | InteractionContext
 ): Promise<Intersection> =>
   Query<

--- a/clients/TypeScript/packages/client/src/StateQuery/StateQueryClient.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/StateQueryClient.ts
@@ -4,7 +4,7 @@ import {
   Hash16,
   Lovelace,
   Ogmios,
-  Point
+  PointOrOrigin
 } from '@cardano-ogmios/schema'
 import {
   ConnectionConfig,
@@ -41,7 +41,7 @@ export interface StateQueryClient {
   genesisConfig: () => ReturnType<typeof genesisConfig>
   ledgerTip: () => ReturnType<typeof ledgerTip>
   nonMyopicMemberRewards: (input: Lovelace[] | Hash16[]) => ReturnType<typeof nonMyopicMemberRewards>
-  point: Point
+  point: PointOrOrigin
   proposedProtocolParameters: () => ReturnType<typeof proposedProtocolParameters>
   release: () => Promise<void>
   stakeDistribution: () => ReturnType<typeof stakeDistribution>
@@ -53,7 +53,7 @@ export const createStateQueryClient = async (
   closeHandler: WebSocketCloseHandler,
   options?: {
     connection?: ConnectionConfig,
-    point?: Point
+    point?: PointOrOrigin
   }): Promise<StateQueryClient> => {
   const context = await createInteractionContext(errorHandler, closeHandler, options)
   const point = options?.point !== undefined

--- a/clients/TypeScript/packages/client/src/StateQuery/queries/ledgerTip.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/queries/ledgerTip.ts
@@ -1,4 +1,4 @@
-import { EraMismatch, Hash16, Ogmios, Point, Slot } from '@cardano-ogmios/schema'
+import { EraMismatch, Hash16, Ogmios, PointOrOrigin, Slot } from '@cardano-ogmios/schema'
 import { EraMismatchError, QueryUnavailableInCurrentEraError, UnknownResultError } from '../../errors'
 import { ConnectionConfig, InteractionContext } from '../../Connection'
 import { Query } from '../Query'
@@ -9,11 +9,11 @@ const isEraMismatch = (result: Ogmios['QueryResponse[ledgerTip]']['result']): re
 const isNonOriginPoint = (result: {slot: Slot, hash: Hash16}): result is {slot: Slot, hash: Hash16} =>
   (result as {slot: Slot, hash: Hash16}).slot !== undefined
 
-export const ledgerTip = (config?: ConnectionConfig | InteractionContext): Promise<Point> =>
+export const ledgerTip = (config?: ConnectionConfig | InteractionContext): Promise<PointOrOrigin> =>
   Query<
     Ogmios['Query'],
     Ogmios['QueryResponse[ledgerTip]'],
-    Point
+    PointOrOrigin
   >({
     methodName: 'Query',
     args: {

--- a/clients/TypeScript/packages/client/src/TxSubmission/errors.ts
+++ b/clients/TypeScript/packages/client/src/TxSubmission/errors.ts
@@ -7,7 +7,6 @@ import {
   CollateralIsScript,
   CollateralTooSmall,
   CollectErrors,
-  DatumsMismatch,
   DelegateNotRegistered,
   DuplicateGenesisVrf,
   ExecutionUnitsTooLarge,
@@ -24,6 +23,7 @@ import {
   MissingAtLeastOneInputUtxo,
   MissingCollateralInputs,
   MissingDatumHashesForInputs,
+  MissingRequiredDatums,
   MissingRequiredSignatures,
   MissingScriptWitnesses,
   MissingTxMetadata,
@@ -35,6 +35,7 @@ import {
   OutsideForecast,
   OutsideOfValidityInterval,
   PoolCostTooSmall,
+  PoolMetadataHashTooBig,
   ProtocolVersionCannotFollow,
   RewardAccountNotEmpty,
   RewardAccountNotExisting,
@@ -53,6 +54,8 @@ import {
   UnknownGenesisKey,
   UnknownOrIncompleteWithdrawals,
   UnredeemableScripts,
+  UnspendableDatums,
+  UnspendableScriptInputs,
   UpdateWrongEpoch,
   UtxoValidationError,
   ValidationTagMismatch,
@@ -63,63 +66,66 @@ import {
 } from '@cardano-ogmios/schema'
 
 type SubmitTxErrorShelley =
-  InvalidWitnesses
-  | MissingVkWitnesses
-  | MissingScriptWitnesses
-  | ScriptWitnessNotValidating
-  | InsufficientGenesisSignatures
-  | MissingTxMetadata
-  | MissingTxMetadataHash
-  | TxMetadataHashMismatch
-  | BadInputs
-  | ExpiredUtxo
-  | TxTooLarge
-  | MissingAtLeastOneInputUtxo
-  | InvalidMetadata
-  | FeeTooSmall
-  | ValueNotConserved
-  | NetworkMismatch
-  | OutputTooSmall
   | AddressAttributesTooLarge
-  | DelegateNotRegistered
-  | UnknownOrIncompleteWithdrawals
-  | StakePoolNotRegistered
-  | WrongRetirementEpoch
-  | WrongPoolCertificate
-  | StakeKeyAlreadyRegistered
-  | PoolCostTooSmall
-  | StakeKeyNotRegistered
-  | RewardAccountNotExisting
-  | RewardAccountNotEmpty
-  | WrongCertificateType
-  | UnknownGenesisKey
   | AlreadyDelegating
+  | BadInputs
+  | CollateralHasNonAdaAssets
+  | CollateralIsScript
+  | CollateralTooSmall
+  | CollectErrors
+  | DelegateNotRegistered
+  | DuplicateGenesisVrf
+  | ExecutionUnitsTooLarge
+  | ExpiredUtxo
+  | ExtraDataMismatch
+  | FeeTooSmall
   | InsufficientFundsForMir
-  | TooLateForMir
-  | MirTransferNotCurrentlyAllowed
+  | InsufficientGenesisSignatures
+  | InvalidMetadata
+  | InvalidWitnesses
   | MirNegativeTransferNotCurrentlyAllowed
   | MirProducesNegativeUpdate
-  | DuplicateGenesisVrf
-  | NonGenesisVoters
-  | UpdateWrongEpoch
-  | ProtocolVersionCannotFollow
-  | OutsideOfValidityInterval
-  | TriesToForgeAda
-  | TooManyAssetsInOutput
-  | UnredeemableScripts
-  | DatumsMismatch
-  | ExtraDataMismatch
-  | MissingRequiredSignatures
-  | MissingDatumHashesForInputs
+  | MirTransferNotCurrentlyAllowed
+  | MissingAtLeastOneInputUtxo
   | MissingCollateralInputs
-  | CollateralTooSmall
-  | CollateralIsScript
-  | CollateralHasNonAdaAssets
-  | TooManyCollateralInputs
-  | ExecutionUnitsTooLarge
+  | MissingDatumHashesForInputs
+  | MissingRequiredDatums
+  | MissingRequiredSignatures
+  | MissingScriptWitnesses
+  | MissingTxMetadata
+  | MissingTxMetadataHash
+  | MissingVkWitnesses
+  | NetworkMismatch
+  | NonGenesisVoters
+  | OutputTooSmall
   | OutsideForecast
+  | OutsideOfValidityInterval
+  | PoolCostTooSmall
+  | PoolMetadataHashTooBig
+  | ProtocolVersionCannotFollow
+  | RewardAccountNotEmpty
+  | RewardAccountNotExisting
+  | ScriptWitnessNotValidating
+  | StakeKeyAlreadyRegistered
+  | StakeKeyNotRegistered
+  | StakePoolNotRegistered
+  | TooLateForMir
+  | TooManyAssetsInOutput
+  | TooManyCollateralInputs
+  | TriesToForgeAda
+  | TxMetadataHashMismatch
+  | TxTooLarge
+  | UnknownGenesisKey
+  | UnknownOrIncompleteWithdrawals
+  | UnredeemableScripts
+  | UnspendableDatums
+  | UnspendableScriptInputs
+  | UpdateWrongEpoch
   | ValidationTagMismatch
-  | CollectErrors
+  | ValueNotConserved
+  | WrongCertificateType
+  | WrongPoolCertificate
+  | WrongRetirementEpoch;
 
 export const errors = {
   byron: {
@@ -585,16 +591,6 @@ export const errors = {
         }
       }
     },
-    DatumsMismatch: {
-      assert: (item: SubmitTxErrorShelley): item is DatumsMismatch =>
-        (item as DatumsMismatch).datumsMismatch !== undefined,
-      Error: class DatumsMismatchError extends CustomError {
-        public constructor (rawError: DatumsMismatch) {
-          super()
-          this.message = JSON.stringify(rawError.datumsMismatch)
-        }
-      }
-    },
     ExtraDataMismatch: {
       assert: (item: SubmitTxErrorShelley): item is ExtraDataMismatch =>
         (item as ExtraDataMismatch).extraDataMismatch !== undefined,
@@ -712,6 +708,46 @@ export const errors = {
         public constructor (rawError: CollectErrors) {
           super()
           this.message = JSON.stringify(rawError.collectErrors)
+        }
+      }
+    },
+    PoolMetadataHashTooBig: {
+      assert: (item: SubmitTxErrorShelley): item is PoolMetadataHashTooBig =>
+        (item as PoolMetadataHashTooBig).poolMetadataHashTooBig !== undefined,
+      Error: class PoolMetadataHashTooBigError extends CustomError {
+        public constructor (rawError: PoolMetadataHashTooBig) {
+          super()
+          this.message = JSON.stringify(rawError.poolMetadataHashTooBig)
+        }
+      }
+    },
+    MissingRequiredDatums: {
+      assert: (item: SubmitTxErrorShelley): item is MissingRequiredDatums =>
+        (item as MissingRequiredDatums).missingRequiredDatums !== undefined,
+      Error: class MissingRequiredDatumsError extends CustomError {
+        public constructor (rawError: MissingRequiredDatums) {
+          super()
+          this.message = JSON.stringify(rawError.missingRequiredDatums)
+        }
+      }
+    },
+    UnspendableDatums: {
+      assert: (item: SubmitTxErrorShelley): item is UnspendableDatums =>
+        (item as UnspendableDatums).unspendableDatums !== undefined,
+      Error: class UnspendableDatumsError extends CustomError {
+        public constructor (rawError: UnspendableDatums) {
+          super()
+          this.message = JSON.stringify(rawError.unspendableDatums)
+        }
+      }
+    },
+    UnspendableScriptInputs: {
+      assert: (item: SubmitTxErrorShelley): item is UnspendableScriptInputs =>
+        (item as UnspendableScriptInputs).unspendableScriptInputs !== undefined,
+      Error: class UnspendableScriptInputsError extends CustomError {
+        public constructor (rawError: UnspendableScriptInputs) {
+          super()
+          this.message = JSON.stringify(rawError.unspendableScriptInputs)
         }
       }
     }

--- a/clients/TypeScript/packages/client/src/TxSubmission/errors.ts
+++ b/clients/TypeScript/packages/client/src/TxSubmission/errors.ts
@@ -43,21 +43,18 @@ import {
   StakeKeyAlreadyRegistered,
   StakeKeyNotRegistered,
   StakePoolNotRegistered,
-  SubmitFail,
   TooLateForMir,
   TooManyAssetsInOutput,
   TooManyCollateralInputs,
   TriesToForgeAda,
   TxMetadataHashMismatch,
   TxTooLarge,
-  TxValidationError,
   UnknownGenesisKey,
   UnknownOrIncompleteWithdrawals,
   UnredeemableScripts,
   UnspendableDatums,
   UnspendableScriptInputs,
   UpdateWrongEpoch,
-  UtxoValidationError,
   ValidationTagMismatch,
   ValueNotConserved,
   WrongCertificateType,
@@ -128,627 +125,603 @@ type SubmitTxErrorShelley =
   | WrongRetirementEpoch;
 
 export const errors = {
-  byron: {
-    UtxoValidation: {
-      assert: (item: SubmitFail['SubmitFail']): item is UtxoValidationError =>
-        (item as UtxoValidationError).utxoValidationError !== undefined,
-      Error: class UtxoValidationErrorClass extends CustomError {
-        public constructor (rawError: UtxoValidationError) {
-          super()
-          this.message = JSON.stringify(rawError.utxoValidationError)
-        }
-      }
-    },
-    TxValidation: {
-      assert: (item: SubmitFail['SubmitFail']): item is TxValidationError =>
-        (item as TxValidationError).txValidationError !== undefined,
-      Error: class TxValidationErrorClass extends CustomError {
-        public constructor (rawError: TxValidationError) {
-          super()
-          this.message = JSON.stringify(rawError.txValidationError)
-        }
+  InvalidWitnesses: {
+    assert: (item: SubmitTxErrorShelley): item is InvalidWitnesses =>
+      (item as InvalidWitnesses).invalidWitnesses !== undefined,
+    Error: class InvalidWitnessesError extends CustomError {
+      public constructor (rawError: InvalidWitnesses) {
+        super()
+        this.message = JSON.stringify(rawError.invalidWitnesses)
       }
     }
   },
-  shelley: {
-    InvalidWitnesses: {
-      assert: (item: SubmitTxErrorShelley): item is InvalidWitnesses =>
-        (item as InvalidWitnesses).invalidWitnesses !== undefined,
-      Error: class InvalidWitnessesError extends CustomError {
-        public constructor (rawError: InvalidWitnesses) {
-          super()
-          this.message = JSON.stringify(rawError.invalidWitnesses)
-        }
+  MissingVkWitnesses: {
+    assert: (item: SubmitTxErrorShelley): item is MissingVkWitnesses =>
+      (item as MissingVkWitnesses).missingVkWitnesses !== undefined,
+    Error: class MissingVkWitnessesError extends CustomError {
+      public constructor (rawError: MissingVkWitnesses) {
+        super()
+        this.message = JSON.stringify(rawError.missingVkWitnesses)
       }
-    },
-    MissingVkWitnesses: {
-      assert: (item: SubmitTxErrorShelley): item is MissingVkWitnesses =>
-        (item as MissingVkWitnesses).missingVkWitnesses !== undefined,
-      Error: class MissingVkWitnessesError extends CustomError {
-        public constructor (rawError: MissingVkWitnesses) {
-          super()
-          this.message = JSON.stringify(rawError.missingVkWitnesses)
-        }
+    }
+  },
+  MissingScriptWitnesses: {
+    assert: (item: SubmitTxErrorShelley): item is MissingScriptWitnesses =>
+      (item as MissingScriptWitnesses).missingScriptWitnesses !== undefined,
+    Error: class MissingScriptWitnessesError extends CustomError {
+      public constructor (rawError: MissingScriptWitnesses) {
+        super()
+        this.message = JSON.stringify(rawError.missingScriptWitnesses)
       }
-    },
-    MissingScriptWitnesses: {
-      assert: (item: SubmitTxErrorShelley): item is MissingScriptWitnesses =>
-        (item as MissingScriptWitnesses).missingScriptWitnesses !== undefined,
-      Error: class MissingScriptWitnessesError extends CustomError {
-        public constructor (rawError: MissingScriptWitnesses) {
-          super()
-          this.message = JSON.stringify(rawError.missingScriptWitnesses)
-        }
+    }
+  },
+  ScriptWitnessNotValidating: {
+    assert: (item: SubmitTxErrorShelley): item is ScriptWitnessNotValidating =>
+      (item as ScriptWitnessNotValidating).scriptWitnessNotValidating !== undefined,
+    Error: class ScriptWitnessNotValidatingError extends CustomError {
+      public constructor (rawError: ScriptWitnessNotValidating) {
+        super()
+        this.message = JSON.stringify(rawError.scriptWitnessNotValidating)
       }
-    },
-    ScriptWitnessNotValidating: {
-      assert: (item: SubmitTxErrorShelley): item is ScriptWitnessNotValidating =>
-        (item as ScriptWitnessNotValidating).scriptWitnessNotValidating !== undefined,
-      Error: class ScriptWitnessNotValidatingError extends CustomError {
-        public constructor (rawError: ScriptWitnessNotValidating) {
-          super()
-          this.message = JSON.stringify(rawError.scriptWitnessNotValidating)
-        }
+    }
+  },
+  InsufficientGenesisSignatures: {
+    assert: (item: SubmitTxErrorShelley): item is InsufficientGenesisSignatures =>
+      (item as InsufficientGenesisSignatures).insufficientGenesisSignatures !== undefined,
+    Error: class InsufficientGenesisSignaturesError extends CustomError {
+      public constructor (rawError: InsufficientGenesisSignatures) {
+        super()
+        this.message = JSON.stringify(rawError.insufficientGenesisSignatures)
       }
-    },
-    InsufficientGenesisSignatures: {
-      assert: (item: SubmitTxErrorShelley): item is InsufficientGenesisSignatures =>
-        (item as InsufficientGenesisSignatures).insufficientGenesisSignatures !== undefined,
-      Error: class InsufficientGenesisSignaturesError extends CustomError {
-        public constructor (rawError: InsufficientGenesisSignatures) {
-          super()
-          this.message = JSON.stringify(rawError.insufficientGenesisSignatures)
-        }
+    }
+  },
+  MissingTxMetadata: {
+    assert: (item: SubmitTxErrorShelley): item is MissingTxMetadata =>
+      (item as MissingTxMetadata).missingTxMetadata !== undefined,
+    Error: class MissingTxMetadataError extends CustomError {
+      public constructor (rawError: MissingTxMetadata) {
+        super()
+        this.message = JSON.stringify(rawError.missingTxMetadata)
       }
-    },
-    MissingTxMetadata: {
-      assert: (item: SubmitTxErrorShelley): item is MissingTxMetadata =>
-        (item as MissingTxMetadata).missingTxMetadata !== undefined,
-      Error: class MissingTxMetadataError extends CustomError {
-        public constructor (rawError: MissingTxMetadata) {
-          super()
-          this.message = JSON.stringify(rawError.missingTxMetadata)
-        }
+    }
+  },
+  MissingTxMetadataHash: {
+    assert: (item: SubmitTxErrorShelley): item is MissingTxMetadataHash =>
+      (item as MissingTxMetadataHash).missingTxMetadataHash !== undefined,
+    Error: class MissingTxMetadataHashError extends CustomError {
+      public constructor (rawError: MissingTxMetadataHash) {
+        super()
+        this.message = JSON.stringify(rawError.missingTxMetadataHash)
       }
-    },
-    MissingTxMetadataHash: {
-      assert: (item: SubmitTxErrorShelley): item is MissingTxMetadataHash =>
-        (item as MissingTxMetadataHash).missingTxMetadataHash !== undefined,
-      Error: class MissingTxMetadataHashError extends CustomError {
-        public constructor (rawError: MissingTxMetadataHash) {
-          super()
-          this.message = JSON.stringify(rawError.missingTxMetadataHash)
-        }
+    }
+  },
+  TxMetadataHashMismatch: {
+    assert: (item: SubmitTxErrorShelley): item is TxMetadataHashMismatch =>
+      (item as TxMetadataHashMismatch).txMetadataHashMismatch !== undefined,
+    Error: class TxMetadataHashMismatchError extends CustomError {
+      public constructor (rawError: TxMetadataHashMismatch) {
+        super()
+        this.message = JSON.stringify(rawError.txMetadataHashMismatch)
       }
-    },
-    TxMetadataHashMismatch: {
-      assert: (item: SubmitTxErrorShelley): item is TxMetadataHashMismatch =>
-        (item as TxMetadataHashMismatch).txMetadataHashMismatch !== undefined,
-      Error: class TxMetadataHashMismatchError extends CustomError {
-        public constructor (rawError: TxMetadataHashMismatch) {
-          super()
-          this.message = JSON.stringify(rawError.txMetadataHashMismatch)
-        }
+    }
+  },
+  BadInputs: {
+    assert: (item: SubmitTxErrorShelley): item is BadInputs =>
+      (item as BadInputs).badInputs !== undefined,
+    Error: class BadInputsError extends CustomError {
+      public constructor (rawError: BadInputs) {
+        super()
+        this.message = JSON.stringify(rawError.badInputs)
       }
-    },
-    BadInputs: {
-      assert: (item: SubmitTxErrorShelley): item is BadInputs =>
-        (item as BadInputs).badInputs !== undefined,
-      Error: class BadInputsError extends CustomError {
-        public constructor (rawError: BadInputs) {
-          super()
-          this.message = JSON.stringify(rawError.badInputs)
-        }
+    }
+  },
+  ExpiredUtxo: {
+    assert: (item: SubmitTxErrorShelley): item is ExpiredUtxo =>
+      (item as ExpiredUtxo).expiredUtxo !== undefined,
+    Error: class ExpiredUtxoError extends CustomError {
+      public constructor (rawError: ExpiredUtxo) {
+        super()
+        this.message = JSON.stringify(rawError.expiredUtxo)
       }
-    },
-    ExpiredUtxo: {
-      assert: (item: SubmitTxErrorShelley): item is ExpiredUtxo =>
-        (item as ExpiredUtxo).expiredUtxo !== undefined,
-      Error: class ExpiredUtxoError extends CustomError {
-        public constructor (rawError: ExpiredUtxo) {
-          super()
-          this.message = JSON.stringify(rawError.expiredUtxo)
-        }
+    }
+  },
+  TxTooLarge: {
+    assert: (item: SubmitTxErrorShelley): item is TxTooLarge =>
+      (item as TxTooLarge).txTooLarge !== undefined,
+    Error: class TxTooLargeError extends CustomError {
+      public constructor (rawError: TxTooLarge) {
+        super()
+        this.message = JSON.stringify(rawError.txTooLarge)
       }
-    },
-    TxTooLarge: {
-      assert: (item: SubmitTxErrorShelley): item is TxTooLarge =>
-        (item as TxTooLarge).txTooLarge !== undefined,
-      Error: class TxTooLargeError extends CustomError {
-        public constructor (rawError: TxTooLarge) {
-          super()
-          this.message = JSON.stringify(rawError.txTooLarge)
-        }
+    }
+  },
+  MissingAtLeastOneInputUtxo: {
+    assert: (item: SubmitTxErrorShelley): item is MissingAtLeastOneInputUtxo =>
+      (item as MissingAtLeastOneInputUtxo) === 'missingAtLeastOneInputUtxo',
+    Error: class MissingAtLeastOneInputUtxoError extends CustomError {
+      public constructor (rawError: MissingAtLeastOneInputUtxo) {
+        super()
+        this.message = JSON.stringify(rawError)
       }
-    },
-    MissingAtLeastOneInputUtxo: {
-      assert: (item: SubmitTxErrorShelley): item is MissingAtLeastOneInputUtxo =>
-        (item as MissingAtLeastOneInputUtxo) === 'missingAtLeastOneInputUtxo',
-      Error: class MissingAtLeastOneInputUtxoError extends CustomError {
-        public constructor (rawError: MissingAtLeastOneInputUtxo) {
-          super()
-          this.message = JSON.stringify(rawError)
-        }
+    }
+  },
+  InvalidMetadata: {
+    assert: (item: SubmitTxErrorShelley): item is InvalidMetadata =>
+      (item as InvalidMetadata) === 'invalidMetadata',
+    Error: class InvalidMetadataError extends CustomError {
+      public constructor (rawError: InvalidMetadata) {
+        super()
+        this.message = JSON.stringify(rawError)
       }
-    },
-    InvalidMetadata: {
-      assert: (item: SubmitTxErrorShelley): item is InvalidMetadata =>
-        (item as InvalidMetadata) === 'invalidMetadata',
-      Error: class InvalidMetadataError extends CustomError {
-        public constructor (rawError: InvalidMetadata) {
-          super()
-          this.message = JSON.stringify(rawError)
-        }
+    }
+  },
+  FeeTooSmall: {
+    assert: (item: SubmitTxErrorShelley): item is FeeTooSmall =>
+      (item as FeeTooSmall).feeTooSmall !== undefined,
+    Error: class FeeTooSmallError extends CustomError {
+      public constructor (rawError: FeeTooSmall) {
+        super()
+        this.message = JSON.stringify(rawError.feeTooSmall)
       }
-    },
-    FeeTooSmall: {
-      assert: (item: SubmitTxErrorShelley): item is FeeTooSmall =>
-        (item as FeeTooSmall).feeTooSmall !== undefined,
-      Error: class FeeTooSmallError extends CustomError {
-        public constructor (rawError: FeeTooSmall) {
-          super()
-          this.message = JSON.stringify(rawError.feeTooSmall)
-        }
+    }
+  },
+  ValueNotConserved: {
+    assert: (item: SubmitTxErrorShelley): item is ValueNotConserved =>
+      (item as ValueNotConserved).valueNotConserved !== undefined,
+    Error: class ValueNotConservedError extends CustomError {
+      public constructor (rawError: ValueNotConserved) {
+        super()
+        this.message = JSON.stringify(rawError.valueNotConserved)
       }
-    },
-    ValueNotConserved: {
-      assert: (item: SubmitTxErrorShelley): item is ValueNotConserved =>
-        (item as ValueNotConserved).valueNotConserved !== undefined,
-      Error: class ValueNotConservedError extends CustomError {
-        public constructor (rawError: ValueNotConserved) {
-          super()
-          this.message = JSON.stringify(rawError.valueNotConserved)
-        }
+    }
+  },
+  NetworkMismatch: {
+    assert: (item: SubmitTxErrorShelley): item is NetworkMismatch =>
+      (item as NetworkMismatch).networkMismatch !== undefined,
+    Error: class NetworkMismatchError extends CustomError {
+      public constructor (rawError: NetworkMismatch) {
+        super()
+        this.message = JSON.stringify(rawError.networkMismatch)
       }
-    },
-    NetworkMismatch: {
-      assert: (item: SubmitTxErrorShelley): item is NetworkMismatch =>
-        (item as NetworkMismatch).networkMismatch !== undefined,
-      Error: class NetworkMismatchError extends CustomError {
-        public constructor (rawError: NetworkMismatch) {
-          super()
-          this.message = JSON.stringify(rawError.networkMismatch)
-        }
+    }
+  },
+  OutputTooSmall: {
+    assert: (item: SubmitTxErrorShelley): item is OutputTooSmall =>
+      (item as OutputTooSmall).outputTooSmall !== undefined,
+    Error: class OutputTooSmallError extends CustomError {
+      public constructor (rawError: OutputTooSmall) {
+        super()
+        this.message = JSON.stringify(rawError.outputTooSmall)
       }
-    },
-    OutputTooSmall: {
-      assert: (item: SubmitTxErrorShelley): item is OutputTooSmall =>
-        (item as OutputTooSmall).outputTooSmall !== undefined,
-      Error: class OutputTooSmallError extends CustomError {
-        public constructor (rawError: OutputTooSmall) {
-          super()
-          this.message = JSON.stringify(rawError.outputTooSmall)
-        }
+    }
+  },
+  AddressAttributesTooLarge: {
+    assert: (item: SubmitTxErrorShelley): item is AddressAttributesTooLarge =>
+      (item as AddressAttributesTooLarge).addressAttributesTooLarge !== undefined,
+    Error: class AddressAttributesTooLargeError extends CustomError {
+      public constructor (rawError: AddressAttributesTooLarge) {
+        super()
+        this.message = JSON.stringify(rawError.addressAttributesTooLarge)
       }
-    },
-    AddressAttributesTooLarge: {
-      assert: (item: SubmitTxErrorShelley): item is AddressAttributesTooLarge =>
-        (item as AddressAttributesTooLarge).addressAttributesTooLarge !== undefined,
-      Error: class AddressAttributesTooLargeError extends CustomError {
-        public constructor (rawError: AddressAttributesTooLarge) {
-          super()
-          this.message = JSON.stringify(rawError.addressAttributesTooLarge)
-        }
+    }
+  },
+  DelegateNotRegistered: {
+    assert: (item: SubmitTxErrorShelley): item is DelegateNotRegistered =>
+      (item as DelegateNotRegistered).delegateNotRegistered !== undefined,
+    Error: class DelegateNotRegisteredError extends CustomError {
+      public constructor (rawError: DelegateNotRegistered) {
+        super()
+        this.message = JSON.stringify(rawError.delegateNotRegistered)
       }
-    },
-    DelegateNotRegistered: {
-      assert: (item: SubmitTxErrorShelley): item is DelegateNotRegistered =>
-        (item as DelegateNotRegistered).delegateNotRegistered !== undefined,
-      Error: class DelegateNotRegisteredError extends CustomError {
-        public constructor (rawError: DelegateNotRegistered) {
-          super()
-          this.message = JSON.stringify(rawError.delegateNotRegistered)
-        }
+    }
+  },
+  UnknownOrIncompleteWithdrawals: {
+    assert: (item: SubmitTxErrorShelley): item is UnknownOrIncompleteWithdrawals =>
+      (item as UnknownOrIncompleteWithdrawals).unknownOrIncompleteWithdrawals !== undefined,
+    Error: class UnknownOrIncompleteWithdrawalsError extends CustomError {
+      public constructor (rawError: UnknownOrIncompleteWithdrawals) {
+        super()
+        this.message = JSON.stringify(rawError.unknownOrIncompleteWithdrawals)
       }
-    },
-    UnknownOrIncompleteWithdrawals: {
-      assert: (item: SubmitTxErrorShelley): item is UnknownOrIncompleteWithdrawals =>
-        (item as UnknownOrIncompleteWithdrawals).unknownOrIncompleteWithdrawals !== undefined,
-      Error: class UnknownOrIncompleteWithdrawalsError extends CustomError {
-        public constructor (rawError: UnknownOrIncompleteWithdrawals) {
-          super()
-          this.message = JSON.stringify(rawError.unknownOrIncompleteWithdrawals)
-        }
+    }
+  },
+  StakePoolNotRegistered: {
+    assert: (item: SubmitTxErrorShelley): item is StakePoolNotRegistered =>
+      (item as StakePoolNotRegistered).stakePoolNotRegistered !== undefined,
+    Error: class StakePoolNotRegisteredError extends CustomError {
+      public constructor (rawError: StakePoolNotRegistered) {
+        super()
+        this.message = JSON.stringify(rawError.stakePoolNotRegistered)
       }
-    },
-    StakePoolNotRegistered: {
-      assert: (item: SubmitTxErrorShelley): item is StakePoolNotRegistered =>
-        (item as StakePoolNotRegistered).stakePoolNotRegistered !== undefined,
-      Error: class StakePoolNotRegisteredError extends CustomError {
-        public constructor (rawError: StakePoolNotRegistered) {
-          super()
-          this.message = JSON.stringify(rawError.stakePoolNotRegistered)
-        }
+    }
+  },
+  WrongRetirementEpoch: {
+    assert: (item: SubmitTxErrorShelley): item is WrongRetirementEpoch =>
+      (item as WrongRetirementEpoch).wrongRetirementEpoch !== undefined,
+    Error: class WrongRetirementEpochError extends CustomError {
+      public constructor (rawError: WrongRetirementEpoch) {
+        super()
+        this.message = JSON.stringify(rawError.wrongRetirementEpoch)
       }
-    },
-    WrongRetirementEpoch: {
-      assert: (item: SubmitTxErrorShelley): item is WrongRetirementEpoch =>
-        (item as WrongRetirementEpoch).wrongRetirementEpoch !== undefined,
-      Error: class WrongRetirementEpochError extends CustomError {
-        public constructor (rawError: WrongRetirementEpoch) {
-          super()
-          this.message = JSON.stringify(rawError.wrongRetirementEpoch)
-        }
+    }
+  },
+  WrongPoolCertificate: {
+    assert: (item: SubmitTxErrorShelley): item is WrongPoolCertificate =>
+      (item as WrongPoolCertificate).wrongPoolCertificate !== undefined,
+    Error: class WrongPoolCertificateError extends CustomError {
+      public constructor (rawError: WrongPoolCertificate) {
+        super()
+        this.message = JSON.stringify(rawError.wrongPoolCertificate)
       }
-    },
-    WrongPoolCertificate: {
-      assert: (item: SubmitTxErrorShelley): item is WrongPoolCertificate =>
-        (item as WrongPoolCertificate).wrongPoolCertificate !== undefined,
-      Error: class WrongPoolCertificateError extends CustomError {
-        public constructor (rawError: WrongPoolCertificate) {
-          super()
-          this.message = JSON.stringify(rawError.wrongPoolCertificate)
-        }
+    }
+  },
+  StakeKeyAlreadyRegistered: {
+    assert: (item: SubmitTxErrorShelley): item is StakeKeyAlreadyRegistered =>
+      (item as StakeKeyAlreadyRegistered).stakeKeyAlreadyRegistered !== undefined,
+    Error: class StakeKeyAlreadyRegisteredError extends CustomError {
+      public constructor (rawError: StakeKeyAlreadyRegistered) {
+        super()
+        this.message = JSON.stringify(rawError.stakeKeyAlreadyRegistered)
       }
-    },
-    StakeKeyAlreadyRegistered: {
-      assert: (item: SubmitTxErrorShelley): item is StakeKeyAlreadyRegistered =>
-        (item as StakeKeyAlreadyRegistered).stakeKeyAlreadyRegistered !== undefined,
-      Error: class StakeKeyAlreadyRegisteredError extends CustomError {
-        public constructor (rawError: StakeKeyAlreadyRegistered) {
-          super()
-          this.message = JSON.stringify(rawError.stakeKeyAlreadyRegistered)
-        }
+    }
+  },
+  PoolCostTooSmall: {
+    assert: (item: SubmitTxErrorShelley): item is PoolCostTooSmall =>
+      (item as PoolCostTooSmall).poolCostTooSmall !== undefined,
+    Error: class PoolCostTooSmallError extends CustomError {
+      public constructor (rawError: PoolCostTooSmall) {
+        super()
+        this.message = JSON.stringify(rawError.poolCostTooSmall)
       }
-    },
-    PoolCostTooSmall: {
-      assert: (item: SubmitTxErrorShelley): item is PoolCostTooSmall =>
-        (item as PoolCostTooSmall).poolCostTooSmall !== undefined,
-      Error: class PoolCostTooSmallError extends CustomError {
-        public constructor (rawError: PoolCostTooSmall) {
-          super()
-          this.message = JSON.stringify(rawError.poolCostTooSmall)
-        }
+    }
+  },
+  StakeKeyNotRegistered: {
+    assert: (item: SubmitTxErrorShelley): item is StakeKeyNotRegistered =>
+      (item as StakeKeyNotRegistered).stakeKeyNotRegistered !== undefined,
+    Error: class StakeKeyNotRegisteredError extends CustomError {
+      public constructor (rawError: StakeKeyNotRegistered) {
+        super()
+        this.message = JSON.stringify(rawError.stakeKeyNotRegistered)
       }
-    },
-    StakeKeyNotRegistered: {
-      assert: (item: SubmitTxErrorShelley): item is StakeKeyNotRegistered =>
-        (item as StakeKeyNotRegistered).stakeKeyNotRegistered !== undefined,
-      Error: class StakeKeyNotRegisteredError extends CustomError {
-        public constructor (rawError: StakeKeyNotRegistered) {
-          super()
-          this.message = JSON.stringify(rawError.stakeKeyNotRegistered)
-        }
+    }
+  },
+  RewardAccountNotExisting: {
+    assert: (item: SubmitTxErrorShelley): item is RewardAccountNotExisting =>
+      (item as RewardAccountNotExisting) === 'rewardAccountNotExisting',
+    Error: class RewardAccountNotExistingError extends CustomError {
+      public constructor (rawError: RewardAccountNotExisting) {
+        super()
+        this.message = JSON.stringify(rawError)
       }
-    },
-    RewardAccountNotExisting: {
-      assert: (item: SubmitTxErrorShelley): item is RewardAccountNotExisting =>
-        (item as RewardAccountNotExisting) === 'rewardAccountNotExisting',
-      Error: class RewardAccountNotExistingError extends CustomError {
-        public constructor (rawError: RewardAccountNotExisting) {
-          super()
-          this.message = JSON.stringify(rawError)
-        }
+    }
+  },
+  RewardAccountNotEmpty: {
+    assert: (item: SubmitTxErrorShelley): item is RewardAccountNotEmpty =>
+      (item as RewardAccountNotEmpty).rewardAccountNotEmpty !== undefined,
+    Error: class RewardAccountNotEmptyError extends CustomError {
+      public constructor (rawError: RewardAccountNotEmpty) {
+        super()
+        this.message = JSON.stringify(rawError.rewardAccountNotEmpty)
       }
-    },
-    RewardAccountNotEmpty: {
-      assert: (item: SubmitTxErrorShelley): item is RewardAccountNotEmpty =>
-        (item as RewardAccountNotEmpty).rewardAccountNotEmpty !== undefined,
-      Error: class RewardAccountNotEmptyError extends CustomError {
-        public constructor (rawError: RewardAccountNotEmpty) {
-          super()
-          this.message = JSON.stringify(rawError.rewardAccountNotEmpty)
-        }
+    }
+  },
+  WrongCertificateType: {
+    assert: (item: SubmitTxErrorShelley): item is WrongCertificateType =>
+      (item as WrongCertificateType) === 'wrongCertificateType',
+    Error: class WrongCertificateTypeError extends CustomError {
+      public constructor (rawError: WrongCertificateType) {
+        super()
+        this.message = JSON.stringify(rawError)
       }
-    },
-    WrongCertificateType: {
-      assert: (item: SubmitTxErrorShelley): item is WrongCertificateType =>
-        (item as WrongCertificateType) === 'wrongCertificateType',
-      Error: class WrongCertificateTypeError extends CustomError {
-        public constructor (rawError: WrongCertificateType) {
-          super()
-          this.message = JSON.stringify(rawError)
-        }
+    }
+  },
+  UnknownGenesisKey: {
+    assert: (item: SubmitTxErrorShelley): item is UnknownGenesisKey =>
+      (item as UnknownGenesisKey).unknownGenesisKey !== undefined,
+    Error: class UnknownGenesisKeyError extends CustomError {
+      public constructor (rawError: UnknownGenesisKey) {
+        super()
+        this.message = JSON.stringify(rawError.unknownGenesisKey)
       }
-    },
-    UnknownGenesisKey: {
-      assert: (item: SubmitTxErrorShelley): item is UnknownGenesisKey =>
-        (item as UnknownGenesisKey).unknownGenesisKey !== undefined,
-      Error: class UnknownGenesisKeyError extends CustomError {
-        public constructor (rawError: UnknownGenesisKey) {
-          super()
-          this.message = JSON.stringify(rawError.unknownGenesisKey)
-        }
+    }
+  },
+  AlreadyDelegating: {
+    assert: (item: SubmitTxErrorShelley): item is AlreadyDelegating =>
+      (item as AlreadyDelegating).alreadyDelegating !== undefined,
+    Error: class AlreadyDelegatingError extends CustomError {
+      public constructor (rawError: AlreadyDelegating) {
+        super()
+        this.message = JSON.stringify(rawError.alreadyDelegating)
       }
-    },
-    AlreadyDelegating: {
-      assert: (item: SubmitTxErrorShelley): item is AlreadyDelegating =>
-        (item as AlreadyDelegating).alreadyDelegating !== undefined,
-      Error: class AlreadyDelegatingError extends CustomError {
-        public constructor (rawError: AlreadyDelegating) {
-          super()
-          this.message = JSON.stringify(rawError.alreadyDelegating)
-        }
+    }
+  },
+  InsufficientFundsForMir: {
+    assert: (item: SubmitTxErrorShelley): item is InsufficientFundsForMir =>
+      (item as InsufficientFundsForMir).insufficientFundsForMir !== undefined,
+    Error: class InsufficientFundsForMirError extends CustomError {
+      public constructor (rawError: InsufficientFundsForMir) {
+        super()
+        this.message = JSON.stringify(rawError.insufficientFundsForMir)
       }
-    },
-    InsufficientFundsForMir: {
-      assert: (item: SubmitTxErrorShelley): item is InsufficientFundsForMir =>
-        (item as InsufficientFundsForMir).insufficientFundsForMir !== undefined,
-      Error: class InsufficientFundsForMirError extends CustomError {
-        public constructor (rawError: InsufficientFundsForMir) {
-          super()
-          this.message = JSON.stringify(rawError.insufficientFundsForMir)
-        }
+    }
+  },
+  TooLateForMir: {
+    assert: (item: SubmitTxErrorShelley): item is TooLateForMir =>
+      (item as TooLateForMir).tooLateForMir !== undefined,
+    Error: class TooLateForMirError extends CustomError {
+      public constructor (rawError: TooLateForMir) {
+        super()
+        this.message = JSON.stringify(rawError.tooLateForMir)
       }
-    },
-    TooLateForMir: {
-      assert: (item: SubmitTxErrorShelley): item is TooLateForMir =>
-        (item as TooLateForMir).tooLateForMir !== undefined,
-      Error: class TooLateForMirError extends CustomError {
-        public constructor (rawError: TooLateForMir) {
-          super()
-          this.message = JSON.stringify(rawError.tooLateForMir)
-        }
+    }
+  },
+  MirTransferNotCurrentlyAllowed: {
+    assert: (item: SubmitTxErrorShelley): item is MirTransferNotCurrentlyAllowed =>
+      (item as MirTransferNotCurrentlyAllowed) === 'mirTransferNotCurrentlyAllowed',
+    Error: class MirTransferNotCurrentlyAllowedError extends CustomError {
+      public constructor (rawError: MirTransferNotCurrentlyAllowed) {
+        super()
+        this.message = JSON.stringify(rawError)
       }
-    },
-    MirTransferNotCurrentlyAllowed: {
-      assert: (item: SubmitTxErrorShelley): item is MirTransferNotCurrentlyAllowed =>
-        (item as MirTransferNotCurrentlyAllowed) === 'mirTransferNotCurrentlyAllowed',
-      Error: class MirTransferNotCurrentlyAllowedError extends CustomError {
-        public constructor (rawError: MirTransferNotCurrentlyAllowed) {
-          super()
-          this.message = JSON.stringify(rawError)
-        }
+    }
+  },
+  MirNegativeTransferNotCurrentlyAllowed: {
+    assert: (item: SubmitTxErrorShelley): item is MirNegativeTransferNotCurrentlyAllowed =>
+      (item as MirNegativeTransferNotCurrentlyAllowed) === 'mirNegativeTransferNotCurrentlyAllowed',
+    Error: class MirNegativeTransferNotCurrentlyAllowedError extends CustomError {
+      public constructor (rawError: MirNegativeTransferNotCurrentlyAllowed) {
+        super()
+        this.message = JSON.stringify(rawError)
       }
-    },
-    MirNegativeTransferNotCurrentlyAllowed: {
-      assert: (item: SubmitTxErrorShelley): item is MirNegativeTransferNotCurrentlyAllowed =>
-        (item as MirNegativeTransferNotCurrentlyAllowed) === 'mirNegativeTransferNotCurrentlyAllowed',
-      Error: class MirNegativeTransferNotCurrentlyAllowedError extends CustomError {
-        public constructor (rawError: MirNegativeTransferNotCurrentlyAllowed) {
-          super()
-          this.message = JSON.stringify(rawError)
-        }
+    }
+  },
+  MirProducesNegativeUpdate: {
+    assert: (item: SubmitTxErrorShelley): item is MirProducesNegativeUpdate =>
+      (item as MirProducesNegativeUpdate) === 'mirProducesNegativeUpdate',
+    Error: class MirProducesNegativeUpdateError extends CustomError {
+      public constructor (rawError: MirProducesNegativeUpdate) {
+        super()
+        this.message = JSON.stringify(rawError)
       }
-    },
-    MirProducesNegativeUpdate: {
-      assert: (item: SubmitTxErrorShelley): item is MirProducesNegativeUpdate =>
-        (item as MirProducesNegativeUpdate) === 'mirProducesNegativeUpdate',
-      Error: class MirProducesNegativeUpdateError extends CustomError {
-        public constructor (rawError: MirProducesNegativeUpdate) {
-          super()
-          this.message = JSON.stringify(rawError)
-        }
+    }
+  },
+  DuplicateGenesisVrf: {
+    assert: (item: SubmitTxErrorShelley): item is DuplicateGenesisVrf =>
+      (item as DuplicateGenesisVrf).duplicateGenesisVrf !== undefined,
+    Error: class DuplicateGenesisVrfError extends CustomError {
+      public constructor (rawError: DuplicateGenesisVrf) {
+        super()
+        this.message = JSON.stringify(rawError.duplicateGenesisVrf)
       }
-    },
-    DuplicateGenesisVrf: {
-      assert: (item: SubmitTxErrorShelley): item is DuplicateGenesisVrf =>
-        (item as DuplicateGenesisVrf).duplicateGenesisVrf !== undefined,
-      Error: class DuplicateGenesisVrfError extends CustomError {
-        public constructor (rawError: DuplicateGenesisVrf) {
-          super()
-          this.message = JSON.stringify(rawError.duplicateGenesisVrf)
-        }
+    }
+  },
+  NonGenesisVoters: {
+    assert: (item: SubmitTxErrorShelley): item is NonGenesisVoters =>
+      (item as NonGenesisVoters).nonGenesisVoters !== undefined,
+    Error: class NonGenesisVotersError extends CustomError {
+      public constructor (rawError: NonGenesisVoters) {
+        super()
+        this.message = JSON.stringify(rawError.nonGenesisVoters)
       }
-    },
-    NonGenesisVoters: {
-      assert: (item: SubmitTxErrorShelley): item is NonGenesisVoters =>
-        (item as NonGenesisVoters).nonGenesisVoters !== undefined,
-      Error: class NonGenesisVotersError extends CustomError {
-        public constructor (rawError: NonGenesisVoters) {
-          super()
-          this.message = JSON.stringify(rawError.nonGenesisVoters)
-        }
+    }
+  },
+  UpdateWrongEpoch: {
+    assert: (item: SubmitTxErrorShelley): item is UpdateWrongEpoch =>
+      (item as UpdateWrongEpoch).updateWrongEpoch !== undefined,
+    Error: class UpdateWrongEpochError extends CustomError {
+      public constructor (rawError: UpdateWrongEpoch) {
+        super()
+        this.message = JSON.stringify(rawError.updateWrongEpoch)
       }
-    },
-    UpdateWrongEpoch: {
-      assert: (item: SubmitTxErrorShelley): item is UpdateWrongEpoch =>
-        (item as UpdateWrongEpoch).updateWrongEpoch !== undefined,
-      Error: class UpdateWrongEpochError extends CustomError {
-        public constructor (rawError: UpdateWrongEpoch) {
-          super()
-          this.message = JSON.stringify(rawError.updateWrongEpoch)
-        }
+    }
+  },
+  ProtocolVersionCannotFollow: {
+    assert: (item: SubmitTxErrorShelley): item is ProtocolVersionCannotFollow =>
+      (item as ProtocolVersionCannotFollow).protocolVersionCannotFollow !== undefined,
+    Error: class ProtocolVersionCannotFollowError extends CustomError {
+      public constructor (rawError: ProtocolVersionCannotFollow) {
+        super()
+        this.message = JSON.stringify(rawError.protocolVersionCannotFollow)
       }
-    },
-    ProtocolVersionCannotFollow: {
-      assert: (item: SubmitTxErrorShelley): item is ProtocolVersionCannotFollow =>
-        (item as ProtocolVersionCannotFollow).protocolVersionCannotFollow !== undefined,
-      Error: class ProtocolVersionCannotFollowError extends CustomError {
-        public constructor (rawError: ProtocolVersionCannotFollow) {
-          super()
-          this.message = JSON.stringify(rawError.protocolVersionCannotFollow)
-        }
+    }
+  },
+  OutsideOfValidityInterval: {
+    assert: (item: SubmitTxErrorShelley): item is OutsideOfValidityInterval =>
+      (item as OutsideOfValidityInterval).outsideOfValidityInterval !== undefined,
+    Error: class OutsideOfValidityIntervalError extends CustomError {
+      public constructor (rawError: OutsideOfValidityInterval) {
+        super()
+        this.message = JSON.stringify(rawError.outsideOfValidityInterval)
       }
-    },
-    OutsideOfValidityInterval: {
-      assert: (item: SubmitTxErrorShelley): item is OutsideOfValidityInterval =>
-        (item as OutsideOfValidityInterval).outsideOfValidityInterval !== undefined,
-      Error: class OutsideOfValidityIntervalError extends CustomError {
-        public constructor (rawError: OutsideOfValidityInterval) {
-          super()
-          this.message = JSON.stringify(rawError.outsideOfValidityInterval)
-        }
+    }
+  },
+  TriesToForgeAda: {
+    assert: (item: SubmitTxErrorShelley): item is TriesToForgeAda =>
+      (item as TriesToForgeAda) === 'triesToForgeAda',
+    Error: class TriesToForgeAdaError extends CustomError {
+      public constructor (rawError: TriesToForgeAda) {
+        super()
+        this.message = JSON.stringify(rawError)
       }
-    },
-    TriesToForgeAda: {
-      assert: (item: SubmitTxErrorShelley): item is TriesToForgeAda =>
-        (item as TriesToForgeAda) === 'triesToForgeAda',
-      Error: class TriesToForgeAdaError extends CustomError {
-        public constructor (rawError: TriesToForgeAda) {
-          super()
-          this.message = JSON.stringify(rawError)
-        }
+    }
+  },
+  TooManyAssetsInOutput: {
+    assert: (item: SubmitTxErrorShelley): item is TooManyAssetsInOutput =>
+      (item as TooManyAssetsInOutput).tooManyAssetsInOutput !== undefined,
+    Error: class TooManyAssetsInOutputError extends CustomError {
+      public constructor (rawError: TooManyAssetsInOutput) {
+        super()
+        this.message = JSON.stringify(rawError.tooManyAssetsInOutput)
       }
-    },
-    TooManyAssetsInOutput: {
-      assert: (item: SubmitTxErrorShelley): item is TooManyAssetsInOutput =>
-        (item as TooManyAssetsInOutput).tooManyAssetsInOutput !== undefined,
-      Error: class TooManyAssetsInOutputError extends CustomError {
-        public constructor (rawError: TooManyAssetsInOutput) {
-          super()
-          this.message = JSON.stringify(rawError.tooManyAssetsInOutput)
-        }
+    }
+  },
+  UnredeemableScripts: {
+    assert: (item: SubmitTxErrorShelley): item is UnredeemableScripts =>
+      (item as UnredeemableScripts).unredeemableScripts !== undefined,
+    Error: class UnredeemableScriptsError extends CustomError {
+      public constructor (rawError: UnredeemableScripts) {
+        super()
+        this.message = JSON.stringify(rawError.unredeemableScripts)
       }
-    },
-    UnredeemableScripts: {
-      assert: (item: SubmitTxErrorShelley): item is UnredeemableScripts =>
-        (item as UnredeemableScripts).unredeemableScripts !== undefined,
-      Error: class UnredeemableScriptsError extends CustomError {
-        public constructor (rawError: UnredeemableScripts) {
-          super()
-          this.message = JSON.stringify(rawError.unredeemableScripts)
-        }
+    }
+  },
+  ExtraDataMismatch: {
+    assert: (item: SubmitTxErrorShelley): item is ExtraDataMismatch =>
+      (item as ExtraDataMismatch).extraDataMismatch !== undefined,
+    Error: class ExtraDataMismatchError extends CustomError {
+      public constructor (rawError: ExtraDataMismatch) {
+        super()
+        this.message = JSON.stringify(rawError.extraDataMismatch)
       }
-    },
-    ExtraDataMismatch: {
-      assert: (item: SubmitTxErrorShelley): item is ExtraDataMismatch =>
-        (item as ExtraDataMismatch).extraDataMismatch !== undefined,
-      Error: class ExtraDataMismatchError extends CustomError {
-        public constructor (rawError: ExtraDataMismatch) {
-          super()
-          this.message = JSON.stringify(rawError.extraDataMismatch)
-        }
+    }
+  },
+  MissingRequiredSignatures: {
+    assert: (item: SubmitTxErrorShelley): item is MissingRequiredSignatures =>
+      (item as MissingRequiredSignatures).missingRequiredSignatures !== undefined,
+    Error: class MissingRequiredSignaturesError extends CustomError {
+      public constructor (rawError: MissingRequiredSignatures) {
+        super()
+        this.message = JSON.stringify(rawError.missingRequiredSignatures)
       }
-    },
-    MissingRequiredSignatures: {
-      assert: (item: SubmitTxErrorShelley): item is MissingRequiredSignatures =>
-        (item as MissingRequiredSignatures).missingRequiredSignatures !== undefined,
-      Error: class MissingRequiredSignaturesError extends CustomError {
-        public constructor (rawError: MissingRequiredSignatures) {
-          super()
-          this.message = JSON.stringify(rawError.missingRequiredSignatures)
-        }
+    }
+  },
+  MissingDatumHashesForInputs: {
+    assert: (item: SubmitTxErrorShelley): item is MissingDatumHashesForInputs =>
+      (item as MissingDatumHashesForInputs).missingDatumHashesForInputs !== undefined,
+    Error: class MissingDatumHashesForInputsError extends CustomError {
+      public constructor (rawError: MissingDatumHashesForInputs) {
+        super()
+        this.message = JSON.stringify(rawError.missingDatumHashesForInputs)
       }
-    },
-    MissingDatumHashesForInputs: {
-      assert: (item: SubmitTxErrorShelley): item is MissingDatumHashesForInputs =>
-        (item as MissingDatumHashesForInputs).missingDatumHashesForInputs !== undefined,
-      Error: class MissingDatumHashesForInputsError extends CustomError {
-        public constructor (rawError: MissingDatumHashesForInputs) {
-          super()
-          this.message = JSON.stringify(rawError.missingDatumHashesForInputs)
-        }
+    }
+  },
+  MissingCollateralInputs: {
+    assert: (item: SubmitTxErrorShelley): item is MissingCollateralInputs =>
+      (item as MissingCollateralInputs) === 'missingCollateralInputs',
+    Error: class MissingCollateralInputsError extends CustomError {
+      public constructor (rawError: MissingCollateralInputs) {
+        super()
+        this.message = JSON.stringify(rawError)
       }
-    },
-    MissingCollateralInputs: {
-      assert: (item: SubmitTxErrorShelley): item is MissingCollateralInputs =>
-        (item as MissingCollateralInputs) === 'missingCollateralInputs',
-      Error: class MissingCollateralInputsError extends CustomError {
-        public constructor (rawError: MissingCollateralInputs) {
-          super()
-          this.message = JSON.stringify(rawError)
-        }
+    }
+  },
+  CollateralTooSmall: {
+    assert: (item: SubmitTxErrorShelley): item is CollateralTooSmall =>
+      (item as CollateralTooSmall).collateralTooSmall !== undefined,
+    Error: class CollateralTooSmallError extends CustomError {
+      public constructor (rawError: CollateralTooSmall) {
+        super()
+        this.message = JSON.stringify(rawError.collateralTooSmall)
       }
-    },
-    CollateralTooSmall: {
-      assert: (item: SubmitTxErrorShelley): item is CollateralTooSmall =>
-        (item as CollateralTooSmall).collateralTooSmall !== undefined,
-      Error: class CollateralTooSmallError extends CustomError {
-        public constructor (rawError: CollateralTooSmall) {
-          super()
-          this.message = JSON.stringify(rawError.collateralTooSmall)
-        }
+    }
+  },
+  CollateralIsScript: {
+    assert: (item: SubmitTxErrorShelley): item is CollateralIsScript =>
+      (item as CollateralIsScript).collateralIsScript !== undefined,
+    Error: class CollateralIsScriptError extends CustomError {
+      public constructor (rawError: CollateralIsScript) {
+        super()
+        this.message = JSON.stringify(rawError.collateralIsScript)
       }
-    },
-    CollateralIsScript: {
-      assert: (item: SubmitTxErrorShelley): item is CollateralIsScript =>
-        (item as CollateralIsScript).collateralIsScript !== undefined,
-      Error: class CollateralIsScriptError extends CustomError {
-        public constructor (rawError: CollateralIsScript) {
-          super()
-          this.message = JSON.stringify(rawError.collateralIsScript)
-        }
+    }
+  },
+  CollateralHasNonAdaAssets: {
+    assert: (item: SubmitTxErrorShelley): item is CollateralHasNonAdaAssets =>
+      (item as CollateralHasNonAdaAssets).collateralHasNonAdaAssets !== undefined,
+    Error: class CollateralHasNonAdaAssetsError extends CustomError {
+      public constructor (rawError: CollateralHasNonAdaAssets) {
+        super()
+        this.message = JSON.stringify(rawError.collateralHasNonAdaAssets)
       }
-    },
-    CollateralHasNonAdaAssets: {
-      assert: (item: SubmitTxErrorShelley): item is CollateralHasNonAdaAssets =>
-        (item as CollateralHasNonAdaAssets).collateralHasNonAdaAssets !== undefined,
-      Error: class CollateralHasNonAdaAssetsError extends CustomError {
-        public constructor (rawError: CollateralHasNonAdaAssets) {
-          super()
-          this.message = JSON.stringify(rawError.collateralHasNonAdaAssets)
-        }
+    }
+  },
+  TooManyCollateralInputs: {
+    assert: (item: SubmitTxErrorShelley): item is TooManyCollateralInputs =>
+      (item as TooManyCollateralInputs).tooManyCollateralInputs !== undefined,
+    Error: class TooManyCollateralInputsError extends CustomError {
+      public constructor (rawError: TooManyCollateralInputs) {
+        super()
+        this.message = JSON.stringify(rawError.tooManyCollateralInputs)
       }
-    },
-    TooManyCollateralInputs: {
-      assert: (item: SubmitTxErrorShelley): item is TooManyCollateralInputs =>
-        (item as TooManyCollateralInputs).tooManyCollateralInputs !== undefined,
-      Error: class TooManyCollateralInputsError extends CustomError {
-        public constructor (rawError: TooManyCollateralInputs) {
-          super()
-          this.message = JSON.stringify(rawError.tooManyCollateralInputs)
-        }
+    }
+  },
+  ExecutionUnitsTooLarge: {
+    assert: (item: SubmitTxErrorShelley): item is ExecutionUnitsTooLarge =>
+      (item as ExecutionUnitsTooLarge).executionUnitsTooLarge !== undefined,
+    Error: class ExecutionUnitsTooLargeError extends CustomError {
+      public constructor (rawError: ExecutionUnitsTooLarge) {
+        super()
+        this.message = JSON.stringify(rawError.executionUnitsTooLarge)
       }
-    },
-    ExecutionUnitsTooLarge: {
-      assert: (item: SubmitTxErrorShelley): item is ExecutionUnitsTooLarge =>
-        (item as ExecutionUnitsTooLarge).executionUnitsTooLarge !== undefined,
-      Error: class ExecutionUnitsTooLargeError extends CustomError {
-        public constructor (rawError: ExecutionUnitsTooLarge) {
-          super()
-          this.message = JSON.stringify(rawError.executionUnitsTooLarge)
-        }
+    }
+  },
+  OutsideForecast: {
+    assert: (item: SubmitTxErrorShelley): item is OutsideForecast =>
+      (item as OutsideForecast).outsideForecast !== undefined,
+    Error: class OutsideForecastError extends CustomError {
+      public constructor (rawError: OutsideForecast) {
+        super()
+        this.message = JSON.stringify(rawError.outsideForecast)
       }
-    },
-    OutsideForecast: {
-      assert: (item: SubmitTxErrorShelley): item is OutsideForecast =>
-        (item as OutsideForecast).outsideForecast !== undefined,
-      Error: class OutsideForecastError extends CustomError {
-        public constructor (rawError: OutsideForecast) {
-          super()
-          this.message = JSON.stringify(rawError.outsideForecast)
-        }
+    }
+  },
+  ValidationTagMismatch: {
+    assert: (item: SubmitTxErrorShelley): item is ValidationTagMismatch =>
+      (item as ValidationTagMismatch) === 'validationTagMismatch',
+    Error: class ValidationTagMismatchError extends CustomError {
+      public constructor (rawError: ValidationTagMismatch) {
+        super()
+        this.message = JSON.stringify(rawError)
       }
-    },
-    ValidationTagMismatch: {
-      assert: (item: SubmitTxErrorShelley): item is ValidationTagMismatch =>
-        (item as ValidationTagMismatch) === 'validationTagMismatch',
-      Error: class ValidationTagMismatchError extends CustomError {
-        public constructor (rawError: ValidationTagMismatch) {
-          super()
-          this.message = JSON.stringify(rawError)
-        }
+    }
+  },
+  CollectErrors: {
+    assert: (item: SubmitTxErrorShelley): item is CollectErrors =>
+      (item as CollectErrors).collectErrors !== undefined,
+    Error: class CollectErrorsError extends CustomError {
+      public constructor (rawError: CollectErrors) {
+        super()
+        this.message = JSON.stringify(rawError.collectErrors)
       }
-    },
-    CollectErrors: {
-      assert: (item: SubmitTxErrorShelley): item is CollectErrors =>
-        (item as CollectErrors).collectErrors !== undefined,
-      Error: class CollectErrorsError extends CustomError {
-        public constructor (rawError: CollectErrors) {
-          super()
-          this.message = JSON.stringify(rawError.collectErrors)
-        }
+    }
+  },
+  PoolMetadataHashTooBig: {
+    assert: (item: SubmitTxErrorShelley): item is PoolMetadataHashTooBig =>
+      (item as PoolMetadataHashTooBig).poolMetadataHashTooBig !== undefined,
+    Error: class PoolMetadataHashTooBigError extends CustomError {
+      public constructor (rawError: PoolMetadataHashTooBig) {
+        super()
+        this.message = JSON.stringify(rawError.poolMetadataHashTooBig)
       }
-    },
-    PoolMetadataHashTooBig: {
-      assert: (item: SubmitTxErrorShelley): item is PoolMetadataHashTooBig =>
-        (item as PoolMetadataHashTooBig).poolMetadataHashTooBig !== undefined,
-      Error: class PoolMetadataHashTooBigError extends CustomError {
-        public constructor (rawError: PoolMetadataHashTooBig) {
-          super()
-          this.message = JSON.stringify(rawError.poolMetadataHashTooBig)
-        }
+    }
+  },
+  MissingRequiredDatums: {
+    assert: (item: SubmitTxErrorShelley): item is MissingRequiredDatums =>
+      (item as MissingRequiredDatums).missingRequiredDatums !== undefined,
+    Error: class MissingRequiredDatumsError extends CustomError {
+      public constructor (rawError: MissingRequiredDatums) {
+        super()
+        this.message = JSON.stringify(rawError.missingRequiredDatums)
       }
-    },
-    MissingRequiredDatums: {
-      assert: (item: SubmitTxErrorShelley): item is MissingRequiredDatums =>
-        (item as MissingRequiredDatums).missingRequiredDatums !== undefined,
-      Error: class MissingRequiredDatumsError extends CustomError {
-        public constructor (rawError: MissingRequiredDatums) {
-          super()
-          this.message = JSON.stringify(rawError.missingRequiredDatums)
-        }
+    }
+  },
+  UnspendableDatums: {
+    assert: (item: SubmitTxErrorShelley): item is UnspendableDatums =>
+      (item as UnspendableDatums).unspendableDatums !== undefined,
+    Error: class UnspendableDatumsError extends CustomError {
+      public constructor (rawError: UnspendableDatums) {
+        super()
+        this.message = JSON.stringify(rawError.unspendableDatums)
       }
-    },
-    UnspendableDatums: {
-      assert: (item: SubmitTxErrorShelley): item is UnspendableDatums =>
-        (item as UnspendableDatums).unspendableDatums !== undefined,
-      Error: class UnspendableDatumsError extends CustomError {
-        public constructor (rawError: UnspendableDatums) {
-          super()
-          this.message = JSON.stringify(rawError.unspendableDatums)
-        }
-      }
-    },
-    UnspendableScriptInputs: {
-      assert: (item: SubmitTxErrorShelley): item is UnspendableScriptInputs =>
-        (item as UnspendableScriptInputs).unspendableScriptInputs !== undefined,
-      Error: class UnspendableScriptInputsError extends CustomError {
-        public constructor (rawError: UnspendableScriptInputs) {
-          super()
-          this.message = JSON.stringify(rawError.unspendableScriptInputs)
-        }
+    }
+  },
+  UnspendableScriptInputs: {
+    assert: (item: SubmitTxErrorShelley): item is UnspendableScriptInputs =>
+      (item as UnspendableScriptInputs).unspendableScriptInputs !== undefined,
+    Error: class UnspendableScriptInputsError extends CustomError {
+      public constructor (rawError: UnspendableScriptInputs) {
+        super()
+        this.message = JSON.stringify(rawError.unspendableScriptInputs)
       }
     }
   }

--- a/clients/TypeScript/packages/client/src/TxSubmission/submitTx.ts
+++ b/clients/TypeScript/packages/client/src/TxSubmission/submitTx.ts
@@ -120,8 +120,6 @@ export const submitTx = (bytes: string, config?: ConnectionConfig | InteractionC
                 return new errors.shelley.TooManyAssetsInOutput.Error(failure)
               } else if (errors.shelley.UnredeemableScripts.assert(failure)) {
                 return new errors.shelley.UnredeemableScripts.Error(failure)
-              } else if (errors.shelley.DatumsMismatch.assert(failure)) {
-                return new errors.shelley.DatumsMismatch.Error(failure)
               } else if (errors.shelley.ExtraDataMismatch.assert(failure)) {
                 return new errors.shelley.ExtraDataMismatch.Error(failure)
               } else if (errors.shelley.MissingRequiredSignatures.assert(failure)) {
@@ -146,6 +144,14 @@ export const submitTx = (bytes: string, config?: ConnectionConfig | InteractionC
                 return new errors.shelley.ValidationTagMismatch.Error(failure)
               } else if (errors.shelley.CollectErrors.assert(failure)) {
                 return new errors.shelley.CollectErrors.Error(failure)
+              } else if (errors.shelley.PoolMetadataHashTooBig.assert(failure)) {
+                return new errors.shelley.PoolMetadataHashTooBig.Error(failure)
+              } else if (errors.shelley.MissingRequiredDatums.assert(failure)) {
+                return new errors.shelley.MissingRequiredDatums.Error(failure)
+              } else if (errors.shelley.UnspendableDatums.assert(failure)) {
+                return new errors.shelley.UnspendableDatums.Error(failure)
+              } else if (errors.shelley.UnspendableScriptInputs.assert(failure)) {
+                return new errors.shelley.UnspendableScriptInputs.Error(failure)
               } else {
                 return new Error(failure)
               }

--- a/clients/TypeScript/packages/client/src/TxSubmission/submitTx.ts
+++ b/clients/TypeScript/packages/client/src/TxSubmission/submitTx.ts
@@ -26,132 +26,128 @@ export const submitTx = (bytes: string, config?: ConnectionConfig | InteractionC
           if (isEraMismatch(SubmitFail)) {
             const { eraMismatch } = SubmitFail
             return reject(new EraMismatchError(eraMismatch.queryEra, eraMismatch.ledgerEra))
-          } else if (errors.byron.UtxoValidation.assert(SubmitFail)) {
-            return reject(new errors.byron.UtxoValidation.Error(SubmitFail))
-          } else if (errors.byron.TxValidation.assert(SubmitFail)) {
-            return reject(new errors.byron.TxValidation.Error(SubmitFail))
           } else if (Array.isArray(SubmitFail)) {
             reject(SubmitFail.map(failure => {
-              if (errors.shelley.InvalidWitnesses.assert(failure)) {
-                return new errors.shelley.InvalidWitnesses.Error(failure)
-              } else if (errors.shelley.MissingVkWitnesses.assert(failure)) {
-                return new errors.shelley.MissingVkWitnesses.Error(failure)
-              } else if (errors.shelley.MissingScriptWitnesses.assert(failure)) {
-                return new errors.shelley.MissingScriptWitnesses.Error(failure)
-              } else if (errors.shelley.ScriptWitnessNotValidating.assert(failure)) {
-                return new errors.shelley.ScriptWitnessNotValidating.Error(failure)
-              } else if (errors.shelley.InsufficientGenesisSignatures.assert(failure)) {
-                return new errors.shelley.InsufficientGenesisSignatures.Error(failure)
-              } else if (errors.shelley.MissingTxMetadata.assert(failure)) {
-                return new errors.shelley.MissingTxMetadata.Error(failure)
-              } else if (errors.shelley.MissingTxMetadataHash.assert(failure)) {
-                return new errors.shelley.MissingTxMetadataHash.Error(failure)
-              } else if (errors.shelley.TxMetadataHashMismatch.assert(failure)) {
-                return new errors.shelley.TxMetadataHashMismatch.Error(failure)
-              } else if (errors.shelley.BadInputs.assert(failure)) {
-                return new errors.shelley.BadInputs.Error(failure)
-              } else if (errors.shelley.ExpiredUtxo.assert(failure)) {
-                return new errors.shelley.ExpiredUtxo.Error(failure)
-              } else if (errors.shelley.TxTooLarge.assert(failure)) {
-                return new errors.shelley.TxTooLarge.Error(failure)
-              } else if (errors.shelley.MissingAtLeastOneInputUtxo.assert(failure)) {
-                return new errors.shelley.MissingAtLeastOneInputUtxo.Error(failure)
-              } else if (errors.shelley.InvalidMetadata.assert(failure)) {
-                return new errors.shelley.InvalidMetadata.Error(failure)
-              } else if (errors.shelley.FeeTooSmall.assert(failure)) {
-                return new errors.shelley.FeeTooSmall.Error(failure)
-              } else if (errors.shelley.ValueNotConserved.assert(failure)) {
-                return new errors.shelley.ValueNotConserved.Error(failure)
-              } else if (errors.shelley.NetworkMismatch.assert(failure)) {
-                return new errors.shelley.NetworkMismatch.Error(failure)
-              } else if (errors.shelley.OutputTooSmall.assert(failure)) {
-                return new errors.shelley.OutputTooSmall.Error(failure)
-              } else if (errors.shelley.AddressAttributesTooLarge.assert(failure)) {
-                return new errors.shelley.AddressAttributesTooLarge.Error(failure)
-              } else if (errors.shelley.DelegateNotRegistered.assert(failure)) {
-                return new errors.shelley.DelegateNotRegistered.Error(failure)
-              } else if (errors.shelley.UnknownOrIncompleteWithdrawals.assert(failure)) {
-                return new errors.shelley.UnknownOrIncompleteWithdrawals.Error(failure)
-              } else if (errors.shelley.StakePoolNotRegistered.assert(failure)) {
-                return new errors.shelley.StakePoolNotRegistered.Error(failure)
-              } else if (errors.shelley.WrongRetirementEpoch.assert(failure)) {
-                return new errors.shelley.WrongRetirementEpoch.Error(failure)
-              } else if (errors.shelley.WrongPoolCertificate.assert(failure)) {
-                return new errors.shelley.WrongPoolCertificate.Error(failure)
-              } else if (errors.shelley.StakeKeyAlreadyRegistered.assert(failure)) {
-                return new errors.shelley.StakeKeyAlreadyRegistered.Error(failure)
-              } else if (errors.shelley.PoolCostTooSmall.assert(failure)) {
-                return new errors.shelley.PoolCostTooSmall.Error(failure)
-              } else if (errors.shelley.StakeKeyNotRegistered.assert(failure)) {
-                return new errors.shelley.StakeKeyNotRegistered.Error(failure)
-              } else if (errors.shelley.RewardAccountNotExisting.assert(failure)) {
-                return new errors.shelley.RewardAccountNotExisting.Error(failure)
-              } else if (errors.shelley.RewardAccountNotEmpty.assert(failure)) {
-                return new errors.shelley.RewardAccountNotEmpty.Error(failure)
-              } else if (errors.shelley.WrongCertificateType.assert(failure)) {
-                return new errors.shelley.WrongCertificateType.Error(failure)
-              } else if (errors.shelley.UnknownGenesisKey.assert(failure)) {
-                return new errors.shelley.UnknownGenesisKey.Error(failure)
-              } else if (errors.shelley.AlreadyDelegating.assert(failure)) {
-                return new errors.shelley.AlreadyDelegating.Error(failure)
-              } else if (errors.shelley.InsufficientFundsForMir.assert(failure)) {
-                return new errors.shelley.InsufficientFundsForMir.Error(failure)
-              } else if (errors.shelley.TooLateForMir.assert(failure)) {
-                return new errors.shelley.TooLateForMir.Error(failure)
-              } else if (errors.shelley.MirTransferNotCurrentlyAllowed.assert(failure)) {
-                return new errors.shelley.MirTransferNotCurrentlyAllowed.Error(failure)
-              } else if (errors.shelley.MirNegativeTransferNotCurrentlyAllowed.assert(failure)) {
-                return new errors.shelley.MirNegativeTransferNotCurrentlyAllowed.Error(failure)
-              } else if (errors.shelley.MirProducesNegativeUpdate.assert(failure)) {
-                return new errors.shelley.MirProducesNegativeUpdate.Error(failure)
-              } else if (errors.shelley.DuplicateGenesisVrf.assert(failure)) {
-                return new errors.shelley.DuplicateGenesisVrf.Error(failure)
-              } else if (errors.shelley.NonGenesisVoters.assert(failure)) {
-                return new errors.shelley.NonGenesisVoters.Error(failure)
-              } else if (errors.shelley.UpdateWrongEpoch.assert(failure)) {
-                return new errors.shelley.UpdateWrongEpoch.Error(failure)
-              } else if (errors.shelley.ProtocolVersionCannotFollow.assert(failure)) {
-                return new errors.shelley.ProtocolVersionCannotFollow.Error(failure)
-              } else if (errors.shelley.OutsideOfValidityInterval.assert(failure)) {
-                return new errors.shelley.OutsideOfValidityInterval.Error(failure)
-              } else if (errors.shelley.TriesToForgeAda.assert(failure)) {
-                return new errors.shelley.TriesToForgeAda.Error(failure)
-              } else if (errors.shelley.TooManyAssetsInOutput.assert(failure)) {
-                return new errors.shelley.TooManyAssetsInOutput.Error(failure)
-              } else if (errors.shelley.UnredeemableScripts.assert(failure)) {
-                return new errors.shelley.UnredeemableScripts.Error(failure)
-              } else if (errors.shelley.ExtraDataMismatch.assert(failure)) {
-                return new errors.shelley.ExtraDataMismatch.Error(failure)
-              } else if (errors.shelley.MissingRequiredSignatures.assert(failure)) {
-                return new errors.shelley.MissingRequiredSignatures.Error(failure)
-              } else if (errors.shelley.MissingDatumHashesForInputs.assert(failure)) {
-                return new errors.shelley.MissingDatumHashesForInputs.Error(failure)
-              } else if (errors.shelley.MissingCollateralInputs.assert(failure)) {
-                return new errors.shelley.MissingCollateralInputs.Error(failure)
-              } else if (errors.shelley.CollateralTooSmall.assert(failure)) {
-                return new errors.shelley.CollateralTooSmall.Error(failure)
-              } else if (errors.shelley.CollateralIsScript.assert(failure)) {
-                return new errors.shelley.CollateralIsScript.Error(failure)
-              } else if (errors.shelley.CollateralHasNonAdaAssets.assert(failure)) {
-                return new errors.shelley.CollateralHasNonAdaAssets.Error(failure)
-              } else if (errors.shelley.TooManyCollateralInputs.assert(failure)) {
-                return new errors.shelley.TooManyCollateralInputs.Error(failure)
-              } else if (errors.shelley.ExecutionUnitsTooLarge.assert(failure)) {
-                return new errors.shelley.ExecutionUnitsTooLarge.Error(failure)
-              } else if (errors.shelley.OutsideForecast.assert(failure)) {
-                return new errors.shelley.OutsideForecast.Error(failure)
-              } else if (errors.shelley.ValidationTagMismatch.assert(failure)) {
-                return new errors.shelley.ValidationTagMismatch.Error(failure)
-              } else if (errors.shelley.CollectErrors.assert(failure)) {
-                return new errors.shelley.CollectErrors.Error(failure)
-              } else if (errors.shelley.PoolMetadataHashTooBig.assert(failure)) {
-                return new errors.shelley.PoolMetadataHashTooBig.Error(failure)
-              } else if (errors.shelley.MissingRequiredDatums.assert(failure)) {
-                return new errors.shelley.MissingRequiredDatums.Error(failure)
-              } else if (errors.shelley.UnspendableDatums.assert(failure)) {
-                return new errors.shelley.UnspendableDatums.Error(failure)
-              } else if (errors.shelley.UnspendableScriptInputs.assert(failure)) {
-                return new errors.shelley.UnspendableScriptInputs.Error(failure)
+              if (errors.InvalidWitnesses.assert(failure)) {
+                return new errors.InvalidWitnesses.Error(failure)
+              } else if (errors.MissingVkWitnesses.assert(failure)) {
+                return new errors.MissingVkWitnesses.Error(failure)
+              } else if (errors.MissingScriptWitnesses.assert(failure)) {
+                return new errors.MissingScriptWitnesses.Error(failure)
+              } else if (errors.ScriptWitnessNotValidating.assert(failure)) {
+                return new errors.ScriptWitnessNotValidating.Error(failure)
+              } else if (errors.InsufficientGenesisSignatures.assert(failure)) {
+                return new errors.InsufficientGenesisSignatures.Error(failure)
+              } else if (errors.MissingTxMetadata.assert(failure)) {
+                return new errors.MissingTxMetadata.Error(failure)
+              } else if (errors.MissingTxMetadataHash.assert(failure)) {
+                return new errors.MissingTxMetadataHash.Error(failure)
+              } else if (errors.TxMetadataHashMismatch.assert(failure)) {
+                return new errors.TxMetadataHashMismatch.Error(failure)
+              } else if (errors.BadInputs.assert(failure)) {
+                return new errors.BadInputs.Error(failure)
+              } else if (errors.ExpiredUtxo.assert(failure)) {
+                return new errors.ExpiredUtxo.Error(failure)
+              } else if (errors.TxTooLarge.assert(failure)) {
+                return new errors.TxTooLarge.Error(failure)
+              } else if (errors.MissingAtLeastOneInputUtxo.assert(failure)) {
+                return new errors.MissingAtLeastOneInputUtxo.Error(failure)
+              } else if (errors.InvalidMetadata.assert(failure)) {
+                return new errors.InvalidMetadata.Error(failure)
+              } else if (errors.FeeTooSmall.assert(failure)) {
+                return new errors.FeeTooSmall.Error(failure)
+              } else if (errors.ValueNotConserved.assert(failure)) {
+                return new errors.ValueNotConserved.Error(failure)
+              } else if (errors.NetworkMismatch.assert(failure)) {
+                return new errors.NetworkMismatch.Error(failure)
+              } else if (errors.OutputTooSmall.assert(failure)) {
+                return new errors.OutputTooSmall.Error(failure)
+              } else if (errors.AddressAttributesTooLarge.assert(failure)) {
+                return new errors.AddressAttributesTooLarge.Error(failure)
+              } else if (errors.DelegateNotRegistered.assert(failure)) {
+                return new errors.DelegateNotRegistered.Error(failure)
+              } else if (errors.UnknownOrIncompleteWithdrawals.assert(failure)) {
+                return new errors.UnknownOrIncompleteWithdrawals.Error(failure)
+              } else if (errors.StakePoolNotRegistered.assert(failure)) {
+                return new errors.StakePoolNotRegistered.Error(failure)
+              } else if (errors.WrongRetirementEpoch.assert(failure)) {
+                return new errors.WrongRetirementEpoch.Error(failure)
+              } else if (errors.WrongPoolCertificate.assert(failure)) {
+                return new errors.WrongPoolCertificate.Error(failure)
+              } else if (errors.StakeKeyAlreadyRegistered.assert(failure)) {
+                return new errors.StakeKeyAlreadyRegistered.Error(failure)
+              } else if (errors.PoolCostTooSmall.assert(failure)) {
+                return new errors.PoolCostTooSmall.Error(failure)
+              } else if (errors.StakeKeyNotRegistered.assert(failure)) {
+                return new errors.StakeKeyNotRegistered.Error(failure)
+              } else if (errors.RewardAccountNotExisting.assert(failure)) {
+                return new errors.RewardAccountNotExisting.Error(failure)
+              } else if (errors.RewardAccountNotEmpty.assert(failure)) {
+                return new errors.RewardAccountNotEmpty.Error(failure)
+              } else if (errors.WrongCertificateType.assert(failure)) {
+                return new errors.WrongCertificateType.Error(failure)
+              } else if (errors.UnknownGenesisKey.assert(failure)) {
+                return new errors.UnknownGenesisKey.Error(failure)
+              } else if (errors.AlreadyDelegating.assert(failure)) {
+                return new errors.AlreadyDelegating.Error(failure)
+              } else if (errors.InsufficientFundsForMir.assert(failure)) {
+                return new errors.InsufficientFundsForMir.Error(failure)
+              } else if (errors.TooLateForMir.assert(failure)) {
+                return new errors.TooLateForMir.Error(failure)
+              } else if (errors.MirTransferNotCurrentlyAllowed.assert(failure)) {
+                return new errors.MirTransferNotCurrentlyAllowed.Error(failure)
+              } else if (errors.MirNegativeTransferNotCurrentlyAllowed.assert(failure)) {
+                return new errors.MirNegativeTransferNotCurrentlyAllowed.Error(failure)
+              } else if (errors.MirProducesNegativeUpdate.assert(failure)) {
+                return new errors.MirProducesNegativeUpdate.Error(failure)
+              } else if (errors.DuplicateGenesisVrf.assert(failure)) {
+                return new errors.DuplicateGenesisVrf.Error(failure)
+              } else if (errors.NonGenesisVoters.assert(failure)) {
+                return new errors.NonGenesisVoters.Error(failure)
+              } else if (errors.UpdateWrongEpoch.assert(failure)) {
+                return new errors.UpdateWrongEpoch.Error(failure)
+              } else if (errors.ProtocolVersionCannotFollow.assert(failure)) {
+                return new errors.ProtocolVersionCannotFollow.Error(failure)
+              } else if (errors.OutsideOfValidityInterval.assert(failure)) {
+                return new errors.OutsideOfValidityInterval.Error(failure)
+              } else if (errors.TriesToForgeAda.assert(failure)) {
+                return new errors.TriesToForgeAda.Error(failure)
+              } else if (errors.TooManyAssetsInOutput.assert(failure)) {
+                return new errors.TooManyAssetsInOutput.Error(failure)
+              } else if (errors.UnredeemableScripts.assert(failure)) {
+                return new errors.UnredeemableScripts.Error(failure)
+              } else if (errors.ExtraDataMismatch.assert(failure)) {
+                return new errors.ExtraDataMismatch.Error(failure)
+              } else if (errors.MissingRequiredSignatures.assert(failure)) {
+                return new errors.MissingRequiredSignatures.Error(failure)
+              } else if (errors.MissingDatumHashesForInputs.assert(failure)) {
+                return new errors.MissingDatumHashesForInputs.Error(failure)
+              } else if (errors.MissingCollateralInputs.assert(failure)) {
+                return new errors.MissingCollateralInputs.Error(failure)
+              } else if (errors.CollateralTooSmall.assert(failure)) {
+                return new errors.CollateralTooSmall.Error(failure)
+              } else if (errors.CollateralIsScript.assert(failure)) {
+                return new errors.CollateralIsScript.Error(failure)
+              } else if (errors.CollateralHasNonAdaAssets.assert(failure)) {
+                return new errors.CollateralHasNonAdaAssets.Error(failure)
+              } else if (errors.TooManyCollateralInputs.assert(failure)) {
+                return new errors.TooManyCollateralInputs.Error(failure)
+              } else if (errors.ExecutionUnitsTooLarge.assert(failure)) {
+                return new errors.ExecutionUnitsTooLarge.Error(failure)
+              } else if (errors.OutsideForecast.assert(failure)) {
+                return new errors.OutsideForecast.Error(failure)
+              } else if (errors.ValidationTagMismatch.assert(failure)) {
+                return new errors.ValidationTagMismatch.Error(failure)
+              } else if (errors.CollectErrors.assert(failure)) {
+                return new errors.CollectErrors.Error(failure)
+              } else if (errors.PoolMetadataHashTooBig.assert(failure)) {
+                return new errors.PoolMetadataHashTooBig.Error(failure)
+              } else if (errors.MissingRequiredDatums.assert(failure)) {
+                return new errors.MissingRequiredDatums.Error(failure)
+              } else if (errors.UnspendableDatums.assert(failure)) {
+                return new errors.UnspendableDatums.Error(failure)
+              } else if (errors.UnspendableScriptInputs.assert(failure)) {
+                return new errors.UnspendableScriptInputs.Error(failure)
               } else {
                 return new Error(failure)
               }

--- a/clients/TypeScript/packages/client/src/errors/IntersectionNotFoundError.ts
+++ b/clients/TypeScript/packages/client/src/errors/IntersectionNotFoundError.ts
@@ -1,8 +1,8 @@
 import { CustomError } from 'ts-custom-error'
-import { Point } from '@cardano-ogmios/schema'
+import { PointOrOrigin } from '@cardano-ogmios/schema'
 
 export class IntersectionNotFoundError extends CustomError {
-  public constructor (points: Point | Point[]) {
+  public constructor (points: PointOrOrigin | PointOrOrigin[]) {
     super()
     this.message = `Intersection with points ${JSON.stringify(points)} not found`
   }

--- a/clients/TypeScript/packages/client/test/ChainSync.test.ts
+++ b/clients/TypeScript/packages/client/test/ChainSync.test.ts
@@ -10,7 +10,7 @@ import {
   BlockMary,
   BlockShelley,
   Hash16,
-  Point
+  PointOrOrigin
 } from '@cardano-ogmios/schema'
 import { expectContextFromConnectionConfig } from './util'
 
@@ -109,7 +109,7 @@ describe('ChainSync', () => {
     })
 
     it('requires message handlers to process roll back and roll forward messages, invoking the requestNext callback once ready for next message', async () => {
-      const rollbackPoints: Point[] = []
+      const rollbackPoints: PointOrOrigin[] = []
       const blocks: Block[] = []
       const client = await createChainSyncClient({
         rollBackward: async ({ point }, requestNext) => {

--- a/clients/TypeScript/packages/client/test/TxSubmission.test.ts
+++ b/clients/TypeScript/packages/client/test/TxSubmission.test.ts
@@ -68,11 +68,11 @@ describe('TxSubmission', () => {
         await expect(error).toHaveLength(2)
         // NOTE: We can't predict in which order will the server return the errors.
         try {
-          await expect(error[0]).toBeInstanceOf(errors.shelley.BadInputs.Error)
-          await expect(error[1]).toBeInstanceOf(errors.shelley.ValueNotConserved.Error)
+          await expect(error[0]).toBeInstanceOf(errors.BadInputs.Error)
+          await expect(error[1]).toBeInstanceOf(errors.ValueNotConserved.Error)
         } catch (e) {
-          await expect(error[1]).toBeInstanceOf(errors.shelley.BadInputs.Error)
-          await expect(error[0]).toBeInstanceOf(errors.shelley.ValueNotConserved.Error)
+          await expect(error[1]).toBeInstanceOf(errors.BadInputs.Error)
+          await expect(error[0]).toBeInstanceOf(errors.ValueNotConserved.Error)
         }
       }
     })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:1.27.0
+    image: inputoutput/cardano-node:1.28.0
     command: [
       "run",
       "--config", "/config/config.json",

--- a/docs/static/ogmios.wsp.json
+++ b/docs/static/ogmios.wsp.json
@@ -89,7 +89,7 @@
                 , "required": [ "tip", "block" ]
                 , "properties":
                   { "block": { "$ref": "#/definitions/Block" }
-                  , "tip": { "$ref": "#/definitions/Tip" }
+                  , "tip": { "$ref": "#/definitions/TipOrOrigin" }
                   }
                 }
               }
@@ -103,8 +103,8 @@
                 , "additionalProperties": false
                 , "required": [ "tip", "point" ]
                 , "properties":
-                  { "point": { "$ref": "#/definitions/Point" }
-                  , "tip": { "$ref": "#/definitions/Tip" }
+                  { "point": { "$ref": "#/definitions/PointOrOrigin" }
+                  , "tip": { "$ref": "#/definitions/TipOrOrigin" }
                   }
                 }
               }
@@ -141,10 +141,11 @@
         }
       , "args":
         { "type": "object"
+        , "additionalProperties": false
         , "properties":
           { "points":
             { "type": "array"
-            , "items": { "$ref": "#/definitions/Point" }
+            , "items": { "$ref": "#/definitions/PointOrOrigin" }
             }
           }
         }
@@ -188,8 +189,8 @@
                 , "additionalProperties": false
                 , "required": [ "point", "tip" ]
                 , "properties":
-                  { "point": { "$ref": "#/definitions/Point" }
-                  , "tip": { "$ref": "#/definitions/Tip" }
+                  { "point": { "$ref": "#/definitions/PointOrOrigin" }
+                  , "tip": { "$ref": "#/definitions/TipOrOrigin" }
                   }
                 }
               }
@@ -204,7 +205,7 @@
                 , "additionalProperties": false
                 , "required": [ "tip" ]
                 , "properties":
-                  { "tip": { "$ref": "#/definitions/Tip" }
+                  { "tip": { "$ref": "#/definitions/TipOrOrigin" }
                   }
                 }
               }
@@ -293,8 +294,7 @@
               { "SubmitFail":
                 { "oneOf":
                   [ { "$ref": "#/definitions/EraMismatch" }
-                  , { "$ref": "#/definitions/SubmitTxError[Byron]" }
-                  , { "$ref": "#/definitions/SubmitTxError[Shelley]" }
+                  , { "$ref": "#/definitions/SubmitTxError" }
                   ]
                 }
               }
@@ -334,7 +334,7 @@
         , "additionalProperties": false
         , "required": ["point"]
         , "properties":
-          { "point": { "$ref": "#/definitions/Point" }
+          { "point": { "$ref": "#/definitions/PointOrOrigin" }
           }
         }
       , "mirror":
@@ -377,7 +377,7 @@
                 , "additionalProperties": false
                 , "required": ["point"]
                 , "properties":
-                  { "point": { "$ref": "#/definitions/Point" }
+                  { "point": { "$ref": "#/definitions/PointOrOrigin" }
                   }
                 }
               }
@@ -637,7 +637,7 @@
         }
       , "result":
         { "oneOf":
-          [ { "$ref": "#/definitions/Point" }
+          [ { "$ref": "#/definitions/PointOrOrigin" }
           , { "$ref": "#/definitions/EraMismatch" }
           , { "$ref": "#/definitions/QueryUnavailableInCurrentEra" }
           ]
@@ -813,12 +813,12 @@
       , "result":
         { "anyOf":
           [ { "type": "object"
-            , "title": "ProtocolParameters[Shelley]"
+            , "title": "ProposedProtocolParameters[Shelley]"
             , "propertyNames": { "contentEncoding": "bech32", "pattern": "^[0-9a-f]+$" }
             , "additionalProperties": { "$ref": "#/definitions/ProtocolParameters[Shelley]" }
             }
           , { "type": "object"
-            , "title": "ProtocolParameters[Alonzo]"
+            , "title": "ProposedProtocolParameters[Alonzo]"
             , "propertyNames": { "contentEncoding": "bech32", "pattern": "^[0-9a-f]+$" }
             , "additionalProperties": { "$ref": "#/definitions/ProtocolParameters[Alonzo]" }
             }
@@ -1191,7 +1191,7 @@
                               , "softwareVersion": { "$ref": "#/definitions/SoftwareVersion" }
                               , "metadata":
                                 { "type": "object"
-                                , "additionalProperties": true
+                                , "additionalProperties": { "type": "string" }
                                 }
                               , "parametersUpdate": { "$ref": "#/definitions/ProtocolParameters[Byron]" }
                               }
@@ -1983,7 +1983,7 @@
                 { "oneOf":
                   [ { "$ref": "#/definitions/Null"}
                   , { "type": "object"
-                    , "title": "metadata"
+                    , "title": "poolMetadata"
                     , "additionalProperties": false
                     , "required": ["hash","url"]
                     , "properties":
@@ -2331,46 +2331,6 @@
     , "description": "An amount, possibly negative, in Lovelace (1e6 Lovelace = 1 Ada)."
     }
 
-  , "LovelaceError":
-    { "oneOf":
-      [ { "type": "object"
-        , "title": "underflow"
-        , "additionalProperties": false
-        , "required": [ "underflow" ]
-        , "properties":
-          { "underflow":
-            { "type": "array"
-            , "items": { "type": "integer" }
-            }
-          }
-        }
-      , { "type": "object"
-        , "title": "tooSmall"
-        , "additionalProperties": false
-        , "required": [ "tooSmall" ]
-        , "properties":
-          { "tooSmall": { "type": "integer" }
-          }
-        }
-      , { "type": "object"
-        , "title": "tooLarge"
-        , "additionalProperties": false
-        , "required": [ "tooLarge" ]
-        , "properties":
-          { "tooLarge": { "type": "integer" }
-          }
-        }
-      , { "type": "object"
-        , "title": "overflow"
-        , "additionalProperties": false
-        , "required": [ "overflow" ]
-        , "properties":
-          { "overflow": { "type": "integer" }
-          }
-        }
-      ]
-    }
-
   , "Metadata":
     { "type": "object"
     , "propertyNames": { "pattern": "^-?[0-9]+$" }
@@ -2592,7 +2552,14 @@
       }
     }
 
-  , "Point":
+  , "Origin":
+    { "type": "string"
+    , "description": "The origin of the blockchain. This point is special in the sense that it doesn't point to any existing slots, but is preceding any existing other point."
+    , "title": "origin"
+    , "enum": [ "origin" ]
+    }
+
+  , "PointOrOrigin":
     { "oneOf":
       [ { "type": "object"
         , "description": "A point on the chain, identified by a slot and a block header hash."
@@ -2604,11 +2571,7 @@
           , "hash": { "$ref": "#/definitions/Hash16" }
           }
         }
-      , { "type": "string"
-        , "description": "The origin of the blockchain. This point is special in the sense that it doesn't point to any existing slots, but is preceding any existing other point."
-        , "title": "origin"
-        , "enum": [ "origin" ]
-        }
+      , { "$ref": "#/definitions/Origin" }
       ]
     }
 
@@ -2667,18 +2630,36 @@
 
   , "ProtocolParameters[Byron]":
     { "type": "object"
-    , "additionalProperties": true
+    , "additionalProperties": false
+    , "required":
+      [ "heavyDlgThreshold"
+      , "maxBlockSize"
+      , "maxHeaderSize"
+      , "maxProposalSize"
+      , "maxTxSize"
+      , "mpcThreshold"
+      , "scriptVersion"
+      , "slotDuration"
+      , "unlockStakeEpoch"
+      , "updateProposalThreshold"
+      , "updateProposalTimeToLive"
+      , "updateVoteThreshold"
+      , "txFeePolicy"
+      , "softforkRule"
+      ]
     , "properties":
-      { "scriptVersion": { "$ref": "#/definitions/NullableInteger" }
-      , "slotDuration": { "$ref": "#/definitions/NullableInteger" }
+      { "heavyDlgThreshold": { "$ref": "#/definitions/NullableRatio" }
       , "maxBlockSize": { "$ref": "#/definitions/NullableInteger" }
       , "maxHeaderSize": { "$ref": "#/definitions/NullableInteger" }
       , "maxProposalSize": { "$ref": "#/definitions/NullableInteger" }
+      , "maxTxSize": { "$ref": "#/definitions/NullableInteger" }
       , "mpcThreshold": { "$ref": "#/definitions/NullableRatio" }
-      , "heavyDlgThreshold": { "$ref": "#/definitions/NullableRatio" }
-      , "updateVoteThreshold": { "$ref": "#/definitions/NullableRatio" }
-      , "updateProposalTimeToLive": { "$ref": "#/definitions/NullableInteger" }
+      , "scriptVersion": { "$ref": "#/definitions/NullableInteger" }
+      , "slotDuration": { "$ref": "#/definitions/NullableInteger" }
       , "unlockStakeEpoch": { "$ref": "#/definitions/NullableInteger" }
+      , "updateProposalThreshold": { "$ref": "#/definitions/NullableRatio" }
+      , "updateProposalTimeToLive": { "$ref": "#/definitions/NullableInteger" }
+      , "updateVoteThreshold": { "$ref": "#/definitions/NullableRatio" }
       , "txFeePolicy":
         { "oneOf":
           [ { "$ref": "#/definitions/TxFeePolicy" }
@@ -2697,6 +2678,25 @@
   , "ProtocolParameters[Shelley]":
     { "type": "object"
     , "additionalProperties": false
+    , "required":
+      [ "minFeeCoefficient"
+      , "minFeeConstant"
+      , "maxBlockBodySize"
+      , "maxBlockHeaderSize"
+      , "maxTxSize"
+      , "stakeKeyDeposit"
+      , "poolDeposit"
+      , "poolRetirementEpochBound"
+      , "desiredNumberOfPools"
+      , "poolInfluence"
+      , "monetaryExpansion"
+      , "treasuryExpansion"
+      , "decentralizationParameter"
+      , "minUtxoValue"
+      , "minPoolCost"
+      , "extraEntropy"
+      , "protocolVersion"
+      ]
     , "properties":
       { "minFeeCoefficient": { "$ref": "#/definitions/NullableInteger" }
       , "minFeeConstant": { "$ref": "#/definitions/NullableInteger" }
@@ -2731,6 +2731,32 @@
   , "ProtocolParameters[Alonzo]":
     { "type": "object"
     , "additionalProperties": false
+    , "required":
+      [ "minFeeCoefficient"
+      , "minFeeConstant"
+      , "maxBlockBodySize"
+      , "maxBlockHeaderSize"
+      , "maxTxSize"
+      , "stakeKeyDeposit"
+      , "poolDeposit"
+      , "poolRetirementEpochBound"
+      , "desiredNumberOfPools"
+      , "poolInfluence"
+      , "monetaryExpansion"
+      , "treasuryExpansion"
+      , "decentralizationParameter"
+      , "minPoolCost"
+      , "coinsPerUtxoWord"
+      , "maxValueSize"
+      , "collateralPercentage"
+      , "maxCollateralInputs"
+      , "extraEntropy"
+      , "protocolVersion"
+      , "costModels"
+      , "prices"
+      , "maxExecutionUnitsPerTransaction"
+      , "maxExecutionUnitsPerBlock"
+      ]
     , "properties":
       { "minFeeCoefficient": { "$ref": "#/definitions/NullableInteger" }
       , "minFeeConstant": { "$ref": "#/definitions/NullableInteger" }
@@ -3086,27 +3112,7 @@
       }
     }
 
-  , "SubmitTxError[Byron]":
-    { "type": "object"
-    , "oneOf":
-      [ { "additionalProperties": false
-        , "title": "utxoValidationError"
-        , "required": [ "utxoValidationError" ]
-        , "properties":
-          { "utxoValidationError": { "$ref": "#/definitions/UtxoValidationError" }
-          }
-        }
-      , { "additionalProperties": false
-        , "title": "txValidationError"
-        , "required": [ "txValidationError" ]
-        , "properties":
-          { "txValidationError": { "$ref": "#/definitions/TxValidationError" }
-          }
-        }
-      ]
-    }
-
-  , "SubmitTxError[Shelley]":
+  , "SubmitTxError":
     { "type": "array"
     , "items":
       { "oneOf":
@@ -3994,7 +4000,7 @@
       }
     }
 
-  , "Tip":
+  , "TipOrOrigin":
     { "oneOf":
       [ { "type": "object"
         , "title": "tip"
@@ -4006,10 +4012,7 @@
           , "blockNo": { "$ref": "#/definitions/BlockNo" }
           }
         }
-      , { "type": "string"
-        , "title": "origin"
-        , "enum": [ "origin" ]
-        }
+      , { "$ref": "#/definitions/Origin" }
       ]
     }
 
@@ -4099,128 +4102,6 @@
       }
     }
 
-  , "TxValidationError":
-    { "oneOf":
-      [ { "type": "string"
-        , "title": "unknownAttributes"
-        , "enum": [ "unknownAttributes", "unknownAddressAttributes" ]
-        }
-      , { "type": "object"
-        , "title": "feeTooSmall_"
-        , "additionalProperties": false
-        , "required": [ "feeTooSmall" ]
-        , "properties":
-          { "feeTooSmall":
-            { "type": "object"
-            , "additionalProperties": false
-            , "required": [ "tx", "requiredFee", "actualFee" ]
-            , "properties":
-              { "tx": { "$ref": "#/definitions/Tx" }
-              , "requiredFee": { "$ref": "#/definitions/Lovelace" }
-              , "actualFee": { "$ref": "#/definitions/Lovelace" }
-              }
-            }
-          }
-        }
-      , { "type": "object"
-        , "title": "txTooLarge_"
-        , "additionalProperties": false
-        , "required": [ "txTooLarge" ]
-        , "properties":
-          { "txTooLarge":
-            { "type": "object"
-            , "additionalProperties": false
-            , "required": [ "maximumSize", "actualSize" ]
-            , "properties":
-              { "maximumSize": { "type": "integer" }
-              , "actualSize": { "type": "integer" }
-              }
-            }
-          }
-        }
-      , { "type": "object"
-        , "title": "missingInput_"
-        , "additionalProperties": false
-        , "required": [ "missingInput" ]
-        , "properties":
-          { "missingInput":
-            { "type": "object"
-            , "additionalProperties": false
-            , "required": [ "index", "txId" ]
-            , "properties":
-              { "index": { "type": "integer" }
-              , "txId": { "$ref": "#/definitions/Hash16" }
-              }
-            }
-          }
-        }
-      , { "type": "object"
-        , "title": "networkMismatch_"
-        , "additionalProperties": false
-        , "required": [ "networkMismatch" ]
-        , "properties":
-          { "networkMismatch":
-            { "type": "object"
-            , "additionalProperties": false
-            , "required": [ "foundInAddress", "expectedNetwork" ]
-            , "properties":
-              { "foundInAddress": { "$ref": "#/definitions/NetworkMagic" }
-              , "expectedNetwork": { "$ref": "#/definitions/NetworkMagic" }
-              }
-            }
-          }
-        }
-      , { "type": "object"
-        , "title": "wrongSignature_"
-        , "additionalProperties": false
-        , "required": [ "wrongSignature" ]
-        , "properties":
-          { "wrongSignature":
-            { "type": "object"
-            , "additionalProperties": false
-            , "required": [ "witness", "protocolMagic" ]
-            , "properties":
-              { "protocolMagic": { "$ref": "#/definitions/ProtocolMagicId" }
-              , "witness": { "$ref": "#/definitions/TxWitness" }
-              }
-            }
-          }
-        }
-      , { "type": "object"
-        , "title": "lovelaceError_"
-        , "additionalProperties": false
-        , "required": [ "lovelaceError" ]
-        , "properties":
-          { "lovelaceError":
-            { "type": "object"
-            , "additionalProperties": false
-            , "required": [ "error", "label" ]
-            , "properties":
-              { "error": { "$ref": "#/definitions/LovelaceError" }
-              , "label": { "type": "string" }
-              }
-            }
-          }
-        }
-      , { "type": "object"
-        , "title": "wrongKey_"
-        , "additionalProperties": false
-        , "required": [ "wrongKey" ]
-        , "properties":
-          { "wrongKey":
-            { "type": "object"
-            , "additionalProperties": false
-            , "required": [ "address", "witness" ]
-            , "properties":
-              { "address": { "$ref": "#/definitions/Address" }
-              , "witness": { "$ref": "#/definitions/TxWitness" }
-              }
-            }
-          }
-        }
-      ]
-    }
-
   , "TxWitness":
     { "type": "object"
     , "oneOf":
@@ -4262,6 +4143,7 @@
       [ { "$ref": "#/definitions/Null"}
       , { "type": "object"
         , "title": "UpdateProposal[Shelley]"
+        , "additionalProperties": false
         , "required": ["proposal", "epoch"]
         , "properties":
           { "epoch": { "$ref": "#/definitions/Epoch" }
@@ -4279,6 +4161,7 @@
       [ { "$ref": "#/definitions/Null"}
       , { "type": "object"
         , "title": "UpdateProposal[Alonzo]"
+        , "additionalProperties": false
         , "required": ["proposal", "epoch"]
         , "properties":
           { "epoch": { "$ref": "#/definitions/Epoch" }
@@ -4309,23 +4192,6 @@
         , { "$ref": "#/definitions/TxOut" }
         ]
       }
-    }
-
-  , "UtxoValidationError":
-    { "oneOf":
-      [ { "type": "string"
-        , "title": "overlappingUnion"
-        , "enum": [ "overlappingUnion" ]
-        }
-      , { "type": "object"
-        , "title": "missingInput"
-        , "additionalProperties": false
-        , "required": [ "missingInput" ]
-        , "properties":
-          { "missingInput": { "$ref": "#/definitions/TxIn" }
-          }
-        }
-      ]
     }
 
   , "ValidityInterval":

--- a/docs/static/ogmios.wsp.json
+++ b/docs/static/ogmios.wsp.json
@@ -3159,7 +3159,7 @@
         , { "$ref": "#/definitions/SubmitTxError[unspendableDatums]" }
         , { "$ref": "#/definitions/SubmitTxError[extraDataMismatch]" }
         , { "$ref": "#/definitions/SubmitTxError[missingRequiredSignatures]" }
-        , { "$ref": "#/definitions/SubmitTxError[unspendableScriptInputsWithoutDatum]" }
+        , { "$ref": "#/definitions/SubmitTxError[unspendableScriptInputs]" }
         , { "$ref": "#/definitions/SubmitTxError[missingDatumHashesForInputs]" }
         , { "$ref": "#/definitions/SubmitTxError[missingCollateralInputs]" }
         , { "$ref": "#/definitions/SubmitTxError[collateralTooSmall]" }
@@ -3860,13 +3860,13 @@
       }
     }
 
-  , "SubmitTxError[unspendableScriptInputsWithoutDatum]":
+  , "SubmitTxError[unspendableScriptInputs]":
     { "type": "object"
-    , "title": "unspendableScriptInputsWithoutDatum"
+    , "title": "unspendableScriptInputs"
     , "additionalProperties": false
-    , "required": [ "unspendableScriptInputsWithoutDatum" ]
+    , "required": [ "unspendableScriptInputs" ]
     , "properties":
-      { "unspendableScriptInputsWithoutDatum":
+      { "unspendableScriptInputs":
         { "type": "array"
         , "items": { "$ref": "#/definitions/TxIn" }
         }

--- a/docs/static/ogmios.wsp.json
+++ b/docs/static/ogmios.wsp.json
@@ -1023,10 +1023,6 @@
         { "type": "array"
         , "items": { "$ref": "#/definitions/Script" }
         }
-      , "datums":
-        { "type": "array"
-        , "items": { "$ref": "#/definitions/Datum" }
-        }
       }
     }
 
@@ -2657,8 +2653,8 @@
     , "additionalProperties": false
     , "required": [ "memory", "steps" ]
     , "properties":
-      { "memory": { "$ref": "#/definitions/Lovelace" }
-      , "steps": { "$ref": "#/definitions/Lovelace" }
+      { "memory": { "$ref": "#/definitions/Ratio" }
+      , "steps": { "$ref": "#/definitions/Ratio" }
       }
     }
 
@@ -2750,7 +2746,7 @@
       , "treasuryExpansion": { "$ref": "#/definitions/NullableRatio" }
       , "decentralizationParameter": { "$ref": "#/definitions/NullableRatio" }
       , "minPoolCost": { "$ref": "#/definitions/NullableInteger" }
-      , "lovelacePerUtxoWord": { "$ref": "#/definitions/NullableInteger" }
+      , "coinsPerUtxoWord": { "$ref": "#/definitions/NullableInteger" }
       , "maxValueSize": { "$ref": "#/definitions/NullableInteger" }
       , "collateralPercentage": { "$ref": "#/definitions/NullableInteger" }
       , "maxCollateralInputs": { "$ref": "#/definitions/NullableInteger" }
@@ -3142,6 +3138,7 @@
         , { "$ref": "#/definitions/SubmitTxError[wrongPoolCertificate]" }
         , { "$ref": "#/definitions/SubmitTxError[stakeKeyAlreadyRegistered]" }
         , { "$ref": "#/definitions/SubmitTxError[poolCostTooSmall]" }
+        , { "$ref": "#/definitions/SubmitTxError[poolMetadataHashTooBig]" }
         , { "$ref": "#/definitions/SubmitTxError[stakeKeyNotRegistered]" }
         , { "$ref": "#/definitions/SubmitTxError[rewardAccountNotExisting]" }
         , { "$ref": "#/definitions/SubmitTxError[rewardAccountNotEmpty]" }
@@ -3158,9 +3155,11 @@
         , { "$ref": "#/definitions/SubmitTxError[updateWrongEpoch]" }
         , { "$ref": "#/definitions/SubmitTxError[protocolVersionCannotFollow]" }
         , { "$ref": "#/definitions/SubmitTxError[unredeemableScripts]" }
-        , { "$ref": "#/definitions/SubmitTxError[datumsMismatch]" }
+        , { "$ref": "#/definitions/SubmitTxError[missingRequiredDatums]" }
+        , { "$ref": "#/definitions/SubmitTxError[unspendableDatums]" }
         , { "$ref": "#/definitions/SubmitTxError[extraDataMismatch]" }
         , { "$ref": "#/definitions/SubmitTxError[missingRequiredSignatures]" }
+        , { "$ref": "#/definitions/SubmitTxError[unspendableScriptInputsWithoutDatum]" }
         , { "$ref": "#/definitions/SubmitTxError[missingDatumHashesForInputs]" }
         , { "$ref": "#/definitions/SubmitTxError[missingCollateralInputs]" }
         , { "$ref": "#/definitions/SubmitTxError[collateralTooSmall]" }
@@ -3560,6 +3559,24 @@
       }
     }
 
+  , "SubmitTxError[poolMetadataHashTooBig]":
+    { "type": "object"
+    , "title": "poolMetadataHashTooBig"
+    , "additionalProperties": false
+    , "required": [ "poolMetadataHashTooBig" ]
+    , "properties":
+      { "poolMetadataHashTooBig":
+        { "type": "object"
+        , "additionalProperties": false
+        , "required": [ "poolId", "measuredSize" ]
+        , "properties":
+          { "poolId": { "$ref": "#/definitions/PoolId" }
+          , "measuredSize": { "type": "integer" }
+          }
+        }
+      }
+    }
+
   , "SubmitTxError[stakeKeyNotRegistered]":
     { "type": "object"
     , "title": "stakeKeyNotRegistered"
@@ -3754,22 +3771,46 @@
       }
     }
 
-  , "SubmitTxError[datumsMismatch]":
+  , "SubmitTxError[missingRequiredDatums]":
     { "type": "object"
-    , "title": "datumsMismatch"
+    , "title": "missingRequiredDatums"
     , "additionalProperties": false
-    , "required": [ "datumsMismatch" ]
+    , "required": [ "missingRequiredDatums" ]
     , "properties":
-      { "datumsMismatch":
+      { "missingRequiredDatums":
         { "type": "object"
         , "additionalProperties": false
-        , "required": [ "provided", "inferredFromInputs" ]
+        , "required": [ "provided", "missing" ]
         , "properties":
           { "provided":
             { "type": "array"
             , "items": { "$ref": "#/definitions/Hash16" }
             }
-          , "inferredFromInputs":
+          , "missing":
+            { "type": "array"
+            , "items": { "$ref": "#/definitions/Hash16" }
+            }
+          }
+        }
+      }
+    }
+
+  , "SubmitTxError[unspendableDatums]":
+    { "type": "object"
+    , "title": "unspendableDatums"
+    , "additionalProperties": false
+    , "required": [ "unspendableDatums" ]
+    , "properties":
+      { "unspendableDatums":
+        { "type": "object"
+        , "additionalProperties": false
+        , "required": [ "nonSpendable", "acceptable" ]
+        , "properties":
+          { "nonSpendable":
+            { "type": "array"
+            , "items": { "$ref": "#/definitions/Hash16" }
+            }
+          , "acceptable":
             { "type": "array"
             , "items": { "$ref": "#/definitions/Hash16" }
             }
@@ -3815,6 +3856,19 @@
       { "missingRequiredSignatures":
         { "type": "array"
         , "items": { "$ref": "#/definitions/Hash16" }
+        }
+      }
+    }
+
+  , "SubmitTxError[unspendableScriptInputsWithoutDatum]":
+    { "type": "object"
+    , "title": "unspendableScriptInputsWithoutDatum"
+    , "additionalProperties": false
+    , "required": [ "unspendableScriptInputsWithoutDatum" ]
+    , "properties":
+      { "unspendableScriptInputsWithoutDatum":
+        { "type": "array"
+        , "items": { "$ref": "#/definitions/TxIn" }
         }
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -2,28 +2,28 @@
   "nodes": {
     "customConfig": {
       "locked": {
-        "narHash": "sha256-4wRvnnVtCrHE0puR4+/+qp4DoUboPuCbCe7GmWOGASA=",
-        "path": "./nix/custom-config",
+        "narHash": "sha256-NdBgwn6xJOM5j+T4ViTq+7FToInEbzvKcdOBpjQvILw=",
+        "path": "./custom-config",
         "type": "path"
       },
       "original": {
-        "path": "./nix/custom-config",
+        "path": "./custom-config",
         "type": "path"
       }
     },
     "haskellNix": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "nixpkgs-2003": "nixpkgs-2003",
         "nixpkgs-2009": "nixpkgs-2009",
+        "nixpkgs-2105": "nixpkgs-2105",
         "nixpkgs-unstable": "nixpkgs-unstable"
       },
       "locked": {
-        "lastModified": 1620954815,
-        "narHash": "sha256-Q7BQ/r87zW9trNS22RaiCAU8HMMgOgGunP7UpIB0W6M=",
+        "lastModified": 1626657157,
+        "narHash": "sha256-4TPqLokSoDVUVqYrpnXvX0aSb+v6jLezonPgs4zR/OU=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "006e792f1c48508d0e9a57598d3f81388a5c86ec",
+        "rev": "f9d261d6d90d4aebd97f7ae60c951fc9e1d98493",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1620314199,
-        "narHash": "sha256-JCu5wnt3ja8UBQv5G3aRhQ+ZcAKB6+ivodv3yA6UnK8=",
+        "lastModified": 1626280493,
+        "narHash": "sha256-+uk8Lb6ulWppzJ0AwS645YJgzbjCutqNix5Ro5g3Z94=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "0ce3abcfed803ed77472488f30b299fda9d941b1",
+        "rev": "0068efb20a3cd74dae8dfaedefaa18ad72d4a1a9",
         "type": "github"
       },
       "original": {
@@ -54,65 +54,65 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1608007629,
-        "narHash": "sha256-lipVFC/a2pzzA5X2ULj64je+fz1JIp2XRrB5qyoizpQ=",
+        "lastModified": 1624291665,
+        "narHash": "sha256-kNkaoa3dai9WOi7fsPklCCWZ8hRAkXx0ZUhpYKShyUk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
+        "rev": "3c6f3f84af60a8ed5b8a79cf3026b7630fcdefb8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2003": {
-      "locked": {
-        "lastModified": 1607708579,
-        "narHash": "sha256-QyADEDydJJPa8n3xawnA82IJAcZHNNm6Pp5DU7exMr4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "7f73e46625f508a793700f5110b86f1a53341d6e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "7f73e46625f508a793700f5110b86f1a53341d6e",
+        "rev": "3c6f3f84af60a8ed5b8a79cf3026b7630fcdefb8",
         "type": "github"
       }
     },
     "nixpkgs-2009": {
       "locked": {
-        "lastModified": 1608007629,
-        "narHash": "sha256-lipVFC/a2pzzA5X2ULj64je+fz1JIp2XRrB5qyoizpQ=",
+        "lastModified": 1624271064,
+        "narHash": "sha256-qns/uRW7MR2EfVf6VEeLgCsCp7pIOjDeR44JzTF09MA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
+        "rev": "46d1c3f28ca991601a53e9a14fdd53fcd3dd8416",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
+        "rev": "46d1c3f28ca991601a53e9a14fdd53fcd3dd8416",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105": {
+      "locked": {
+        "lastModified": 1624291665,
+        "narHash": "sha256-kNkaoa3dai9WOi7fsPklCCWZ8hRAkXx0ZUhpYKShyUk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3c6f3f84af60a8ed5b8a79cf3026b7630fcdefb8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3c6f3f84af60a8ed5b8a79cf3026b7630fcdefb8",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1612284693,
-        "narHash": "sha256-efzJNF1jvjK3BMl0gZ0ZaUWcFMv0nLb9AHN/++5+u0U=",
+        "lastModified": 1623862044,
+        "narHash": "sha256-mY7nldu9Wl/Yb0qMPihZrWw0bRWXNsk6iyYztw/6F6Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "410bbd828cdc6156aecd5bc91772ad3a6b1099c7",
+        "rev": "0747387223edf1aa5beaedf48983471315d95e16",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "410bbd828cdc6156aecd5bc91772ad3a6b1099c7",
+        "rev": "0747387223edf1aa5beaedf48983471315d95e16",
         "type": "github"
       }
     },
@@ -123,18 +123,18 @@
         "iohkNix": "iohkNix",
         "nixpkgs": [
           "haskellNix",
-          "nixpkgs-unstable"
+          "nixpkgs-2105"
         ],
         "utils": "utils"
       }
     },
     "utils": {
       "locked": {
-        "lastModified": 1620759905,
-        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {

--- a/server/cabal.project
+++ b/server/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2021-03-15T00:00:00Z
+index-state: 2021-04-30T00:00:00Z
 
 packages:
   ./
@@ -35,8 +35,8 @@ allow-newer:
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: a715c7f420770b70bbe95ca51d3dec83866cb1bd
-  --sha256: 06l06mmb8cd4q37bnvfpgx1c5zgsl4xaf106dqva98738i8asj7j
+  tag: b6a215c42a28dc8b71b42946fe30256a333d34af
+  --sha256: 1l9nqsg6kfkfadlbvyl4afdf8v408zf0fn6dkihqf56g2mnk4i04
   subdir:
     binary
     binary/test
@@ -55,8 +55,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a3ef848542961079b7cd53d599e5385198a3035c
-  --sha256: 02iwn2lcfcfvrnvcqnx586ncdnma23vdqvicxgr4f39vcacalzpd
+  tag: ec9c77edbf5700a4b2ece8f97a1e313df06abc97
+  --sha256: 1ia8x9dnw36y0xazg7xg263ax9mamw9w4sg460cmibj3wv49im4w
   subdir:
     alonzo/impl
     alonzo/test
@@ -78,8 +78,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 8c142704e7df8ca857b179e26fdebb6919b5a7a6
-  --sha256: 1xydm6xhyyj9nhg42d2gdha9bv5xd9i7hf1s8akg9xj2mcxfh2mk
+  tag: 48429531f0d3d71fadce9a5971bf56a6df396f2d
+  --sha256: 0arhmmxb86ggfc73rbyz1fj43glj9z2f8w5416cix2wxkvlm8bys
   subdir:
     cardano-api
     cardano-config
@@ -103,8 +103,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/hedgehog-extras
-  tag: 8bcd3c9dc22cc44f9fcfe161f4638a384fc7a187
-  --sha256: 12viwpahjdfvlqpnzdgjp40nw31rvyznnab1hml9afpaxd6ixh70
+  tag: edf6945007177a638fbeb8802397f3a6f4e47c14
+  --sha256: 0wc7qzkc7j4ns2rz562h6qrx2f8xyq7yjcb7zidnj7f6j0pcd0i9
 
 source-repository-package
   type: git
@@ -136,11 +136,12 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e50613562d6d4a0f933741fcf590b0f69a1eda67
-  --sha256: 0i192ksa69lpzjhzmhd2h1mramkvvikw04pqws18h5dly55f4z3k
+  tag: e338f2cf8e1078fbda9555dd2b169c6737ef6774
+  --sha256: 12x81hpjyw2cpkazfalz6bw2wgr6ax7bnmlxl2rlfakkvsjfgaqd
   subdir:
+    io-classes
     io-sim
-    io-sim-classes
+    monoidal-synchronisation
     network-mux
     ouroboros-consensus
     ouroboros-consensus-test
@@ -161,14 +162,14 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: 13da6d416b2b47cdb6f287ff078b9e759bb90b7f
-  --sha256: 11jpcjdr05l2yyhy9zp3hpkq8bhipx5w3y9bjzg2hzh0fay8571w
+  tag: 523f349f3d68db07c98150734793ed7003d1f562
+  --sha256: 0vp6wiv1fz5bzvw90pdwv96nck78m5s91xiwjhkksq06l1yqr3ps
   subdir:
     plutus-core
     plutus-ledger-api
     plutus-tx
-    plutus-tx-plugin
     prettyprinter-configurable
+    word-array
 
 source-repository-package
   type: git
@@ -179,8 +180,14 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/Win32-network
-  tag: 94153b676617f8f33abe8d8182c37377d2784bd1
-  --sha256: 0pb7bg0936fldaa5r08nqbxvi2g8pcy4w3c7kdcg7pdgmimr30ss
+  tag: 5b3d08c454f425da5cf045fe7865950d7c806691
+  --sha256: 0npyihbaqlih9abdbaj451lm1h0kl5braczy8vn41s3ivbbnvpcw
+
+source-repository-package
+  type: git
+  location: https://github.com/Quid2/flat.git
+  tag: 95e5d7488451e43062ca84d5376b3adcc465f1cd
+  --sha256: 06l31x3y93rjpryvlxnpsyq2zyxvb0z6lik6yq2fvh36i5zwvwa3
 
 constraints:
     hedgehog >= 1.0

--- a/server/modules/cardano-client/cardano-client.cabal
+++ b/server/modules/cardano-client/cardano-client.cabal
@@ -80,7 +80,7 @@ library
     , cborg
     , containers
     , contra-tracer
-    , io-sim-classes
+    , io-classes
     , iohk-monitoring
     , network-mux
     , ouroboros-consensus

--- a/server/modules/cardano-client/package.yaml
+++ b/server/modules/cardano-client/package.yaml
@@ -31,7 +31,7 @@ library:
     - cborg
     - containers
     - contra-tracer
-    - io-sim-classes
+    - io-classes
     - iohk-monitoring
     - network-mux
     - ouroboros-consensus

--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -147,7 +147,7 @@ library
     , generic-lens
     , git-th
     , http-types
-    , io-sim-classes
+    , io-classes
     , iohk-monitoring
     , iproute
     , json-wsp
@@ -298,8 +298,8 @@ test-suite unit
     , hedgehog-quickcheck
     , hspec
     , hspec-json-schema
+    , io-classes
     , io-sim
-    , io-sim-classes
     , json-wsp
     , ogmios
     , ouroboros-consensus

--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -243,6 +243,7 @@ test-suite unit
       Ogmios.Data.MetricsSpec
       Test.App.Protocol.Util
       Test.Generators
+      Test.Instances.Util
       Test.Path.Util
       Paths_ogmios
   hs-source-dirs:
@@ -315,6 +316,7 @@ test-suite unit
     , shelley-spec-ledger
     , shelley-spec-ledger-test
     , template-haskell
+    , time
     , typed-protocols
     , typed-protocols-examples
   default-language: Haskell2010

--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -240,6 +240,7 @@ test-suite unit
       Ogmios.App.Protocol.StateQuerySpec
       Ogmios.Data.HealthSpec
       Ogmios.Data.JsonSpec
+      Ogmios.Data.MetricsSpec
       Test.App.Protocol.Util
       Test.Generators
       Test.Path.Util

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -149,6 +149,7 @@ tests:
     - shelley-spec-ledger
     - shelley-spec-ledger-test
     - template-haskell
+    - time
     - typed-protocols
     - typed-protocols-examples
     build-tools:

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -67,7 +67,7 @@ library:
     - generic-lens
     - git-th
     - http-types
-    - io-sim-classes
+    - io-classes
     - iohk-monitoring
     - iproute
     - json-wsp
@@ -133,7 +133,7 @@ tests:
     - hspec
     - hspec-json-schema
     - io-sim
-    - io-sim-classes
+    - io-classes
     - json-wsp
     - ogmios
     - ouroboros-consensus

--- a/server/resolver.yaml
+++ b/server/resolver.yaml
@@ -20,7 +20,7 @@ packages:
 - constraints-extras-0.3.1.0
 - containers-0.5.11.0 # 0.6.2.1 on LTS 17.6
 - dependent-map-0.4.0.0
-- dependent-sum-0.6.2.0
+- dependent-sum-0.7.1.0
 - dependent-sum-template-0.1.0.3
 - dns-3.0.4 # 4.0.1 on LTS 17.6
 - gray-code-0.3.1
@@ -50,7 +50,7 @@ packages:
 
 
 - git: https://github.com/input-output-hk/cardano-base
-  commit: a715c7f420770b70bbe95ca51d3dec83866cb1bd
+  commit: b6a215c42a28dc8b71b42946fe30256a333d34af
   subdirs:
   - binary
   - binary/test
@@ -64,7 +64,7 @@ packages:
   commit: ce8f1934e4b6252084710975bd9bbc0a4648ece4
 
 - git: https://github.com/input-output-hk/cardano-ledger-specs
-  commit: a3ef848542961079b7cd53d599e5385198a3035c
+  commit: ec9c77edbf5700a4b2ece8f97a1e313df06abc97
   subdirs:
   - alonzo/impl
   - alonzo/test
@@ -84,7 +84,7 @@ packages:
   - shelley-ma/shelley-ma-test
 
 - git: https://github.com/input-output-hk/cardano-node
-  commit: 8c142704e7df8ca857b179e26fdebb6919b5a7a6
+  commit: 48429531f0d3d71fadce9a5971bf56a6df396f2d
   subdirs:
     - cardano-api
     - cardano-config
@@ -96,11 +96,14 @@ packages:
   - cardano-prelude
   - cardano-prelude-test
 
+- git: https://github.com/Quid2/flat.git
+  commit: 95e5d7488451e43062ca84d5376b3adcc465f1cd
+
 - git: https://github.com/input-output-hk/goblins
   commit: cde90a2b27f79187ca8310b6549331e59595e7ba
 
 - git: https://github.com/input-output-hk/hedgehog-extras
-  commit: 8bcd3c9dc22cc44f9fcfe161f4638a384fc7a187
+  commit: edf6945007177a638fbeb8802397f3a6f4e47c14
 
 - git: https://github.com/KtorZ/hjsonpointer
   commit: 75ed0d049c33274a6cb4c36c8538d4bf2ef9c30e
@@ -121,10 +124,11 @@ packages:
   - tracer-transformers
 
 - git: https://github.com/input-output-hk/ouroboros-network
-  commit: e50613562d6d4a0f933741fcf590b0f69a1eda67
+  commit: e338f2cf8e1078fbda9555dd2b169c6737ef6774
   subdirs:
+    - io-classes
     - io-sim
-    - io-sim-classes
+    - monoidal-synchronisation
     - network-mux
     - ouroboros-consensus
     - ouroboros-consensus-test
@@ -142,15 +146,16 @@ packages:
     - typed-protocols-examples
 
 - git: https://github.com/input-output-hk/plutus
-  commit: 13da6d416b2b47cdb6f287ff078b9e759bb90b7f
+  commit: 523f349f3d68db07c98150734793ed7003d1f562
   subdirs:
     - plutus-core
     - plutus-ledger-api
     - plutus-tx
     - prettyprinter-configurable
+    - word-array
 
 - git: https://github.com/KtorZ/wai-routes
   commit: d74b39683792649c01113f40bf57724dcf95c96a
 
 - git: https://github.com/input-output-hk/Win32-network
-  commit: 82f4afb8c240b8446a1db6c6b50901a42028ce0f
+  commit: 5b3d08c454f425da5cf045fe7865950d7c806691

--- a/server/src/Ogmios.hs
+++ b/server/src/Ogmios.hs
@@ -31,6 +31,12 @@ module Ogmios
 
 import Ogmios.Prelude
 
+import Cardano.Network.Protocol.NodeToClient
+    ( Block )
+import Control.Monad.Class.MonadST
+    ( MonadST )
+import Data.Aeson
+    ( ToJSON, genericToEncoding )
 import Ogmios.App.Health
     ( Health
     , TraceHealth
@@ -68,14 +74,8 @@ import Ogmios.Control.MonadSTM
 import Ogmios.Control.MonadWebSocket
     ( MonadWebSocket )
 
-import Cardano.Network.Protocol.NodeToClient
-    ( Block )
-import Control.Monad.Class.MonadST
-    ( MonadST )
-import Data.Aeson
-    ( ToJSON, genericToEncoding )
-
 import qualified Data.Aeson as Json
+
 --
 -- App
 --

--- a/server/src/Ogmios/App/Health.hs
+++ b/server/src/Ogmios/App/Health.hs
@@ -58,6 +58,7 @@ import Ogmios.Data.Health
     ( CardanoEra (..)
     , Health (..)
     , NetworkSynchronization
+    , NodeTip (..)
     , emptyHealth
     , mkNetworkSynchronization
     , modifyHealth
@@ -129,10 +130,10 @@ newHealthCheckClient
 newHealthCheckClient tr Debouncer{debounce} = do
     (stateQueryClient, getNetworkInformation) <- newTimeInterpreterClient
     pure $ HealthCheckClient $ Clients
-        { chainSyncClient = mkHealthCheckClient $ \lastKnownTip -> debounce $ do
+        { chainSyncClient = mkHealthCheckClient $ \(NodeTip -> lastKnownTip) -> debounce $ do
             tvar <- asks (view typed)
             metrics <- join (Metrics.sample <$> asks (view typed) <*> asks (view typed))
-            (now, networkSynchronization, currentEra) <- getNetworkInformation lastKnownTip
+            (now, networkSynchronization, currentEra) <- getNetworkInformation (getTip lastKnownTip)
             health <- modifyHealth tvar $ \h -> h
                 { lastKnownTip
                 , lastTipUpdate = Just now

--- a/server/src/Ogmios/App/Server/Http.hs
+++ b/server/src/Ogmios/App/Server/Http.hs
@@ -17,8 +17,6 @@ module Ogmios.App.Server.Http
 
 import Ogmios.Prelude
 
-import Ogmios.App.Health
-    ( Health (..), modifyHealth )
 import Ogmios.App.Metrics
     ( RuntimeStats, Sampler, Sensors )
 import Ogmios.Control.MonadClock
@@ -27,6 +25,8 @@ import Ogmios.Control.MonadMetrics
     ( MonadMetrics )
 import Ogmios.Control.MonadSTM
     ( MonadSTM (..), TVar )
+import Ogmios.Data.Health
+    ( Health (..), NodeTip (..), modifyHealth )
 
 import qualified Ogmios.App.Metrics as Metrics
 
@@ -34,8 +34,6 @@ import Data.Aeson
     ( ToJSON (..) )
 import Data.FileEmbed
     ( embedFile )
-import Ouroboros.Network.Block
-    ( Tip (..) )
 import Wai.Routes
     ( Handler
     , RenderRoute (..)
@@ -64,7 +62,7 @@ data EnvServer block m = EnvServer
 
 data Server where
     Server
-        :: (MonadClock m, MonadMetrics m, MonadSTM m, ToJSON (Tip block))
+        :: (MonadClock m, MonadMetrics m, MonadSTM m, ToJSON (NodeTip block))
         => (forall a. m a -> IO a)
         -> EnvServer block m
         -> Server
@@ -141,7 +139,7 @@ mkHttpApp
         , HasType (TVar m (Health block)) env
         , HasType (Sensors m) env
         , HasType (Sampler RuntimeStats m) env
-        , ToJSON (Tip block)
+        , ToJSON (NodeTip block)
         )
     => (forall a. m a -> IO a)
     -> m Wai.Application

--- a/server/src/Ogmios/Data/Json.hs
+++ b/server/src/Ogmios/Data/Json.hs
@@ -13,6 +13,7 @@ module Ogmios.Data.Json
     , FromJSON
     , ToJSON
     , decodeWith
+    , inefficientEncodingToValue
 
       -- * Encoders
     , encodeAcquireFailure

--- a/server/src/Ogmios/Data/Json.hs
+++ b/server/src/Ogmios/Data/Json.hs
@@ -242,7 +242,7 @@ instance Crypto crypto => FromJSON (QueryInEra Proxy (CardanoBlock crypto)) wher
         , Query.parseGetProposedPParamsUpdates (const id)
         , Query.parseGetStakeDistribution id
         , Query.parseGetUTxO (const id)
-        , Query.parseGetFilteredUTxO (const id)
+        , Query.parseGetUTxOByAddress (const id)
         , Query.parseGetGenesisConfig (const id)
         ]
 

--- a/server/src/Ogmios/Data/Json/Alonzo.hs
+++ b/server/src/Ogmios/Data/Json/Alonzo.hs
@@ -97,7 +97,7 @@ encodeAlonzoPredFail = \case
             ]
     Al.UnspendableUTxONoDatumHash utxos ->
         encodeObject
-            [ ( "unspendableScriptInputsWithoutDatum"
+            [ ( "unspendableScriptInputs"
               , encodeFoldable Shelley.encodeTxIn utxos
               )
             ]

--- a/server/src/Ogmios/Data/Json/Byron.hs
+++ b/server/src/Ogmios/Data/Json/Byron.hs
@@ -435,7 +435,7 @@ encodeProtocolParametersUpdate x = encodeObject
     , ( "updateVoteThreshold"
       , encodeMaybe encodeLovelacePortion (By.ppuUpdateVoteThd x)
       )
-    , ( "updateProposalTheshold"
+    , ( "updateProposalThreshold"
       , encodeMaybe encodeLovelacePortion (By.ppuUpdateProposalThd x)
       )
     , ( "updateProposalTimeToLive"

--- a/server/src/Ogmios/Data/Json/Prelude.hs
+++ b/server/src/Ogmios/Data/Json/Prelude.hs
@@ -48,8 +48,10 @@ module Ogmios.Data.Json.Prelude
     , encodeInteger
     , encodeNatural
     , encodeNominalDiffTime
+    , encodeNonNegativeInterval
     , encodeNull
     , encodePort
+    , encodePositiveUnitInterval
     , encodeRational
     , encodeRelativeTime
     , encodeScientific
@@ -88,13 +90,15 @@ import Cardano.Binary
     ( Annotated (..) )
 import Cardano.Ledger.BaseTypes
     ( DnsName
+    , NonNegativeInterval
     , Port
+    , PositiveUnitInterval
     , StrictMaybe (..)
     , UnitInterval
     , Url
     , dnsToText
     , portToWord16
-    , unitIntervalToRational
+    , unboundRational
     , urlToText
     )
 import Cardano.Ledger.Coin
@@ -281,6 +285,11 @@ encodeNominalDiffTime =
     encodeInteger . round
 {-# INLINABLE encodeNominalDiffTime #-}
 
+encodeNonNegativeInterval :: NonNegativeInterval -> Json
+encodeNonNegativeInterval =
+    encodeRational . unboundRational
+{-# INLINABLE encodeNonNegativeInterval #-}
+
 encodeNull :: Json
 encodeNull =
     Json.null_
@@ -290,6 +299,11 @@ encodePort :: Port -> Json
 encodePort =
     encodeWord16 . portToWord16
 {-# INLINABLE encodePort #-}
+
+encodePositiveUnitInterval :: PositiveUnitInterval -> Json
+encodePositiveUnitInterval =
+    encodeRational . unboundRational
+{-# INLINABLE encodePositiveUnitInterval #-}
 
 encodeRational :: Rational -> Json
 encodeRational r =
@@ -328,7 +342,7 @@ encodeText =
 
 encodeUnitInterval :: UnitInterval -> Json
 encodeUnitInterval =
-    encodeRational . unitIntervalToRational
+    encodeRational . unboundRational
 {-# INLINABLE encodeUnitInterval #-}
 
 encodeUrl :: Url -> Json

--- a/server/src/Ogmios/Data/Metrics.hs
+++ b/server/src/Ogmios/Data/Metrics.hs
@@ -15,7 +15,7 @@ module Ogmios.Data.Metrics
 
     -- ** DistributionStats
     , DistributionStats (..)
-    , emptyDistribution
+    , emptyDistributionStats
     ) where
 
 import Ogmios.Prelude
@@ -52,7 +52,7 @@ instance ToJSON Metrics where
 
 -- | Empty 'Metrics', for initialization.
 emptyMetrics :: Metrics
-emptyMetrics = Metrics emptyRuntimeStats 0 0 emptyDistribution 0 0
+emptyMetrics = Metrics emptyRuntimeStats 0 0 emptyDistributionStats 0 0
 
 --
 -- RuntimeStats
@@ -94,8 +94,8 @@ data DistributionStats = DistributionStats
     } deriving (Generic, Eq, Show)
 
 -- | Create an empty distribution with all values to 0
-emptyDistribution :: DistributionStats
-emptyDistribution = DistributionStats 0 0 0
+emptyDistributionStats :: DistributionStats
+emptyDistributionStats = DistributionStats 0 0 0
 
 instance ToJSON DistributionStats where
     toJSON = genericToJSON Json.defaultOptions

--- a/server/test/unit/Ogmios/App/Protocol/ChainSyncSpec.hs
+++ b/server/test/unit/Ogmios/App/Protocol/ChainSyncSpec.hs
@@ -215,7 +215,7 @@ chainSyncMockPeer seed codec (recv, send) = flip evalStateT seed $ forever $ do
     genRequestNextResponse
         :: Gen (ChainSync.Message Protocol ('StNext any) 'StIdle)
     genRequestNextResponse = frequency
-        [ (10, ChainSync.MsgRollForward <$> genBlock <*> genTip)
+        [ (10, ChainSync.MsgRollForward <$> genBlock False <*> genTip)
         , ( 1, ChainSync.MsgRollBackward <$> genPoint <*> genTip)
         ]
 

--- a/server/test/unit/Ogmios/App/Protocol/StateQuerySpec.hs
+++ b/server/test/unit/Ogmios/App/Protocol/StateQuerySpec.hs
@@ -242,7 +242,6 @@ stateQueryMockPeer seed codec (recv, send) = flip evalStateT seed $ forever $ do
             SomeResponse . LSQ.MsgResult query <$> genEpochResult Proxy
         Ledger.BlockQuery (QueryIfCurrentAlonzo GetEpochNo) ->
             SomeResponse . LSQ.MsgResult query <$> genEpochResult Proxy
-
         Ledger.BlockQuery (QueryHardFork GetCurrentEra) -> elements
             [ SomeResponse $ LSQ.MsgResult query (EraIndex (IxByron   (K ())))
             , SomeResponse $ LSQ.MsgResult query (EraIndex (IxShelley (K ())))
@@ -250,7 +249,7 @@ stateQueryMockPeer seed codec (recv, send) = flip evalStateT seed $ forever $ do
             , SomeResponse $ LSQ.MsgResult query (EraIndex (IxMary    (K ())))
             , SomeResponse $ LSQ.MsgResult query (EraIndex (IxAlonzo  (K ())))
             ]
-        Ledger.BlockQuery _ ->
+        _ ->
             error $ "No generator for query: " <> show query
 
 --

--- a/server/test/unit/Ogmios/Data/JsonSpec.hs
+++ b/server/test/unit/Ogmios/Data/JsonSpec.hs
@@ -42,13 +42,13 @@ import Ogmios.Data.Json.Query
     , parseGetEpochNo
     , parseGetEraStart
     , parseGetFilteredDelegationsAndRewards
-    , parseGetFilteredUTxO
     , parseGetGenesisConfig
     , parseGetLedgerTip
     , parseGetNonMyopicMemberRewards
     , parseGetProposedPParamsUpdates
     , parseGetStakeDistribution
     , parseGetUTxO
+    , parseGetUTxOByAddress
     )
 import Ogmios.Data.Protocol.ChainSync
     ( FindIntersect
@@ -289,7 +289,7 @@ spec = do
             [aesonQQ|
             { "utxo": []
             }|]
-            ( parseGetFilteredUTxO genUTxOResult
+            ( parseGetUTxOByAddress genUTxOResult
             ) "ogmios.wsp.json#/properties/QueryResponse[utxo]"
 
         validateQuery
@@ -300,7 +300,7 @@ spec = do
                 , "82d818582183581cb0574c7a1564697578b840fd7ec9d8963fa1398415f9f2f87737a83da0001ae9e3e303"
                 ]
             }|]
-            ( parseGetFilteredUTxO genUTxOResult
+            ( parseGetUTxOByAddress genUTxOResult
             ) "ogmios.wsp.json#/properties/QueryResponse[utxo]"
 
         validateQuery

--- a/server/test/unit/Ogmios/Data/JsonSpec.hs
+++ b/server/test/unit/Ogmios/Data/JsonSpec.hs
@@ -380,7 +380,7 @@ instance Arbitrary (Tip Block) where
     arbitrary = genTip
 
 instance Arbitrary Block where
-    arbitrary = genBlock
+    arbitrary = genBlock True
 
 --
 -- Local Tx Submit

--- a/server/test/unit/Ogmios/Data/MetricsSpec.hs
+++ b/server/test/unit/Ogmios/Data/MetricsSpec.hs
@@ -1,0 +1,54 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+module Ogmios.Data.MetricsSpec
+    ( spec
+    ) where
+
+import Ogmios.Prelude hiding
+    ( max, min )
+
+import Data.Aeson
+    ( ToJSON (..) )
+import Ogmios.Data.Metrics
+    ( DistributionStats (..)
+    , Metrics (..)
+    , RuntimeStats (..)
+    , emptyDistributionStats
+    , emptyMetrics
+    , emptyRuntimeStats
+    )
+import Test.Hspec
+    ( Expectation, Spec, SpecWith, context, parallel, shouldBe, specify )
+
+spec :: Spec
+spec = parallel $ do
+    context "empty smart-constructors" $ do
+        cover "Metrics" emptyMetrics $ \metrics -> do
+            runtimeStats metrics `shouldBe` emptyRuntimeStats
+            activeConnections metrics `shouldBe` 0
+            totalConnections metrics `shouldBe` 0
+            sessionDurations metrics `shouldBe` emptyDistributionStats
+            totalMessages metrics `shouldBe` 0
+            totalUnrouted metrics `shouldBe` 0
+
+        cover "RuntimeStats" emptyRuntimeStats $ \stats -> do
+            maxHeapSize stats `shouldBe` 0
+            currentHeapSize stats `shouldBe` 0
+            cpuTime stats `shouldBe` 0
+            gcCpuTime stats `shouldBe` 0
+
+        cover "DistributionStats" emptyDistributionStats $ \stats -> do
+            mean stats `shouldBe` 0
+            max stats `shouldBe` 0
+            min stats `shouldBe` 0
+
+--
+-- Helpers
+--
+
+cover :: (Eq a, Show a, ToJSON a) => String -> a -> (a -> Expectation) -> SpecWith ()
+cover lbl zero predicate =
+    specify (lbl <> " / " <> show zero <> " / " <> show (toJSON zero)) $
+        predicate zero >> shouldBe zero zero

--- a/server/test/unit/Ogmios/Data/MetricsSpec.hs
+++ b/server/test/unit/Ogmios/Data/MetricsSpec.hs
@@ -9,8 +9,6 @@ module Ogmios.Data.MetricsSpec
 import Ogmios.Prelude hiding
     ( max, min )
 
-import Data.Aeson
-    ( ToJSON (..) )
 import Ogmios.Data.Metrics
     ( DistributionStats (..)
     , Metrics (..)
@@ -20,12 +18,14 @@ import Ogmios.Data.Metrics
     , emptyRuntimeStats
     )
 import Test.Hspec
-    ( Expectation, Spec, SpecWith, context, parallel, shouldBe, specify )
+    ( Spec, context, parallel, shouldBe )
+import Test.Instances.Util
+    ( eqShowJson )
 
 spec :: Spec
 spec = parallel $ do
-    context "empty smart-constructors" $ do
-        cover "Metrics" emptyMetrics $ \metrics -> do
+    context "Eq/Show/Json" $ do
+        eqShowJson "Metrics" emptyMetrics $ \metrics -> do
             runtimeStats metrics `shouldBe` emptyRuntimeStats
             activeConnections metrics `shouldBe` 0
             totalConnections metrics `shouldBe` 0
@@ -33,22 +33,13 @@ spec = parallel $ do
             totalMessages metrics `shouldBe` 0
             totalUnrouted metrics `shouldBe` 0
 
-        cover "RuntimeStats" emptyRuntimeStats $ \stats -> do
+        eqShowJson "RuntimeStats" emptyRuntimeStats $ \stats -> do
             maxHeapSize stats `shouldBe` 0
             currentHeapSize stats `shouldBe` 0
             cpuTime stats `shouldBe` 0
             gcCpuTime stats `shouldBe` 0
 
-        cover "DistributionStats" emptyDistributionStats $ \stats -> do
+        eqShowJson "DistributionStats" emptyDistributionStats $ \stats -> do
             mean stats `shouldBe` 0
             max stats `shouldBe` 0
             min stats `shouldBe` 0
-
---
--- Helpers
---
-
-cover :: (Eq a, Show a, ToJSON a) => String -> a -> (a -> Expectation) -> SpecWith ()
-cover lbl zero predicate =
-    specify (lbl <> " / " <> show zero <> " / " <> show (toJSON zero)) $
-        predicate zero >> shouldBe zero zero

--- a/server/test/unit/Test/App/Protocol/Util.hs
+++ b/server/test/unit/Test/App/Protocol/Util.hs
@@ -42,7 +42,7 @@ import Ouroboros.Network.Channel
 import System.Random
     ( StdGen, mkStdGen )
 import Test.QuickCheck
-    ( Property, arbitrary )
+    ( Arbitrary (..), Property )
 import Test.QuickCheck.Monadic
     ( monadicIO, pick, run )
 

--- a/server/test/unit/Test/Generators.hs
+++ b/server/test/unit/Test/Generators.hs
@@ -84,13 +84,19 @@ import qualified Data.Aeson as Json
 import qualified Ouroboros.Network.Point as Point
 import qualified Shelley.Spec.Ledger.BlockChain as Spec
 
-genBlock :: Gen Block
-genBlock = reasonablySized $ oneof
+genBlock :: Bool -> Gen Block
+genBlock withAlonzo = reasonablySized $ oneof $
     [ BlockByron <$> arbitrary
     , BlockShelley <$> genBlockFrom @(ShelleyEra StandardCrypto)
     , BlockAllegra <$> genBlockFrom @(AllegraEra StandardCrypto)
     , BlockMary <$> genBlockFrom @(MaryEra StandardCrypto)
-    , BlockAlonzo <$> genBlockFrom @(AlonzoEra StandardCrypto)
+    ]
+    -- FIXME: Temporary. There's an issue with one of the CBOR decoder in an
+    -- Alonzo component. It doesn't roundtrip and make some of our test fail.
+    -- The issue has been reported to the core team, but in the meantime, we
+    -- selectively disable this one when needed.
+    ++
+    [ BlockAlonzo <$> genBlockFrom @(AlonzoEra StandardCrypto) | withAlonzo
     ]
   where
     genBlockFrom

--- a/server/test/unit/Test/Instances/Util.hs
+++ b/server/test/unit/Test/Instances/Util.hs
@@ -1,0 +1,21 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+module Test.Instances.Util
+    ( eqShowJson
+    ) where
+
+import Ogmios.Prelude
+
+import Data.Aeson
+    ( ToJSON (..) )
+import Test.Hspec
+    ( Expectation, SpecWith, shouldBe, specify )
+
+-- | Non-interesting test meant to tick coverage for Eq, Show and JSON
+-- instances, as well as record-fields.
+eqShowJson :: (Eq a, Show a, ToJSON a) => String -> a -> (a -> Expectation) -> SpecWith ()
+eqShowJson lbl a predicate =
+    specify (lbl <> " / " <> show a <> " / " <> show (toEncoding a)) $
+        predicate a >> shouldBe a a


### PR DESCRIPTION
- :round_pushpin: **Upgrade dependencies to latest cardano-node@1.28.0**
  
- :round_pushpin: **Temporarily disable Alonzo block generation for ChainSync test**
    see: https://github.com/input-output-hk/ouroboros-network/issues/3099

- :round_pushpin: **Start CHANGELOG for 4.0.0**
  
- :round_pushpin: **Update TypeScript client with 1.28's changes: new errors.**
  
- :round_pushpin: **Clean-up JSON definitions & TypeScript types / interfaces.**
    In particular:

  - `Tip` & `Point` have been renamed to `TipOrOrigin` and `PointOrOrigin`.
    As a consequence, `Tip1` and `Point1` are now simply `Tip` and `Point`.

  - Create a standalone definition for `Origin` and removed / replaced `Origin1`.

  - `SubmitTx` no-longer returns Byron errors. While this _is_ possible
    under some circumstances for privately set blockchain which would be
    running only the Byron era, it is not a use-case we're willing to
    support. Consequently, the TxSubmit errors are no-longer scoped
    under `errors.shelley` but simple `errors`.

  - Fixed `proposedProtocolParameters` query. All fields are actually
    required AND, more importantly, it can return either Shelley
    protocol parameters or, Alonzo protocol parameters.

- :round_pushpin: **Update CHANGELOG.**
