### PR TITLE
fix: address floating promises

### DIFF
--- a/clients/TypeScript/.eslintrc.js
+++ b/clients/TypeScript/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
       "unix"
     ],
     "no-unused-expressions": 0,
-    "no-useless-constructor": 0
+    "no-useless-constructor": 0,
+    "@typescript-eslint/no-floating-promises": 1
   }
 }

--- a/clients/TypeScript/packages/client/src/ChainSync/ChainSyncClient.ts
+++ b/clients/TypeScript/packages/client/src/ChainSync/ChainSyncClient.ts
@@ -68,10 +68,14 @@ export const createChainSyncClient = async (
     const responseHandler = options?.sequential !== false
       ? fastq.promise(messageHandler, 1).push
       : messageHandler
-    socket.on('message', (message: string) => {
+    socket.on('message', async (message: string) => {
       const response: Ogmios['RequestNextResponse'] = safeJSON.parse(message)
       if (response.methodname === 'RequestNext') {
-        responseHandler(response)
+        try {
+          await responseHandler(response)
+        } catch (error) {
+          console.error(error)
+        }
       }
     })
     return resolve({

--- a/clients/TypeScript/packages/client/test/Connection.test.ts
+++ b/clients/TypeScript/packages/client/test/Connection.test.ts
@@ -128,7 +128,7 @@ describe('Connection', () => {
           await context.socket.close()
         }
       } catch (error) {
-        expect(error.code).toMatch(/EAI_AGAIN|ENOTFOUND/)
+        await expect(error.code).toMatch(/EAI_AGAIN|ENOTFOUND/)
       }
       try {
         context = await createInteractionContext(

--- a/clients/TypeScript/packages/client/test/ServerHealth.test.ts
+++ b/clients/TypeScript/packages/client/test/ServerHealth.test.ts
@@ -30,7 +30,7 @@ describe('ServerHealth', () => {
         const connection = createConnectionObject({ host: 'non-existent' })
         await getServerHealth(connection)
       } catch (error) {
-        expect(error.code).toMatch(/EAI_AGAIN|ENOTFOUND/)
+        await expect(error.code).toMatch(/EAI_AGAIN|ENOTFOUND/)
       }
     })
   })

--- a/clients/TypeScript/packages/client/test/StateQuery.test.ts
+++ b/clients/TypeScript/packages/client/test/StateQuery.test.ts
@@ -45,7 +45,7 @@ describe('Local state queries', () => {
     it('uses the provided point for reproducible queries across clients', async () => {
       const context = await dummyInteractionContext()
       const tip = await ledgerTip(context)
-      delay(2000)
+      await delay(2000)
       const clientA = await createStateQueryClient(context, { point: tip })
       const clientB = await createStateQueryClient(context, { point: tip })
       const tipA = await clientA.ledgerTip()
@@ -59,7 +59,7 @@ describe('Local state queries', () => {
       const context = await dummyInteractionContext()
       const client = await createStateQueryClient(context)
       const tip = await client.ledgerTip()
-      delay(2000)
+      await delay(2000)
       await client.acquire(tip)
       const tipAgain = await client.ledgerTip()
       expect(tip).toEqual(tipAgain)
@@ -178,9 +178,9 @@ describe('Local state queries', () => {
         expect(item).toHaveProperty('delegate')
         expect(item).toHaveProperty('rewards')
       })
-      it('returns an error when given a malformed key hash', () => {
+      it('returns an error when given a malformed key hash', async () => {
         const notKeyHashes = ['patate'] as Hash16[]
-        expect(delegationsAndRewards(context, notKeyHashes)).rejects.toBeInstanceOf(UnknownResultError)
+        await expect(delegationsAndRewards(context, notKeyHashes)).rejects.toBeInstanceOf(UnknownResultError)
       })
     })
     describe('eraStart', () => {

--- a/clients/TypeScript/packages/client/test/TxSubmission.test.ts
+++ b/clients/TypeScript/packages/client/test/TxSubmission.test.ts
@@ -17,7 +17,7 @@ describe('TxSubmission', () => {
         await createTxSubmissionClient(context)
         // expect(client).toBeUndefined()
       } catch (error) {
-        expect(error.code).toMatch(/EAI_AGAIN|ENOTFOUND/)
+        await expect(error.code).toMatch(/EAI_AGAIN|ENOTFOUND/)
       }
       try {
         const context = await dummyInteractionContext('LongRunning', { port: 1111 })

--- a/clients/TypeScript/packages/repl/src/index.ts
+++ b/clients/TypeScript/packages/repl/src/index.ts
@@ -79,4 +79,7 @@ const logObject = (obj: Object) =>
     ])
     process.exit(1)
   })
-})()
+})().catch((error) => {
+  console.log(error)
+  process.exit(1)
+})


### PR DESCRIPTION
In an attempt to narrow #120 I discovered we have a few floating promises. This doesn't appear to touch the code of interest, so is unlikely to change much there, but it should improve the reliability of tests given the `delay`s were not being awaited.