### PR TITLE
ci: fix TypeScript schema generation in CI

### DIFF
--- a/clients/TypeScript/packages/schema/package.json
+++ b/clients/TypeScript/packages/schema/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "tsc --build ./src",
     "cleanup": "shx rm -rf dist node_modules index.ts",
-    "generate-schema-types": "json2ts -i $INIT_CWD/../../server/ogmios.wsp.json -o src/index.ts --enableBigInt",
+    "generate-schema-types": "json2ts -i ../../../../server/ogmios.wsp.json -o src/index.ts --enableBigInt",
     "lint": "shx echo No code to lint in this package",
     "prepack": "yarn generate-schema-types && yarn build",
     "test": "shx echo No tests in this package"


### PR DESCRIPTION
The use of the `INIT_CWD` env in the npm script is unnecessary for development,
and breaks CI. This was a carry-over from another project where context was more tricky,
although I do not recall exactly why this approach was taken.

https://github.com/CardanoSolutions/ogmios/runs/3329401416?check_suite_focus=true