### PR TITLE
Handle client faults in the TypeScript StateQueryClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ chapter: false
 pre: "<b>6. </b>"
 ---
 
+### [4.0.1] - 2021-09-08
+
+#### Added
+
+N/A
+
+#### Changed
+
+- The TypeScript `StateQueryClient` now wraps every query in a try/catch to cope with malformed queries leading to client `fault` results from the server.
+
+#### Removed
+
+N/A
+
+
 ### [4.0.0] - 2021-09-06
 
 #### Added

--- a/clients/TypeScript/packages/client/src/StateQuery/queries/delegationsAndRewards.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/queries/delegationsAndRewards.ts
@@ -37,20 +37,16 @@ export const delegationsAndRewards = (
     }
   }, {
     handler: (response, resolve, reject) => {
-      try {
-        if (response.result === 'QueryUnavailableInCurrentEra') {
-          return reject(new QueryUnavailableInCurrentEraError('delegationsAndRewards'))
-        } else if (isEraMismatch(response.result)) {
-          const { eraMismatch } = response.result
-          const { ledgerEra, queryEra } = eraMismatch
-          return reject(new EraMismatchError(queryEra, ledgerEra))
-        } else if (isDelegationsAndRewardsByAccounts(response.result)) {
-          return resolve(response.result)
-        } else {
-          return reject(new UnknownResultError(response.result))
-        }
-      } catch (e) {
-        return reject(new UnknownResultError(e))
+      if (response.result === 'QueryUnavailableInCurrentEra') {
+        return reject(new QueryUnavailableInCurrentEraError('delegationsAndRewards'))
+      } else if (isEraMismatch(response.result)) {
+        const { eraMismatch } = response.result
+        const { ledgerEra, queryEra } = eraMismatch
+        return reject(new EraMismatchError(queryEra, ledgerEra))
+      } else if (isDelegationsAndRewardsByAccounts(response.result)) {
+        return resolve(response.result)
+      } else {
+        return reject(new UnknownResultError(response.result))
       }
     }
   }, context)

--- a/clients/TypeScript/packages/client/src/StateQuery/queries/delegationsAndRewards.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/queries/delegationsAndRewards.ts
@@ -37,16 +37,20 @@ export const delegationsAndRewards = (
     }
   }, {
     handler: (response, resolve, reject) => {
-      if (response.result === 'QueryUnavailableInCurrentEra') {
-        return reject(new QueryUnavailableInCurrentEraError('delegationsAndRewards'))
-      } else if (isEraMismatch(response.result)) {
-        const { eraMismatch } = response.result
-        const { ledgerEra, queryEra } = eraMismatch
-        return reject(new EraMismatchError(queryEra, ledgerEra))
-      } else if (isDelegationsAndRewardsByAccounts(response.result)) {
-        return resolve(response.result)
-      } else {
-        return reject(new UnknownResultError(response.result))
+      try {
+        if (response.result === 'QueryUnavailableInCurrentEra') {
+          return reject(new QueryUnavailableInCurrentEraError('delegationsAndRewards'))
+        } else if (isEraMismatch(response.result)) {
+          const { eraMismatch } = response.result
+          const { ledgerEra, queryEra } = eraMismatch
+          return reject(new EraMismatchError(queryEra, ledgerEra))
+        } else if (isDelegationsAndRewardsByAccounts(response.result)) {
+          return resolve(response.result)
+        } else {
+          return reject(new UnknownResultError(response.result))
+        }
+      } catch (e) {
+        return reject(new UnknownResultError(e))
       }
     }
   }, context)

--- a/clients/TypeScript/packages/client/test/StateQuery.test.ts
+++ b/clients/TypeScript/packages/client/test/StateQuery.test.ts
@@ -1,4 +1,5 @@
 import {
+  UnknownResultError,
   createStateQueryClient,
   currentEpoch,
   currentProtocolParameters,
@@ -176,6 +177,10 @@ describe('Local state queries', () => {
         const item = result[stakeKeyHashes[0]] as DelegationsAndRewards
         expect(item).toHaveProperty('delegate')
         expect(item).toHaveProperty('rewards')
+      })
+      it('returns an error when given a malformed key hash', () => {
+        const notKeyHashes = ['patate'] as Hash16[]
+        expect(delegationsAndRewards(context, notKeyHashes)).rejects.toBeInstanceOf(UnknownResultError)
       })
     })
     describe('eraStart', () => {


### PR DESCRIPTION
Motivation: When you enter an invalid stake address to delegationsAndRewards API endpoint, the function fails on

(node:267433) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'eraMismatch' of undefined
at isEraMismatch (node_modules/@cardano-ogmios/client/src/StateQuery/queries/delegationsAndRewards.ts:16:9)
    at Object.handler (node_modules/@cardano-ogmios/client/src/StateQuery/queries/delegationsAndRewards.ts:46:8)

and never finishes. This fix provides at least a rejection instead of neverending await.