### PR TITLE
Documentation tweaks

### DIFF
--- a/docs/content/api-reference/_index.md
+++ b/docs/content/api-reference/_index.md
@@ -6,17 +6,17 @@ chapter = false
 pre = "<b>5. </b>"
 +++
 
-Ogmios as a JSON-WSP service is entirely described using [JSON Schema - Draft 7](https://json-schema.org/). This can be fed into various tools to generate code, data-types or definitions in many languages. In particular, the server schema can be visualized [here](http://localhost:1313/api/interfaces/_cardano_ogmios_schema.Ogmios.html). 
+Ogmios as a JSON-WSP service is entirely described using [JSON Schema - Draft 7](https://json-schema.org/). This can be fed into various tools to generate code, data-types or definitions in many languages. In particular, the server schema can be visualized [here](/api/interfaces/_cardano_ogmios_schema.Ogmios.html).
 
 {{% notice tip %}}
 The schema is large (200+ type definitions!) for it covers everything there's to cover in Cardano. If you get lost, look for the `Ogmios` object in the search bar to get back to the root of the schema!
 {{% /notice %}}
 
-If you're using TypeScript, take a look at the [API reference for the TypeScript client](http://localhost:1313/api/modules/_cardano_ogmios_client.html) or more specifically, documentation for one of the Ouroboros mini-protocols clients:
+If you're using TypeScript, take a look at the [API reference for the TypeScript client](/api/modules/_cardano_ogmios_client.html) or more specifically, documentation for one of the Ouroboros mini-protocols clients:
 
-- [ChainSync](http://localhost:1313/api/modules/_cardano_ogmios_client.html)
-- [StateQuery](http://localhost:1313/api/modules/_cardano_ogmios_client.StateQuery.html)
-- [TxSubmission](http://localhost:1313/api/modules/_cardano_ogmios_client.TxSubmission.html)
+- [ChainSync](/api/modules/_cardano_ogmios_client.ChainSync.html)
+- [StateQuery](/api/modules/_cardano_ogmios_client.StateQuery.html)
+- [TxSubmission](/api/modules/_cardano_ogmios_client.TxSubmission.html)
 
 {{% notice info %}}
 Ogmios is tested against this JSON schema to make sure that it remains up-to-date as new features are added.

--- a/docs/content/getting-started/building.md
+++ b/docs/content/getting-started/building.md
@@ -8,22 +8,22 @@ weight = 2
 You may **skip this section** if you're using **Docker 🐳.**
 {{% /notice %}}
 
-## Pre-requisites 
+## Pre-requisites
 
 Ogmios is built using the great Haskell build tool [stack](https://docs.haskellstack.org/en/stable/README/). You'll also need [git](https://git-scm.com/) to clone the source code, that is:
 - `git 2.11.*`
 - `stack 2.*.*`
 
-Ogmios in itself is a rather small project, yet it's using library directly from the ouroboros-network, cardano-ledger-specs and cardano-node projects. This is handy for re-using existing logic, but comes at the cost of several system dependencies that are required for building everything. Some may already be installed on your system, but the complete list is: 
+Ogmios in itself is a rather small project, yet it's using library directly from the ouroboros-network, cardano-ledger-specs and cardano-node projects. This is handy for re-using existing logic, but comes at the cost of several system dependencies that are required for building everything. Some may already be installed on your system, but the complete list is:
 
 - `libsodium-dev 1.0.*`
 - `libgmp-dev 6.1.*`
 - `libssl-dev 1.1.*`
 - `libpcre3-dev 2.8.*`
-- `libsystemd-dev` 
+- `libsystemd-dev`
 - `zlib1g-dev 1.2.*`
 
-## 🔨  Ogmios
+## 🔨 Server
 
 Clone the git repository from Github:
 
@@ -32,7 +32,7 @@ $ git clone --depth 1 --recursive --shallow-submodules git@github.com:cardanosol
 $ cd cardano-ogmios/server
 ```
 
-Then, use Stack to compile the project source code from the 'server' repository:
+Then, use Stack to compile the project source code from the `server` directory:
 
 ```console
 $ stack build ogmios
@@ -53,6 +53,24 @@ $ stack install ogmios
 $ ogmios --help
 ```
 
+## 🔨 TypeScript Client
+
+Clone the git repository from Github:
+
+```console
+$ git clone --depth 1 --recursive --shallow-submodules git@github.com:cardanosolutions/ogmios.git
+$ cd cardano-ogmios/clients/TypeScript
+```
+
+Then, use Yarn to install dependencies and compile the project source code from the
+`client/TypeScript` directory:
+
+```console
+$ yarn install && \
+yarn generate-schema-types && \
+yarn build
+```
+
 ## 📚 Documentation
 
 The documentation can be generated from the TypeScript client workbench. Follow the instruction in the README to setup the TypeScript workspace, and then run:
@@ -61,6 +79,6 @@ The documentation can be generated from the TypeScript client workbench. Follow 
 $ yarn docs
 ```
 
-This will generate documentation for the API and the TypeScript clients in `/docs/static` to be served by the static website generator [Hugo](https://gohugo.io/documentation/). 
+This will generate documentation for the API and the TypeScript clients in `/docs/static` to be served by the static website generator [Hugo](https://gohugo.io/documentation/).
 
 Alternatively, you can also look at our [User-Guide Github Workflow](https://github.com/CardanoSolutions/ogmios/blob/master/.github/workflows/user-guide.yaml#L18-L30) to see how its done.

--- a/docs/content/getting-started/building.md
+++ b/docs/content/getting-started/building.md
@@ -8,7 +8,7 @@ weight = 2
 You may **skip this section** if you're using **Docker 🐳.**
 {{% /notice %}}
 
-## Pre-requisites
+## Pre-requisites (Server)
 
 Ogmios is built using the great Haskell build tool [stack](https://docs.haskellstack.org/en/stable/README/). You'll also need [git](https://git-scm.com/) to clone the source code, that is:
 - `git 2.11.*`
@@ -66,9 +66,9 @@ Then, use Yarn to install dependencies and compile the project source code from 
 `client/TypeScript` directory:
 
 ```console
-$ yarn install && \
-yarn generate-schema-types && \
-yarn build
+$ yarn install \ 
+  && yarn generate-schema-types \
+  && yarn build
 ```
 
 ## 📚 Documentation

--- a/docs/content/typescript-client/chain-sync.md
+++ b/docs/content/typescript-client/chain-sync.md
@@ -10,7 +10,7 @@ The ChainSync client streams block from the network, one-by-one in the form of e
 - on `rollBackward`, to process rollback requests to a previous point of your local chain.
 
 {{% notice tip %}}
-These callbacks are captured via the [ChainSyncMessageHandlers](http://localhost:1313/api/interfaces/_cardano_ogmios_client.ChainSync.ChainSyncMessageHandlers.html) interface.
+These callbacks are captured via the [ChainSyncMessageHandlers](/api/interfaces/_cardano_ogmios_client.ChainSync.ChainSyncMessageHandlers.html) interface.
 {{% /notice %}}
 
 For example, you can store blocks into a _database_ (assuming some high-level `db` interface) as follows:

--- a/docs/content/typescript-client/chain-sync.md
+++ b/docs/content/typescript-client/chain-sync.md
@@ -4,15 +4,13 @@ chapter = false
 weight = 2
 +++
 
-## ChainSyncClient
-
 The ChainSync client streams block from the network, one-by-one in the form of events. Creating such a client requires your application to register two callbacks:
 
 - on `rollForward`, to process new blocks coming in and advancing your local chain.
 - on `rollBackward`, to process rollback requests to a previous point of your local chain.
 
 {{% notice tip %}}
-These callbacks are captured via the [ChainSyncMessageHandlers](http://localhost:1313/api/interfaces/_cardano_ogmios_client.ChainSync.ChainSyncMessageHandlers.html) interface. 
+These callbacks are captured via the [ChainSyncMessageHandlers](http://localhost:1313/api/interfaces/_cardano_ogmios_client.ChainSync.ChainSyncMessageHandlers.html) interface.
 {{% /notice %}}
 
 For example, you can store blocks into a _database_ (assuming some high-level `db` interface) as follows:
@@ -42,14 +40,14 @@ await client.shutdown()
 
 Notice how the callback also includes a continuation `requestNext` which commands the server to send the next block. For more details about the chain-sync mini-protocol, have a look at [the protocol documentation itself](mini-protocols/local-chain-sync/).
 
-Once created, the client offers two methods `startSync` and `shutdown`. As a matter of fact, the client does not start syncing automatically. This allows you to specify a starting point if necessary (in case your application is resuming from a previous state). This is optional and by default the client will synchronize from the node's tip and onward. 
+Once created, the client offers two methods `startSync` and `shutdown`. As a matter of fact, the client does not start syncing automatically. This allows you to specify a starting point if necessary (in case your application is resuming from a previous state). This is optional and by default the client will synchronize from the node's tip and onward.
 
 ### Concurrent vs sequential
 
-By default, the client will send requests and process requests _sequentially_ for it is more intuitive. However, some applications may not necessarily bother about sequentiality and may process messages in any order. This behavior can hence by changed by providing an extra option to `createChainSyncClient`: 
+By default, the client will send requests and process requests _sequentially_ for it is more intuitive. However, some applications may not necessarily bother about sequentiality and may process messages in any order. This behavior can hence by changed by providing an extra option to `createChainSyncClient`:
 
 ```ts
 const client = await createChainSyncClient(context, callbacks, { sequential: false })
 ```
 
-When `sequential` is set to `false`, the order in which message callbacks are resolved depends on the JavaScript runtime and whether or not your are making concurrent requests. 
+When `sequential` is set to `false`, the order in which message callbacks are resolved depends on the JavaScript runtime and whether or not your are making concurrent requests.

--- a/docs/content/typescript-client/state-query.md
+++ b/docs/content/typescript-client/state-query.md
@@ -4,8 +4,6 @@ chapter = false
 weight = 3
 +++
 
-## StateQueryClient
-
 The StateQuery client allows you to play with the [Local State Query](/mini-protocols/local-state-query) mini protocol; that is, a protocol for querying parts of the ledger state. The complete set of queries is described in [the documentation](#TODO). To use it, create a client from a context and start querying!
 
 ```ts
@@ -13,7 +11,7 @@ import { createStateQueryClient } from '@cardano-ogmios/client'
 
 const client = await createStateQueryClient(context)
 
-console.log(`ledgerTip: ${(await client.ledgerTip()).tip}`) 
+console.log(`ledgerTip: ${(await client.ledgerTip()).tip}`)
 // ledgerTip: {"slot":33055551,"hash":"050b05030645fdc4ee10e81f131030049c08f7763355873564540fe5a0533f43"}
 
 console.log(`currentEpoch: ${await client.currentEpoch()}`)
@@ -24,7 +22,7 @@ await client.shutdown() // Close the connection when done.
 
 ### Acquire a specific point
 
-By default, the client will acquire the current tip of the blockchain and **run all subsequent queries** from that point. This makes it possible to get somewhat consistent data when running multiple queries. You can specify which point you want to acquire by providing an extra argument when constructing the client. 
+By default, the client will acquire the current tip of the blockchain and **run all subsequent queries** from that point. This makes it possible to get somewhat consistent data when running multiple queries. You can specify which point you want to acquire by providing an extra argument when constructing the client.
 
 For example (notice how the `ledgerTip` remains unchanged, and equal to the acquired point!):
 
@@ -38,15 +36,15 @@ const point = {
 }
 const client = await createStateQueryClient(context, { point })
 
-console.log(`ledgerTip: ${await client.ledgerTip().tip}`) 
+console.log(`ledgerTip: ${await client.ledgerTip().tip}`)
 // ledgerTip: {"slot":33055551,"hash":"050b05030645fdc4ee10e81f131030049c08f7763355873564540fe5a0533f43"}
 
 delay(5000)
 
-console.log(`ledgerTip: ${await client.ledgerTip().tip}`) 
+console.log(`ledgerTip: ${await client.ledgerTip().tip}`)
 // ledgerTip: {"slot":33055551,"hash":"050b05030645fdc4ee10e81f131030049c08f7763355873564540fe5a0533f43"}
 ```
 
 {{% notice info %}}
-You cannot acquire points that are _too old_ on the blockchain. Too old may be a bit tricky to define but a good rule of thumb is: anything older than 64800 slots is too old (i.e. `3k/f`). 
+You cannot acquire points that are _too old_ on the blockchain. Too old may be a bit tricky to define but a good rule of thumb is: anything older than 64800 slots is too old (i.e. `3k/f`).
 {{% /notice %}}

--- a/docs/content/typescript-client/tx-submission.md
+++ b/docs/content/typescript-client/tx-submission.md
@@ -4,23 +4,21 @@ chapter = false
 weight = 4
 +++
 
-## TxSubmissionClient
-
 Similarly to the other two clients, a [`TxSubmissionClient`](http://localhost:1313/api/interfaces/_cardano_ogmios_client.TxSubmission.TxSubmissionClient.html) can be created from an [`InteractionContext`](http://localhost:1313/api/interfaces/_cardano_ogmios_client.InteractionContext.html) (see the [Overview](/typescript-client/overview) section for more details).
 
-Once created, it allows for submitting already serialized transactions to the network. The format it accepts is a CBOR-serialized Cardano transaction, as obtained from the cardano-cli or 
-the [cardano-serialization-lib](https://github.com/Emurgo/cardano-serialization-lib), in either `base16` or `base64`. 
+Once created, it allows for submitting already serialized transactions to the network. The format it accepts is a CBOR-serialized Cardano transaction, as obtained from the cardano-cli or
+the [cardano-serialization-lib](https://github.com/Emurgo/cardano-serialization-lib), in either `base16` or `base64`.
 
 In case of success, the transaction is submitted to the network and should eventually be inserted in the ledger. Submitting transactions through Ogmios does indeed give you strong guarantees since behind the scene, the transaction gets fully validated by a Cardano node which has its own ledger. In case of error, the transaction is rejected with one of the many error causes in Cardano. You can find all the possible errors in the [API reference](http://localhost:1313/api/modules/_cardano_ogmios_client.TxSubmission.html#SubmitTxErrorShelley).
 
 Errors are also conveniently exported from the client so that it is easy to assert the type of an error response. For example:
 
-```ts 
+```ts
 import { createTxSubmissionClient, TxSubmission } from '@cardano-ogmios/client'
 
 const client = await createTxSubmissionClient(context)
 
-try { 
+try {
   await client.submitTx(toCBOR(tx))
 } catch (error) {
   await expect(error[0]).toBeInstanceOf(TxSubmission.errors.BadInputs.Error)

--- a/docs/content/typescript-client/tx-submission.md
+++ b/docs/content/typescript-client/tx-submission.md
@@ -4,12 +4,12 @@ chapter = false
 weight = 4
 +++
 
-Similarly to the other two clients, a [`TxSubmissionClient`](http://localhost:1313/api/interfaces/_cardano_ogmios_client.TxSubmission.TxSubmissionClient.html) can be created from an [`InteractionContext`](http://localhost:1313/api/interfaces/_cardano_ogmios_client.InteractionContext.html) (see the [Overview](/typescript-client/overview) section for more details).
+Similarly to the other two clients, a [`TxSubmissionClient`](/api/interfaces/_cardano_ogmios_client.TxSubmission.TxSubmissionClient.html) can be created from an [`InteractionContext`](/api/interfaces/_cardano_ogmios_client.InteractionContext.html) (see the [Overview](/typescript-client/overview) section for more details).
 
 Once created, it allows for submitting already serialized transactions to the network. The format it accepts is a CBOR-serialized Cardano transaction, as obtained from the cardano-cli or
 the [cardano-serialization-lib](https://github.com/Emurgo/cardano-serialization-lib), in either `base16` or `base64`.
 
-In case of success, the transaction is submitted to the network and should eventually be inserted in the ledger. Submitting transactions through Ogmios does indeed give you strong guarantees since behind the scene, the transaction gets fully validated by a Cardano node which has its own ledger. In case of error, the transaction is rejected with one of the many error causes in Cardano. You can find all the possible errors in the [API reference](http://localhost:1313/api/modules/_cardano_ogmios_client.TxSubmission.html#SubmitTxErrorShelley).
+In case of success, the transaction is submitted to the network and should eventually be inserted in the ledger. Submitting transactions through Ogmios does indeed give you strong guarantees since behind the scene, the transaction gets fully validated by a Cardano node which has its own ledger. In case of error, the transaction is rejected with one of the many error causes in Cardano. You can find all the possible errors in the [API reference](/api/modules/_cardano_ogmios_client.TxSubmission.html#SubmitTxErrorShelley).
 
 Errors are also conveniently exported from the client so that it is easy to assert the type of an error response. For example:
 


### PR DESCRIPTION
**:pushpin: docs: Remove duplicate headings in TypeScript client docs**
Also removes illegal whitespace

**:pushpin: docs: Add client build instructions to getting started docs**

**:pushpin: Use relative links for TypeScript client and API reference docs**

@KtorZ  The last commit is untested, and probably only partially resolving the issue as it looks like the index page link structure doesn't match the hugo output. See inline comment

Closes #92 #93
