### PR TITLE
chore: bump cardano-node and config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ pre: "<b>6. </b>"
 
 #### Added
 
-- Integrated with the Cardano eco-system corresponding to cardano-node@1.28.0 & latest testnet (alonzo-purple). Bumped the docker-compose installation accordingly.
+- Integrated with the Cardano eco-system corresponding to cardano-node@1.29.0 & latest testnet
+  (alonzo-purple). Bumped the docker-compose installation accordingly.
 
 - New possible errors from the transaction submission:
   - `collateralHasNonAdaAssets`

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 #                                                                              #
 
 FROM haskell:8.10.4 as setup
-ARG CARDANO_NODE_REV=alonzo-purple-1.0.1
+ARG CARDANO_NODE_REV=1.29.0-rc2
 ARG IOHK_LIBSODIUM_GIT_REV=66f017f16633f2060db25e17c170c2afa0f2a8a1
 WORKDIR /build
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:alonzo-purple-1.0
+    image: inputoutput/cardano-node:1.29.0-rc2
     command: [
       "run",
       "--config", "/config/config.json",


### PR DESCRIPTION
Updates the latest node RC and config. _alonzo-qa_ and _alonzo-purple_ were re-spun on 2021-08-21

https://github.com/input-output-hk/cardano-node/compare/alonzo-purple-1.0.2...1.29.0-rc2