### PR TITLE
Re-acquire state query points

### DIFF
--- a/clients/TypeScript/packages/client/test/StateQuery.test.ts
+++ b/clients/TypeScript/packages/client/test/StateQuery.test.ts
@@ -16,7 +16,6 @@ import {
 import {
   DelegationsAndRewards,
   Hash16,
-  Point,
   Slot
 } from '@cardano-ogmios/schema'
 import { dummyInteractionContext } from './util'
@@ -44,13 +43,24 @@ describe('Local state queries', () => {
       const context = await dummyInteractionContext()
       const tip = await ledgerTip(context)
       delay(2000)
-      const clientA = await createStateQueryClient(context, { point: tip as Point })
-      const clientB = await createStateQueryClient(context, { point: tip as Point })
+      const clientA = await createStateQueryClient(context, { point: tip })
+      const clientB = await createStateQueryClient(context, { point: tip })
       const tipA = await clientA.ledgerTip()
       const tipB = await clientB.ledgerTip()
       expect(tip).toEqual(tipA)
       expect(tip).toEqual(tipB)
       await context.socket.close()
+    })
+
+    it('can acquire / re-acquire after a client is created', async () => {
+      const context = await dummyInteractionContext()
+      const client = await createStateQueryClient(context)
+      const tip = await client.ledgerTip()
+      delay(2000)
+      await client.acquire(tip)
+      const tipAgain = await client.ledgerTip()
+      expect(tip).toEqual(tipAgain)
+      await client.shutdown()
     })
 
     it('rejects if the provided point is too old', async () => {


### PR DESCRIPTION
- :round_pushpin: **Change state query client setup to not acquire when no point is provided.**
    Behind the scene, the server will automatically acquire the most recent tip and run the query for that point. This however exposes clients to race conditions should they make multiple queries one after the other and expect them to be consistent.

- :round_pushpin: **Allow state query client to re-acquire points when necessary.**

Fixes #90