### PR TITLE
Feat/client TS abstract logger

### DIFF
--- a/clients/TypeScript/packages/client/package.json
+++ b/clients/TypeScript/packages/client/package.json
@@ -59,6 +59,7 @@
     "isomorphic-ws": "^4.0.1",
     "nanoid": "^3.1.22",
     "ts-custom-error": "^3.2.0",
+    "ts-log": "^2.2.3",
     "ws": "^7.4.6"
   },
   "files": [

--- a/clients/TypeScript/packages/client/src/Request.ts
+++ b/clients/TypeScript/packages/client/src/Request.ts
@@ -1,5 +1,6 @@
 import { WebSocket } from './IsomorphicWebSocket'
 import { InteractionContext } from './Connection'
+import { loadLogger, Logger } from './logger'
 
 /** @internal */
 export const baseRequest = {
@@ -11,12 +12,20 @@ export const baseRequest = {
 /** @internal */
 export const send = async <T>(
   send: (socket: WebSocket) => Promise<T>,
-  context: InteractionContext
+  context: InteractionContext,
+  options?: {
+    logger?: Logger
+  }
 ): Promise<T> => {
   const { socket, afterEach } = context
   return new Promise((resolve, reject) => {
+    const logger = loadLogger('send', options?.logger)
+    logger.debug('Sending...')
     send(socket)
-      .then(result => afterEach(resolve.bind(this, result)))
+      .then(result => {
+        logger.debug({ result })
+        afterEach(resolve.bind(this, result))
+      })
       .catch(error => afterEach(reject.bind(this, error)))
   })
 }

--- a/clients/TypeScript/packages/client/src/ServerHealth.ts
+++ b/clients/TypeScript/packages/client/src/ServerHealth.ts
@@ -1,6 +1,7 @@
 import fetch from 'cross-fetch'
 import { Connection } from './Connection'
 import { Tip } from '@cardano-ogmios/schema'
+import { loadLogger, Logger } from './logger'
 
 /**
  * Captures the health of the server, including metrics and synchronization progress.
@@ -51,10 +52,15 @@ export interface ServerHealth {
  * @category Connection
  */
 export const getServerHealth = async (
-  connection: Connection
+  connection: Connection,
+  options?: {
+    logger?: Logger
+  }
 ): Promise<ServerHealth> => {
+  const logger = loadLogger('ServerHealth', options?.logger)
   const response = await fetch(`${connection.address.http}/health`)
   const responseJson = await response.json()
+  logger.debug({ response: responseJson })
   if (response.ok) {
     return responseJson
   } else {

--- a/clients/TypeScript/packages/client/src/ServerHealth.ts
+++ b/clients/TypeScript/packages/client/src/ServerHealth.ts
@@ -59,10 +59,10 @@ export const getServerHealth = async (
 ): Promise<ServerHealth> => {
   const logger = loadLogger('ServerHealth', options?.logger)
   const response = await fetch(`${connection.address.http}/health`)
-  const responseJson = await response.json()
-  logger.debug({ response: responseJson })
+  const health = await response.json()
+  logger.debug({ health })
   if (response.ok) {
-    return responseJson
+    return health
   } else {
     throw new Error(response.statusText)
   }

--- a/clients/TypeScript/packages/client/src/ServerHealth.ts
+++ b/clients/TypeScript/packages/client/src/ServerHealth.ts
@@ -51,7 +51,7 @@ export interface ServerHealth {
  * @category Connection
  */
 export const getServerHealth = async (
-  connection?: Connection
+  connection: Connection
 ): Promise<ServerHealth> => {
   const response = await fetch(`${connection.address.http}/health`)
   const responseJson = await response.json()

--- a/clients/TypeScript/packages/client/src/logger.ts
+++ b/clients/TypeScript/packages/client/src/logger.ts
@@ -1,0 +1,24 @@
+import { dummyLogger, Logger as TsLogger } from 'ts-log'
+import util from 'util'
+
+export type Logger = TsLogger
+
+/** @internal */
+export const loadLogger = (context: string, logger?: Logger): Logger => {
+  if (logger === undefined) return dummyLogger
+  const methodNames = ['debug', 'error', 'info', 'trace', 'warn'] as (keyof Logger)[]
+  return <Logger>(
+    (<unknown>(
+      Object.fromEntries(
+        methodNames.map((method) => [
+          method,
+          (message: string, ...optionalParams: any[]) =>
+            logger[method](
+              util.inspect({ context, ...optionalParams }, false, null, true),
+              message
+            )
+        ])
+      )
+    ))
+  )
+}

--- a/clients/TypeScript/packages/client/test/Connection.test.ts
+++ b/clients/TypeScript/packages/client/test/Connection.test.ts
@@ -3,6 +3,7 @@ import {
   createConnectionObject,
   InteractionContext
 } from '../src'
+import { dummyLogger } from 'ts-log'
 
 describe('Connection', () => {
   describe('createConnectionObject', () => {
@@ -151,6 +152,18 @@ describe('Connection', () => {
       } catch (error) {
         expect(error.code).toBe('ECONNREFUSED')
       }
+    })
+
+    it('implements an abstract logger compatible with console', async () => {
+      const spy = jest.spyOn(dummyLogger, 'debug')
+      await createInteractionContext(
+        (error) => console.error(error),
+        () => {
+        },
+        { connection: { port: 1338 }, logger: dummyLogger }
+      )
+      expect(spy).toHaveBeenCalled()
+      spy.mockClear()
     })
     // describe('connecting before the node socket is ready', () => {
     //   // Todo: Implement https://github.com/mswjs/msw to return required health to trigger this

--- a/clients/TypeScript/packages/client/test/ServerHealth.test.ts
+++ b/clients/TypeScript/packages/client/test/ServerHealth.test.ts
@@ -1,3 +1,4 @@
+import { dummyLogger } from 'ts-log'
 import { createConnectionObject, getServerHealth } from '../src'
 
 const expectHealth = (obj: any): void => {
@@ -19,6 +20,13 @@ describe('ServerHealth', () => {
     // it('fetches the service metadata using default connection config by default', async () => {
     //   expectHealth(await getServerHealth())
     // })
+    it('implements an abstract logger compatible with console', async () => {
+      const spy = jest.spyOn(dummyLogger, 'debug')
+      const connection = createConnectionObject({ port: 1338 })
+      await getServerHealth(connection, { logger: dummyLogger })
+      expect(spy).toHaveBeenCalled()
+      spy.mockClear()
+    })
     it('fetches the service metadata', async () => {
       const connection = createConnectionObject({ port: 1338 })
       expectHealth(await getServerHealth(connection))

--- a/clients/TypeScript/packages/client/test/StateQuery/StateQuery.test.ts
+++ b/clients/TypeScript/packages/client/test/StateQuery/StateQuery.test.ts
@@ -219,10 +219,11 @@ describe('Local state queries', () => {
       })
     })
     describe('utxo', () => {
-      it('fetches the complete UTxO set when an empty array is provided', async () => {
-        const utxoSet = await StateQuery.utxo(context, [])
-        expect(utxoSet[0]).toBeDefined()
-      })
+      // This is an impractical query to run.
+      // it('fetches the complete UTxO set when an empty array is provided', async () => {
+      //   const utxoSet = await StateQuery.utxo(context, [])
+      //   expect(utxoSet[0]).toBeDefined()
+      // })
       it('fetches the UTxO for the given addresses', async () => {
         const utxoSet = await StateQuery.utxo(context, ['addr_test1qqymtheun4y437fa6cms4jmtfex39wzz7jfwggudwnqkdnr8udjk6d89dcjadt7tw6hmz0aeue2jzdpl2vnkz8wdk4fqz3y5m9'])
         expect(utxoSet[0]).toBeDefined()

--- a/clients/TypeScript/tsconfig.json
+++ b/clients/TypeScript/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2020",
     "esModuleInterop": true,
     "declaration": true,
     "declarationMap": true,

--- a/clients/TypeScript/yarn.lock
+++ b/clients/TypeScript/yarn.lock
@@ -5811,6 +5811,11 @@ ts-jest@^26.5.3:
     semver "7.x"
     yargs-parser "20.x"
 
+ts-log@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/ts-log/-/ts-log-2.2.3.tgz#4da5640fe25a9fb52642cd32391c886721318efb"
+  integrity sha512-XvB+OdKSJ708Dmf9ore4Uf/q62AYDTzFcAdxc8KNML1mmAWywRFVt/dn1KYJH8Agt5UJNujfM3znU5PxgAzA2w==
+
 tsconfig-paths@^3.11.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz#954c1fe973da6339c78e06b03ce2e48810b65f36"


### PR DESCRIPTION
Closes #69

:pushpin: **test: disable impractical unbounded utxo test**
This is a valid query based on the Ouroboros mini-protocol, however as it lacks batching, the unbounded invocation is impractical for larger networks. Disabling here since we're using the `testnet`.

:pushpin: **fix: getServerHealth connection param**
Connection param for `getServerHealth` is now required, reflecting
the function's dependency on the value being passed in. While the
interface is changing, it's actually better considered a fix since
omitting the argument would throw an error.

:pushpin: **feat: client TypeScript abstract logging**
Introduces an abstract logger compatible with `console` or more sophisticated
loggers such as bunyan, with the default operation being silent. Relevant
interfaces now accept an optional logger argument.

_Draft until I've done an integration to get a feel for logging points given this is a subjective issue._ 