### PR TITLE
Improve JSON schema definitions of base16 and base64 encoded strings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,12 @@ pre: "<b>6. </b>"
 > - ⚠️ Serialised Plutus scripts are now labelled either `plutus:v1` or `plutus:v2` (instead of `plutus`).
 >
 > - Upgraded internal dependencies to Cardano eco-system 1.31.0
->
+> 
 > ##### 🚗 TypeScript Client
 >
 > - ⚠️ `getServerHealth`'s `connection` argument is now wrapped into an object, mapped to the field `connection`. (see [#135](https://github.com/CardanoSolutions/ogmios/issues/135))
+>
+> - ⚠️ Replaced schema definitions for `Hash16` and `Hash64` with more precise type definitions. For hashes, definitions now follows a convention `Digest[ALGORITHM]::PRE-IMAGE` where `ALGORITHM` and `PRE-IMAGE` points to the corresponding has algorithm used to hash the `PRE-IMAGE`. The length of the digest is given by `minLength` and `maxLength` JSON-schema constraints. Consequently, TypeScript types / interfaces generated from the JSON-schema definitions have been altered. 
 
 #### Removed
 

--- a/clients/TypeScript/package.json
+++ b/clients/TypeScript/package.json
@@ -7,7 +7,9 @@
     "node": "^14"
   },
   "workspaces": [
-    "packages/*"
+    "packages/schema",
+    "packages/client",
+    "packages/repl"
   ],
   "main": "dist/index.js",
   "repository": "https://github.com/cardanosolutions/ogmios",

--- a/clients/TypeScript/packages/client/src/StateQuery/StateQueryClient.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/StateQueryClient.ts
@@ -1,7 +1,7 @@
 import { nanoid } from 'nanoid'
 import {
   Address,
-  Hash16,
+  DigestBlake2BCredential,
   Lovelace,
   Ogmios,
   PointOrOrigin,
@@ -50,11 +50,11 @@ export interface StateQueryClient {
   chainTip: () => ReturnType<typeof chainTip>
   currentEpoch: () => ReturnType<typeof currentEpoch>
   currentProtocolParameters: () => ReturnType<typeof currentProtocolParameters>
-  delegationsAndRewards: (stakeKeyHashes: Hash16[]) => ReturnType<typeof delegationsAndRewards>
+  delegationsAndRewards: (stakeKeyHashes: DigestBlake2BCredential[]) => ReturnType<typeof delegationsAndRewards>
   eraStart: () => ReturnType<typeof eraStart>
   genesisConfig: () => ReturnType<typeof genesisConfig>
   ledgerTip: () => ReturnType<typeof ledgerTip>
-  nonMyopicMemberRewards: (input: Lovelace[] | Hash16[]) => ReturnType<typeof nonMyopicMemberRewards>
+  nonMyopicMemberRewards: (input: Lovelace[] | DigestBlake2BCredential[]) => ReturnType<typeof nonMyopicMemberRewards>
   poolIds: () => ReturnType<typeof poolIds>
   poolParameters: (pools: PoolId[]) => ReturnType<typeof poolParameters>
   poolsRanking: () => ReturnType<typeof poolsRanking>

--- a/clients/TypeScript/packages/client/src/StateQuery/queries/delegationsAndRewards.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/queries/delegationsAndRewards.ts
@@ -2,7 +2,7 @@ import {
   DelegationsAndRewardsByAccounts,
   DelegationsAndRewards,
   EraMismatch,
-  Hash16,
+  DigestBlake2BCredential,
   Ogmios
 } from '@cardano-ogmios/schema'
 import { EraMismatchError, QueryUnavailableInCurrentEraError, UnknownResultError } from '../../errors'
@@ -30,7 +30,7 @@ const isDelegationsAndRewardsByAccounts = (result: Ogmios['QueryResponse[delegat
  */
 export const delegationsAndRewards = (
   context: InteractionContext,
-  stakeKeyHashes: Hash16[]
+  stakeKeyHashes: DigestBlake2BCredential[]
 ): Promise<DelegationsAndRewardsByAccounts> =>
   Query<
     Ogmios['Query'],

--- a/clients/TypeScript/packages/client/src/StateQuery/queries/ledgerTip.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/queries/ledgerTip.ts
@@ -1,4 +1,4 @@
-import { EraMismatch, Hash16, Ogmios, PointOrOrigin, Slot } from '@cardano-ogmios/schema'
+import { EraMismatch, DigestBlake2BBlockHeader, Ogmios, PointOrOrigin, Slot } from '@cardano-ogmios/schema'
 import { EraMismatchError, QueryUnavailableInCurrentEraError, UnknownResultError } from '../../errors'
 import { InteractionContext } from '../../Connection'
 import { Query } from '../Query'
@@ -6,8 +6,8 @@ import { Query } from '../Query'
 const isEraMismatch = (result: Ogmios['QueryResponse[ledgerTip]']['result']): result is EraMismatch =>
   (result as EraMismatch).eraMismatch !== undefined
 
-const isNonOriginPoint = (result: {slot: Slot, hash: Hash16}): result is {slot: Slot, hash: Hash16} =>
-  (result as {slot: Slot, hash: Hash16}).slot !== undefined
+const isNonOriginPoint = (result: {slot: Slot, hash: DigestBlake2BBlockHeader}): result is {slot: Slot, hash: DigestBlake2BBlockHeader} =>
+  (result as {slot: Slot, hash: DigestBlake2BBlockHeader}).slot !== undefined
 
 /**
  * Get the current ledger tip. Will resolve the the acquired point if any.

--- a/clients/TypeScript/packages/client/src/StateQuery/queries/nonMyopicMemberRewards.ts
+++ b/clients/TypeScript/packages/client/src/StateQuery/queries/nonMyopicMemberRewards.ts
@@ -1,6 +1,6 @@
 import {
   EraMismatch,
-  Hash16,
+  DigestBlake2BCredential,
   Lovelace,
   NonMyopicMemberRewards,
   Ogmios
@@ -26,7 +26,7 @@ const isNonMyopicMemberRewards = (result: Ogmios['QueryResponse[nonMyopicMemberR
  */
 export const nonMyopicMemberRewards = (
   context: InteractionContext,
-  input: (Lovelace | Hash16)[]
+  input: (Lovelace | DigestBlake2BCredential)[]
 ): Promise<NonMyopicMemberRewards> =>
   Query<
     Ogmios['Query'],

--- a/clients/TypeScript/packages/client/test/ChainSync/ChainSync.test.ts
+++ b/clients/TypeScript/packages/client/test/ChainSync/ChainSync.test.ts
@@ -14,7 +14,7 @@ import {
   BlockByron,
   BlockMary,
   BlockShelley,
-  Hash16,
+  DigestBlake2BBlockHeader,
   PointOrOrigin
 } from '@cardano-ogmios/schema'
 import { dummyInteractionContext } from '../util'
@@ -138,7 +138,7 @@ describe('ChainSync', () => {
       })
       await client.startSync(['origin'], 10)
       await delay(2000)
-      let firstBlockHash: Hash16
+      let firstBlockHash: DigestBlake2BBlockHeader
       if ('byron' in blocks[0]) {
         const block = blocks[0] as { byron: BlockByron }
         firstBlockHash = block.byron.hash

--- a/clients/TypeScript/packages/client/test/StateQuery/StateQuery.test.ts
+++ b/clients/TypeScript/packages/client/test/StateQuery/StateQuery.test.ts
@@ -1,6 +1,7 @@
 import {
   DelegationsAndRewards,
-  Hash16,
+  DigestBlake2BBlockHeader,
+  DigestBlake2BCredential,
   Point,
   Slot
 } from '@cardano-ogmios/schema'
@@ -97,7 +98,7 @@ describe('Local state queries', () => {
       const compactGenesis = await client.genesisConfig()
       expect(compactGenesis.systemStart).toBeDefined()
 
-      const point = await client.ledgerTip() as { slot: Slot, hash: Hash16 }
+      const point = await client.ledgerTip() as { slot: Slot, hash: DigestBlake2BBlockHeader }
       expect(point.slot).toBeDefined()
 
       const nonMyopicMemberRewards = await client.nonMyopicMemberRewards(
@@ -157,19 +158,19 @@ describe('Local state queries', () => {
     })
     describe('delegationsAndRewards', () => {
       it('fetches the current delegate and rewards for given stake key hashes', async () => {
-        const stakeKeyHashes = ['7c16240714ea0e12b41a914f2945784ac494bb19573f0ca61a08afa8'] as Hash16[]
+        const stakeKeyHashes = ['7c16240714ea0e12b41a914f2945784ac494bb19573f0ca61a08afa8'] as DigestBlake2BCredential[]
         const result = await StateQuery.delegationsAndRewards(context, stakeKeyHashes)
         const item = result[stakeKeyHashes[0]] as DelegationsAndRewards
         expect(item).toHaveProperty('delegate')
         expect(item).toHaveProperty('rewards')
       })
       it('returns an empty object when there are no rewards', async () => {
-        const stakeKeyHashes = ['00000000000000000000000000000000000000000000000000000000'] as Hash16[]
+        const stakeKeyHashes = ['00000000000000000000000000000000000000000000000000000000'] as DigestBlake2BCredential[]
         const result = await StateQuery.delegationsAndRewards(context, stakeKeyHashes)
         expect(result).toBeDefined()
       })
       it('returns an error when given a malformed key hash', async () => {
-        const notKeyHashes = ['patate'] as Hash16[]
+        const notKeyHashes = ['patate'] as DigestBlake2BCredential[]
         await expect(StateQuery.delegationsAndRewards(context, notKeyHashes)).rejects.toBeInstanceOf(StateQuery.UnknownResultError)
       })
     })
@@ -190,7 +191,7 @@ describe('Local state queries', () => {
     })
     describe('ledgerTip', () => {
       it('fetches the tip of the ledger', async () => {
-        const point = await StateQuery.ledgerTip(context) as { slot: Slot, hash: Hash16 }
+        const point = await StateQuery.ledgerTip(context) as { slot: Slot, hash: DigestBlake2BCredential }
         expect(point.hash).toBeDefined()
         expect(point.slot).toBeDefined()
       })

--- a/clients/TypeScript/packages/repl/src/index.ts
+++ b/clients/TypeScript/packages/repl/src/index.ts
@@ -58,14 +58,14 @@ const logObject = (obj: Object) =>
     currentEpoch: () => StateQuery.currentEpoch(context),
     currentProtocolParameters: () => StateQuery.currentProtocolParameters(context),
     delegationsAndRewards:
-      (stakeKeyHashes: Schema.Hash16[]) => StateQuery.delegationsAndRewards(context, stakeKeyHashes),
+      (stakeKeyHashes: Schema.DigestBlake2BCredential[]) => StateQuery.delegationsAndRewards(context, stakeKeyHashes),
     eraStart: () => StateQuery.eraStart(context),
     genesisConfig: () => StateQuery.genesisConfig(context),
     getServerHealth: () => getServerHealth({ connection: createConnectionObject(connection) }),
     findIntersect: (points: Schema.Point[]) => ChainSync.findIntersect(context, points),
     ledgerTip: () => StateQuery.ledgerTip(context),
     nonMyopicMemberRewards:
-      (input: (Schema.Lovelace | Schema.Hash16)[]) =>
+      (input: (Schema.Lovelace | Schema.DigestBlake2BCredential)[]) =>
         StateQuery.nonMyopicMemberRewards(context, input),
     poolIds: () => StateQuery.poolIds(context),
     poolParameters: (pools: Schema.PoolId[]) => StateQuery.poolParameters(context, pools),

--- a/clients/TypeScript/packages/schema/src/index.ts
+++ b/clients/TypeScript/packages/schema/src/index.ts
@@ -14,14 +14,34 @@ export type Block = Byron | Shelley | Allegra | Mary | Alonzo;
  */
 export type BlockByron = StandardBlock | EpochBoundaryBlock;
 /**
- * A base16-encoded digest.
+ * A Blake2b 32-byte digest of an era-independent block header, serialised as CBOR.
  */
-export type Hash16 = string;
+export type DigestBlake2BBlockHeader = string;
 /**
  * A block number, the i-th block to be minted is number i.
  */
 export type BlockNo = number;
+/**
+ * An Ed25519-BIP32 Byron genesis delegate verification key with chain-code.
+ */
+export type GenesisVerificationKey = string;
 export type UInt32 = number;
+/**
+ * A Blake2b 32-byte digest of a Merkle tree (or all block's transactions) root hash.
+ */
+export type DigestBlake2BMerkleRoot = string;
+/**
+ * A Blake2b 32-byte digest of a Byron transaction witness set, CBOR-encoded.
+ */
+export type DigestBlake2BBlockByronBodyTxPayloadWitness = string;
+/**
+ * A Blake2b 32-byte digest of a Byron delegation payload, CBOR-encoded.
+ */
+export type DigestBlake2BBlockByronBodyDlgPayload = string;
+/**
+ * A Blake2b 32-byte digest of a Byron update payload, CBOR-encoded.
+ */
+export type DigestBlake2BBlockByronBodyUpdatePayload = string;
 export type ProtocolMagicId = number;
 /**
  * An epoch number.
@@ -36,6 +56,10 @@ export type Hash64 = string;
  */
 export type Slot = number;
 /**
+ * A Blake2b 32-byte digest of a transaction body, CBOR-encoded.
+ */
+export type TxId = string;
+/**
  * A Cardano address (either legacy format or new format).
  */
 export type Address = string;
@@ -44,8 +68,16 @@ export type Lovelace = number;
  * A number of asset, can be negative went burning assets.
  */
 export type AssetQuantity = bigint;
+/**
+ * A Blake2b 32-byte digest of a serialized datum, CBOR-encoded.
+ */
+export type DigestBlake2BDatum = string;
 export type Null = null;
 export type TxWitness = WitnessVk | RedeemWitness;
+/**
+ * A Blake2b 28-byte digest of an Ed25519 verification key.
+ */
+export type DigestBlake2BVerificationKey = string;
 export type NullableRatio = Ratio | Null;
 /**
  * A ratio of two integers, to express exact fractions.
@@ -53,6 +85,10 @@ export type NullableRatio = Ratio | Null;
 export type Ratio = string;
 export type NullableUInt64 = UInt64 | Null;
 export type UInt64 = number;
+/**
+ * A Blake2b 32-byte digest of an era-independent block body.
+ */
+export type DigestBlake2BBlockBody = string;
 export type Certificate =
   | StakeDelegation
   | StakeKeyRegistration
@@ -61,7 +97,22 @@ export type Certificate =
   | PoolRetirement
   | GenesisDelegation
   | MoveInstantaneousRewards;
+/**
+ * A Blake2b 28-byte digest of a verification key or a script.
+ */
+export type DigestBlake2BCredential = string;
+/**
+ * A Blake2b 32-byte digest of a pool's verification key.
+ */
 export type PoolId = string;
+/**
+ * A Blake2b 32-byte digest of a VRF verification key.
+ */
+export type DigestBlake2BVrfVerificationKey = string;
+/**
+ * A Blake2b 32-byte digest of stake pool (canonical) JSON metadata.
+ */
+export type DigestBlake2BPoolMetadata = string;
 export type Relay = ByAddress | ByName;
 /**
  * A reward account, also known as 'stake address'.
@@ -76,18 +127,38 @@ export type LovelaceDelta = number;
  */
 export type RewardPot = "reserves" | "treasury";
 export type UpdateShelley = Null | UpdateProposalShelley;
-export type Nonce = Neutral | Hash16;
+export type Nonce = Neutral | DigestBlake2BNonce;
 export type Neutral = "neutral";
+/**
+ * A Blake2b 32-byte digest of some arbitrary to make a nonce.
+ */
+export type DigestBlake2BNonce = string;
 export type Signature = string;
 export type Script = Native | Plutus | Plutus1;
 /**
  * A phase-1 monetary script. Timelocks constraints are only supported since Allegra.
  */
-export type ScriptNative = Hash16 | Any | All | NOf | ExpiresAt | StartsAt;
+export type ScriptNative = DigestBlake2BVerificationKey | Any | All | NOf | ExpiresAt | StartsAt;
 /**
  * A phase-2 Plutus script; or said differently, a serialized Plutus-core program.
  */
 export type ScriptPlutus = string;
+/**
+ * An Ed25519-BIP32 chain-code for key deriviation.
+ */
+export type ChainCode = string;
+/**
+ * Extra attributes carried by Byron addresses (network magic and/or HD payload).
+ */
+export type AddressAttributes = string;
+/**
+ * An Ed25519 verification key.
+ */
+export type VerificationKey = string;
+/**
+ * A Blake2b 32-byte digest of an 'AuxiliaryDataBody', serialised as CBOR.
+ */
+export type DigestBlake2BAuxiliaryDataBody = string;
 export type Metadatum = Int | String | Bytes | List | Map;
 /**
  * The size of the block in bytes.
@@ -99,6 +170,10 @@ export type Int64 = number;
  * A network target, as defined since the Shelley era.
  */
 export type Network = "mainnet" | "testnet";
+/**
+ * A Blake2b 32-byte digest of a script-integrity hash (i.e redeemers, datums and cost model, CBOR-encoded).
+ */
+export type DigestBlake2BScriptIntegrity = string;
 export type TipOrOrigin = Tip | Origin;
 /**
  * The origin of the blockchain. This point is special in the sense that it doesn't point to any existing slots, but is preceding any existing other point.
@@ -107,6 +182,10 @@ export type Origin = "origin";
 export type PointOrOrigin = Point | Origin;
 export type SubmitSuccess = "SubmitSuccess";
 export type Era = "Byron" | "Shelley" | "Allegra" | "Mary" | "Alonzo";
+/**
+ * A Blake2b 32-byte digest of a phase-1 or phase-2 script, CBOR-encoded.
+ */
+export type DigestBlake2BScript = string;
 export type MissingAtLeastOneInputUtxo = "missingAtLeastOneInputUtxo";
 export type InvalidMetadata = "invalidMetadata";
 export type InvalidEntity =
@@ -205,7 +284,7 @@ export type GetEraStart = "eraStart";
 export type GetLedgerTip = "ledgerTip";
 export type GetCurrentEpoch = "currentEpoch";
 export type Lovelaces = Lovelace[];
-export type Credentials = Hash16[];
+export type Credentials = DigestBlake2BCredential[];
 export type GetCurrentProtocolParameters = "currentProtocolParameters";
 export type GetProposedProtocolParameters = "proposedProtocolParameters";
 export type GetStakeDistribution = "stakeDistribution";
@@ -696,11 +775,11 @@ export interface Byron {
   byron: BlockByron;
 }
 export interface StandardBlock {
-  hash: Hash16;
+  hash: DigestBlake2BBlockHeader;
   header: {
     blockHeight: BlockNo;
-    genesisKey: Hash16;
-    prevHash: Hash16;
+    genesisKey: GenesisVerificationKey;
+    prevHash: DigestBlake2BBlockHeader;
     proof: BlockProof;
     protocolMagicId: ProtocolMagicId;
     protocolVersion: ProtocolVersion;
@@ -710,7 +789,7 @@ export interface StandardBlock {
   };
   body: {
     txPayload: {
-      id: Hash16;
+      id: TxId;
       body: Tx;
       witness: TxWitness[];
     }[];
@@ -724,11 +803,11 @@ export interface StandardBlock {
 export interface BlockProof {
   utxo: {
     number: UInt32;
-    root: Hash16;
-    witnessesHash: Hash16;
+    root: DigestBlake2BMerkleRoot;
+    witnessesHash: DigestBlake2BBlockByronBodyTxPayloadWitness;
   };
-  delegation: Hash16;
-  update: Hash16;
+  delegation: DigestBlake2BBlockByronBodyDlgPayload;
+  update: DigestBlake2BBlockByronBodyUpdatePayload;
 }
 export interface ProtocolVersion {
   major: UInt32;
@@ -744,8 +823,8 @@ export interface BlockSignature {
  */
 export interface DlgCertificate {
   epoch: Epoch;
-  issuerVk: Hash16;
-  delegateVk: Hash16;
+  issuerVk: GenesisVerificationKey;
+  delegateVk: GenesisVerificationKey;
   signature: Hash64;
 }
 export interface SoftwareVersion {
@@ -757,7 +836,7 @@ export interface Tx {
   outputs: TxOut[];
 }
 export interface TxIn {
-  txId: Hash16;
+  txId: TxId;
   index: number;
 }
 /**
@@ -766,7 +845,7 @@ export interface TxIn {
 export interface TxOut {
   address: Address;
   value: Value;
-  datum?: Hash16 | Null;
+  datum?: DigestBlake2BDatum | Null;
 }
 export interface Value {
   coins: Lovelace;
@@ -776,7 +855,7 @@ export interface Value {
 }
 export interface WitnessVk {
   witnessVk: {
-    key: Hash16;
+    key: DigestBlake2BVerificationKey;
     signature: Hash64;
   };
 }
@@ -825,15 +904,15 @@ export interface SoftForkRule {
 }
 export interface Vote {
   voterVk: Hash64;
-  proposalId: Hash16;
+  proposalId: DigestBlake2BVerificationKey;
   signature: Hash64;
 }
 export interface EpochBoundaryBlock {
-  hash: Hash16;
+  hash: DigestBlake2BBlockHeader;
   header: {
     blockHeight: BlockNo;
     epoch: Epoch;
-    prevHash: Hash16;
+    prevHash: DigestBlake2BBlockHeader;
   };
 }
 export interface Shelley {
@@ -841,24 +920,24 @@ export interface Shelley {
 }
 export interface BlockShelley {
   body?: BlockBodyShelley[];
-  headerHash?: Hash16;
+  headerHash?: DigestBlake2BBlockHeader;
   header?: {
     blockHeight: BlockNo;
     slot: Slot;
-    prevHash: Hash16;
-    issuerVk: Hash16;
+    prevHash: DigestBlake2BBlockHeader;
+    issuerVk: VerificationKey;
     issuerVrf: Hash64;
     nonce?: NonceProof;
     leaderValue: LeaderValue;
     blockSize: BlockSize;
-    blockHash: Hash16;
+    blockHash: DigestBlake2BBlockBody;
     opCert: OpCert;
     protocolVersion: ProtocolVersion;
     signature: Hash64;
   };
 }
 export interface BlockBodyShelley {
-  id: Hash16;
+  id: DigestBlake2BBlockBody;
   body: {
     inputs: TxIn[];
     outputs: TxOut[];
@@ -884,7 +963,7 @@ export interface BlockBodyShelley {
  */
 export interface StakeDelegation {
   stakeDelegation: {
-    delegator: Hash16;
+    delegator: DigestBlake2BCredential;
     delegatee: PoolId;
   };
 }
@@ -892,13 +971,13 @@ export interface StakeDelegation {
  * A stake key registration certificate.
  */
 export interface StakeKeyRegistration {
-  stakeKeyRegistration: Hash16;
+  stakeKeyRegistration: DigestBlake2BCredential;
 }
 /**
  * A stake key de-registration certificate.
  */
 export interface StakeKeyDeregistration {
-  stakeKeyDeregistration: Hash16;
+  stakeKeyDeregistration: DigestBlake2BCredential;
 }
 /**
  * A pool registration certificate.
@@ -907,18 +986,18 @@ export interface PoolRegistration {
   poolRegistration: PoolParameters;
 }
 export interface PoolParameters {
-  owners: Hash16[];
+  owners: DigestBlake2BVerificationKey[];
   cost: Lovelace;
   margin: Ratio;
   pledge: Lovelace;
-  vrf: Hash16;
+  vrf: DigestBlake2BVrfVerificationKey;
   metadata: Null | PoolMetadata;
   id: PoolId;
   relays: Relay[];
   rewardAccount: RewardAccount;
 }
 export interface PoolMetadata {
-  hash: Hash16;
+  hash: DigestBlake2BPoolMetadata;
   url: string;
 }
 export interface ByAddress {
@@ -941,9 +1020,9 @@ export interface PoolRetirement {
 }
 export interface GenesisDelegation {
   genesisDelegation: {
-    delegateKeyHash: Hash16;
-    verificationKeyHash: Hash16;
-    vrfVerificationKeyHash: Hash16;
+    delegateKeyHash: DigestBlake2BVerificationKey;
+    verificationKeyHash: DigestBlake2BVerificationKey;
+    vrfVerificationKeyHash: DigestBlake2BVrfVerificationKey;
   };
 }
 /**
@@ -1013,12 +1092,12 @@ export interface Plutus1 {
 }
 export interface BootstrapWitness {
   signature?: Hash64;
-  chainCode?: Hash16 | Null;
-  addressAttributes?: Hash64 | Null;
-  key?: Hash16;
+  chainCode?: ChainCode | Null;
+  addressAttributes?: AddressAttributes | Null;
+  key?: VerificationKey;
 }
 export interface AuxiliaryData {
-  hash: Hash16;
+  hash: DigestBlake2BAuxiliaryDataBody;
   body: AuxiliaryDataBody;
 }
 export interface AuxiliaryDataBody {
@@ -1072,24 +1151,24 @@ export interface Allegra {
 }
 export interface BlockAllegra {
   body?: BlockBodyAllegra[];
-  headerHash?: Hash16;
+  headerHash?: DigestBlake2BBlockHeader;
   header?: {
     blockHeight: BlockNo;
     slot: Slot;
-    prevHash: Hash16;
-    issuerVk: Hash16;
+    prevHash: DigestBlake2BBlockHeader;
+    issuerVk: VerificationKey;
     issuerVrf: Hash64;
     nonce?: NonceProof;
     leaderValue: LeaderValue;
     blockSize: BlockSize;
-    blockHash: Hash16;
+    blockHash: DigestBlake2BBlockBody;
     opCert: OpCert;
     protocolVersion: ProtocolVersion;
     signature: Hash64;
   };
 }
 export interface BlockBodyAllegra {
-  id: Hash16;
+  id: DigestBlake2BBlockBody;
   body: {
     inputs: TxIn[];
     outputs: TxOut[];
@@ -1119,24 +1198,24 @@ export interface Mary {
 }
 export interface BlockMary {
   body?: BlockBodyMary[];
-  headerHash?: Hash16;
+  headerHash?: DigestBlake2BBlockHeader;
   header?: {
     blockHeight: BlockNo;
     slot: Slot;
-    prevHash: Hash16;
-    issuerVk: Hash16;
+    prevHash: DigestBlake2BBlockHeader;
+    issuerVk: VerificationKey;
     issuerVrf: Hash64;
     nonce?: NonceProof;
     leaderValue: LeaderValue;
     blockSize: BlockSize;
-    blockHash: Hash16;
+    blockHash: DigestBlake2BBlockBody;
     opCert: OpCert;
     protocolVersion: ProtocolVersion;
     signature: Hash64;
   };
 }
 export interface BlockBodyMary {
-  id: Hash16;
+  id: DigestBlake2BBlockBody;
   body: {
     inputs: TxIn[];
     outputs: TxOut[];
@@ -1163,24 +1242,24 @@ export interface Alonzo {
 }
 export interface BlockAlonzo {
   body?: BlockBodyAlonzo[];
-  headerHash?: Hash16;
+  headerHash?: DigestBlake2BBlockHeader;
   header?: {
     blockHeight: BlockNo;
     slot: Slot;
-    prevHash: Hash16;
-    issuerVk: Hash16;
+    prevHash: DigestBlake2BBlockHeader;
+    issuerVk: VerificationKey;
     issuerVrf: Hash64;
     nonce?: NonceProof;
     leaderValue: LeaderValue;
     blockSize: BlockSize;
-    blockHash: Hash16;
+    blockHash: DigestBlake2BBlockBody;
     opCert: OpCert;
     protocolVersion: ProtocolVersion;
     signature: Hash64;
   };
 }
 export interface BlockBodyAlonzo {
-  id: Hash16;
+  id: DigestBlake2BBlockBody;
   body: {
     inputs: TxIn[];
     collaterals: TxIn[];
@@ -1192,8 +1271,8 @@ export interface BlockBodyAlonzo {
     update: UpdateAlonzo;
     mint: Value;
     network: Network | Null;
-    scriptIntegrityHash: Hash16 | Null;
-    requiredExtraSignatures: Hash16[];
+    scriptIntegrityHash: DigestBlake2BScriptIntegrity | Null;
+    requiredExtraSignatures: DigestBlake2BVerificationKey[];
   };
   witness: {
     signatures: {
@@ -1264,7 +1343,7 @@ export interface Redeemer {
 }
 export interface Tip {
   slot: Slot;
-  hash: Hash16;
+  hash: DigestBlake2BBlockHeader;
   blockNo: BlockNo;
 }
 export interface RollBackward {
@@ -1278,7 +1357,7 @@ export interface RollBackward {
  */
 export interface Point {
   slot: Slot;
-  hash: Hash16;
+  hash: DigestBlake2BBlockHeader;
 }
 export interface IntersectionFound {
   IntersectionFound: {
@@ -1304,30 +1383,30 @@ export interface EraMismatch {
   };
 }
 export interface InvalidWitnesses {
-  invalidWitnesses: Hash16[];
+  invalidWitnesses: VerificationKey[];
 }
 export interface MissingVkWitnesses {
-  missingVkWitnesses: Hash16[];
+  missingVkWitnesses: DigestBlake2BVerificationKey[];
 }
 export interface MissingScriptWitnesses {
-  missingScriptWitnesses: Hash16[];
+  missingScriptWitnesses: DigestBlake2BScript[];
 }
 export interface ScriptWitnessNotValidating {
-  scriptWitnessNotValidating: Hash16[];
+  scriptWitnessNotValidating: DigestBlake2BScript[];
 }
 export interface InsufficientGenesisSignatures {
-  insufficientGenesisSignatures: Hash16[];
+  insufficientGenesisSignatures: DigestBlake2BVerificationKey[];
 }
 export interface MissingTxMetadata {
-  missingTxMetadata: Hash16;
+  missingTxMetadata: DigestBlake2BAuxiliaryDataBody;
 }
 export interface MissingTxMetadataHash {
-  missingTxMetadataHash: Hash16;
+  missingTxMetadataHash: DigestBlake2BAuxiliaryDataBody;
 }
 export interface TxMetadataHashMismatch {
   txMetadataHashMismatch: {
-    includedHash: Hash16;
-    expectedHash: Hash16;
+    includedHash: DigestBlake2BAuxiliaryDataBody;
+    expectedHash: DigestBlake2BAuxiliaryDataBody;
   };
 }
 export interface BadInputs {
@@ -1410,7 +1489,7 @@ export interface WrongPoolCertificate {
   wrongPoolCertificate: UInt8;
 }
 export interface StakeKeyAlreadyRegistered {
-  stakeKeyAlreadyRegistered: Hash16;
+  stakeKeyAlreadyRegistered: DigestBlake2BVerificationKey;
 }
 export interface PoolCostTooSmall {
   poolCostTooSmall: {
@@ -1424,7 +1503,7 @@ export interface PoolMetadataHashTooBig {
   };
 }
 export interface StakeKeyNotRegistered {
-  stakeKeyNotRegistered: Hash16;
+  stakeKeyNotRegistered: DigestBlake2BVerificationKey;
 }
 export interface RewardAccountNotEmpty {
   rewardAccountNotEmpty: {
@@ -1432,10 +1511,10 @@ export interface RewardAccountNotEmpty {
   };
 }
 export interface UnknownGenesisKey {
-  unknownGenesisKey: Hash16;
+  unknownGenesisKey: DigestBlake2BVerificationKey;
 }
 export interface AlreadyDelegating {
-  alreadyDelegating: Hash16;
+  alreadyDelegating: DigestBlake2BVerificationKey;
 }
 export interface InsufficientFundsForMir {
   insufficientFundsForMir: {
@@ -1451,12 +1530,12 @@ export interface TooLateForMir {
   };
 }
 export interface DuplicateGenesisVrf {
-  duplicateGenesisVrf: Hash16;
+  duplicateGenesisVrf: DigestBlake2BVrfVerificationKey;
 }
 export interface NonGenesisVoters {
   nonGenesisVoters: {
-    currentlyVoting: Hash16[];
-    shouldBeVoting: Hash16[];
+    currentlyVoting: DigestBlake2BVerificationKey[];
+    shouldBeVoting: DigestBlake2BVerificationKey[];
   };
 }
 export interface UpdateWrongEpoch {
@@ -1480,7 +1559,7 @@ export interface Spend {
   spend: TxIn;
 }
 export interface Mint {
-  mint: Hash16;
+  mint: DigestBlake2BScript;
 }
 export interface Certificate1 {
   certificate: Certificate;
@@ -1490,24 +1569,24 @@ export interface Withdrawal {
 }
 export interface MissingRequiredDatums {
   missingRequiredDatums: {
-    provided: Hash16[];
-    missing: Hash16[];
+    provided: DigestBlake2BDatum[];
+    missing: DigestBlake2BDatum[];
   };
 }
 export interface UnspendableDatums {
   unspendableDatums: {
-    nonSpendable: Hash16[];
-    acceptable: Hash16[];
+    nonSpendable: DigestBlake2BDatum[];
+    acceptable: DigestBlake2BDatum[];
   };
 }
 export interface ExtraDataMismatch {
   extraDataMismatch: {
-    provided: Hash16 | Null;
-    inferredFromParameters: Hash16 | Null;
+    provided: DigestBlake2BScriptIntegrity | Null;
+    inferredFromParameters: DigestBlake2BScriptIntegrity | Null;
   };
 }
 export interface MissingRequiredSignatures {
-  missingRequiredSignatures: Hash16[];
+  missingRequiredSignatures: DigestBlake2BVerificationKey[];
 }
 export interface UnspendableScriptInputs {
   unspendableScriptInputs: TxIn[];
@@ -1562,7 +1641,7 @@ export interface GetNonMyopicMemberRewards {
   nonMyopicMemberRewards: Lovelaces | Credentials;
 }
 export interface GetDelegationsAndRewards {
-  delegationsAndRewards: Hash16[];
+  delegationsAndRewards: DigestBlake2BCredential[];
 }
 export interface GetUtxoByAddress {
   utxo: Address[];
@@ -1608,7 +1687,7 @@ export interface ProposedProtocolParametersAlonzo {
 export interface PoolDistribution {
   [k: string]: {
     stake: Ratio;
-    vrf: Hash16;
+    vrf: DigestBlake2BVrfVerificationKey;
   };
 }
 /**

--- a/docs/static/ogmios.wsp.json
+++ b/docs/static/ogmios.wsp.json
@@ -1502,8 +1502,8 @@
                               , "parametersUpdate": { "$ref": "#/definitions/ProtocolParameters[Byron]" }
                               }
                             }
-                          , "issuer": { "$ref": "#/definitions/Hash64" }
-                          , "signature": { "$ref": "#/definitions/Hash64" }
+                          , "issuer": { "$ref": "#/definitions/IssuerVrfVerificationKey" }
+                          , "signature": { "$ref": "#/definitions/IssuerSignature" }
                           }
                         }
                       ]
@@ -1630,14 +1630,14 @@
           , "slot": { "$ref": "#/definitions/Slot" }
           , "prevHash": { "$ref": "#/definitions/Digest[Blake2b]::Block[*].header" }
           , "issuerVk": { "$ref": "#/definitions/VerificationKey" }
-          , "issuerVrf": { "$ref": "#/definitions/Hash64" }
-          , "nonce": { "$ref": "#/definitions/NonceProof" }
-          , "leaderValue": { "$ref": "#/definitions/LeaderValue" }
+          , "issuerVrf": { "$ref": "#/definitions/IssuerVrfVerificationKey" }
+          , "nonce": { "$ref": "#/definitions/CertifiedVrf" }
+          , "leaderValue": { "$ref": "#/definitions/CertifiedVrf" }
           , "blockSize": { "$ref": "#/definitions/BlockSize" }
           , "blockHash": { "$ref": "#/definitions/Digest[Blake2b]::Block[*].body" }
           , "opCert": { "$ref": "#/definitions/OpCert" }
           , "protocolVersion": { "$ref": "#/definitions/ProtocolVersion" }
-          , "signature": { "$ref": "#/definitions/Hash64" }
+          , "signature": { "$ref": "#/definitions/IssuerSignature" }
           }
         }
       }
@@ -2114,7 +2114,7 @@
           , "datums":
             { "type": "object"
             , "propertyNames": { "contentEncoding": "base16", "pattern": "^[0-9a-f]+$" }
-            , "additionalProperties": { "$ref": "#/definitions/Hash64" }
+            , "additionalProperties": { "$ref": "#/definitions/Datum" }
             }
           , "redeemers":
             { "type": "object"
@@ -2172,7 +2172,7 @@
     , "required": [ "dlgCertificate", "signature" ]
     , "properties":
       { "dlgCertificate": { "$ref": "#/definitions/DlgCertificate" }
-      , "signature": { "$ref": "#/definitions/Hash64" }
+      , "signature": { "$ref": "#/definitions/IssuerSignature" }
       }
     }
 
@@ -2199,7 +2199,7 @@
       ]
     , "additionalProperties": false
     , "properties":
-      { "signature": { "$ref": "#/definitions/Hash64" }
+      { "signature": { "$ref": "#/definitions/Signature" }
       , "chainCode":
         { "oneOf":
           [ { "$ref": "#/definitions/ChainCode" }
@@ -2373,6 +2373,15 @@
           }
         }
       ]
+    }
+
+  , "CertifiedVrf":
+    { "type": "object"
+    , "additionalProperties": false
+    , "properties":
+      { "proof": { "$ref": "#/definitions/VrfProof" }
+      , "output": { "$ref": "#/definitions/VrfOutput" }
+      }
     }
 
   , "ChainCode":
@@ -2618,7 +2627,7 @@
       { "epoch": { "$ref": "#/definitions/Epoch" }
       , "issuerVk": { "$ref": "#/definitions/GenesisVerificationKey" }
       , "delegateVk": { "$ref": "#/definitions/GenesisVerificationKey" }
-      , "signature": { "$ref": "#/definitions/Hash64" }
+      , "signature": { "$ref": "#/definitions/IssuerSignature" }
       }
     }
 
@@ -2668,13 +2677,6 @@
     , "contentEncoding": "base16"
     , "minLength": 128
     , "maxLength": 128
-    }
-
-  , "Hash64":
-    { "type": "string"
-    , "description": "A base64-encoded digest."
-    , "contentEncoding": "base64"
-    , "pattern": "^[A-Za-z0-9+/]*=?=?$"
     }
 
   , "IndividualPoolRewardsProvenance":
@@ -2778,14 +2780,16 @@
       ]
     }
 
-  , "LeaderValue":
-    { "type": "object"
-    , "description": "In Ouroboros Praos, designate the leader's contribution to the Multi-Party computation used for calculating the leader schedule."
-    , "additionalProperties": false
-    , "properties":
-      { "proof": { "$ref": "#/definitions/Hash64" }
-      , "output": { "$ref": "#/definitions/Hash64" }
-      }
+  , "IssuerVrfVerificationKey":
+    { "type": "string"
+    , "description": "A key identifying a block issuer."
+    , "contentEncoding": "base64"
+    }
+
+  , "IssuerSignature":
+    { "type": "string"
+    , "description": "Signature proving a block was issued by a given issuer VRF key."
+    , "contentEncoding": "base64"
     }
 
   , "Lovelace":
@@ -2799,6 +2803,11 @@
     , "description": "An amount, possibly negative, in Lovelace (1e6 Lovelace = 1 Ada)."
     , "minimum": -9223372036854775808
     , "maximum": 9223372036854775807
+    }
+
+  , "KesVerificationKey":
+    { "type": "string"
+    , "contentEncoding": "base64"
     }
 
   , "Metadata":
@@ -2941,15 +2950,6 @@
       ]
     }
 
-  , "NonceProof":
-    { "type": "object"
-    , "additionalProperties": false
-    , "properties":
-      { "proof": { "$ref": "#/definitions/Hash64" }
-      , "output": { "$ref": "#/definitions/Hash64" }
-      }
-    }
-
   , "NonMyopicMemberRewards":
     { "type": "object"
     , "description": "Rewards that can be expected assuming a pool is fully saturated. Such rewards are said non-myopic, in opposition to short-sighted rewards looking at immediate benefits. Keys of the map can be either Lovelace amounts or account credentials depending on the query."
@@ -3002,9 +3002,9 @@
     , "additionalProperties": false
     , "properties":
       { "count": { "$ref": "#/definitions/UInt64" }
-      , "sigma": { "$ref": "#/definitions/Hash64" }
+      , "sigma": { "$ref": "#/definitions/Signature" }
       , "kesPeriod": { "$ref": "#/definitions/UInt64" }
-      , "hotVk": { "$ref": "#/definitions/Hash64" }
+      , "hotVk": { "$ref": "#/definitions/KesVerificationKey" }
       }
     }
 
@@ -3385,9 +3385,15 @@
     , "additionalProperties": false
     , "required": [ "redeemer", "executionUnits" ]
     , "properties":
-      { "redeemer": { "$ref": "#/definitions/Hash64" }
+      { "redeemer": { "$ref": "#/definitions/RedeemerData" }
       , "executionUnits": { "$ref": "#/definitions/ExUnits" }
       }
+    }
+
+  , "RedeemerData":
+    { "type": "string"
+    , "contentEncoding": "base64"
+    , "description": "Plutus data, CBOR-serialised."
     }
 
   , "RedeemerPointer":
@@ -3765,8 +3771,8 @@
 
   , "Signature":
     { "type": "string"
+    , "description": "A signature coming from an Ed25519 or Ed25519-BIP32 signing key."
     , "contentEncoding": "base64"
-    , "pattern": "^[A-Za-z0-9+/]*=?=?$"
     }
 
   , "Slot":
@@ -4829,7 +4835,7 @@
             , "required": [ "key", "signature" ]
             , "properties":
               { "key": { "$ref": "#/definitions/Digest[Blake2b]::VerificationKey" }
-              , "signature": { "$ref": "#/definitions/Hash64" }
+              , "signature": { "$ref": "#/definitions/Signature" }
               }
             }
           }
@@ -4843,8 +4849,8 @@
             , "additionalProperties": false
             , "required": [ "key", "signature" ]
             , "properties":
-              { "key": { "$ref": "#/definitions/Hash64" }
-              , "signature": { "$ref": "#/definitions/Hash64" }
+              { "key": { "$ref": "#/definitions/VerificationKey" }
+              , "signature": { "$ref": "#/definitions/Signature" }
               }
             }
           }
@@ -4948,15 +4954,25 @@
     , "additionalProperties": false
     , "required": [ "voterVk", "proposalId", "signature" ]
     , "properties":
-      { "voterVk": { "$ref": "#/definitions/Hash64" }
+      { "voterVk": { "$ref": "#/definitions/VerificationKey" }
       , "proposalId": { "$ref": "#/definitions/Digest[Blake2b]::VerificationKey" }
-      , "signature": { "$ref": "#/definitions/Hash64" }
+      , "signature": { "$ref": "#/definitions/Signature" }
       }
     }
 
   , "VotingPeriod":
     { "type": "string"
     , "enum": [ "voteForThisEpoch", "voteForNextEpoch" ]
+    }
+
+  , "VrfProof":
+    { "type": "string"
+    , "contentEncoding": "base64"
+    }
+
+  , "VrfOutput":
+    { "type": "string"
+    , "contentEncoding": "base64"
     }
 
   , "Withdrawals":

--- a/docs/static/ogmios.wsp.json
+++ b/docs/static/ogmios.wsp.json
@@ -530,7 +530,7 @@
                         }
                       , { "type": "array"
                         , "title": "Credentials"
-                        , "items": { "$ref": "#/definitions/Hash16" }
+                        , "items": { "$ref": "#/definitions/Digest[Blake2b]::Credential" }
                         }
                       ]
                     }
@@ -543,7 +543,7 @@
                 , "properties":
                   { "delegationsAndRewards":
                     { "type": "array"
-                    , "items": { "$ref": "#/definitions/Hash16" }
+                    , "items": { "$ref": "#/definitions/Digest[Blake2b]::Credential" }
                     }
                   }
                 }
@@ -1297,6 +1297,12 @@
       ]
     }
 
+  , "AddressAttributes":
+    { "type": "string"
+    , "description": "Extra attributes carried by Byron addresses (network magic and/or HD payload)."
+    , "contentEncoding": "base64"
+    }
+
   , "AssetQuantity":
     { "type": "integer"
     , "description": "A number of asset, can be negative went burning assets."
@@ -1307,7 +1313,7 @@
     , "additionalProperties": false
     , "required": [ "hash", "body" ]
     , "properties":
-      { "hash": { "$ref": "#/definitions/Hash16" }
+      { "hash": { "$ref": "#/definitions/Digest[Blake2b]::AuxiliaryDataBody" }
       , "body": { "$ref": "#/definitions/AuxiliaryDataBody" }
       }
     }
@@ -1423,7 +1429,7 @@
             }
           ]
         , "properties":
-          { "hash": { "$ref": "#/definitions/Hash16" }
+          { "hash": { "$ref": "#/definitions/Digest[Blake2b]::Block[*].header" }
           , "header":
             { "type": "object"
             , "additionalProperties": false
@@ -1431,8 +1437,8 @@
             , "$omitted-if-compact": ["proof", "signature"]
             , "properties":
               { "blockHeight": { "$ref": "#/definitions/BlockNo" }
-              , "genesisKey": { "$ref": "#/definitions/Hash16" }
-              , "prevHash": { "$ref": "#/definitions/Hash16" }
+              , "genesisKey": { "$ref": "#/definitions/GenesisVerificationKey" }
+              , "prevHash": { "$ref": "#/definitions/Digest[Blake2b]::Block[*].header" }
               , "proof": { "$ref": "#/definitions/BlockProof" }
               , "protocolMagicId": { "$ref": "#/definitions/ProtocolMagicId" }
               , "protocolVersion": { "$ref": "#/definitions/ProtocolVersion" }
@@ -1455,7 +1461,7 @@
                   , "required": [ "id", "body", "witness" ]
                   , "$omitted-if-compact": ["witness"]
                   , "properties":
-                    { "id": { "$ref": "#/definitions/Hash16" }
+                    { "id": { "$ref": "#/definitions/TxId" }
                     , "body": { "$ref": "#/definitions/Tx" }
                     , "witness":
                       { "type": "array"
@@ -1516,7 +1522,7 @@
         , "title": "epoch boundary block"
         , "additionalProperties": false
         , "properties":
-          { "hash": { "$ref": "#/definitions/Hash16" }
+          { "hash": { "$ref": "#/definitions/Digest[Blake2b]::Block[*].header" }
           , "header":
             { "type": "object"
             , "additionalProperties": false
@@ -1524,7 +1530,7 @@
             , "properties":
               { "blockHeight": { "$ref": "#/definitions/BlockNo" }
               , "epoch": { "$ref": "#/definitions/Epoch" }
-              , "prevHash": { "$ref": "#/definitions/Hash16" }
+              , "prevHash": { "$ref": "#/definitions/Digest[Blake2b]::Block[*].header" }
               }
             }
           }
@@ -1610,7 +1616,7 @@
         { "type": "array"
         , "items": { "$ref": "#/definitions/BlockBody[Shelley]" }
         }
-      , "headerHash": { "$ref": "#/definitions/Hash16" }
+      , "headerHash": { "$ref": "#/definitions/Digest[Blake2b]::Block[*].header" }
       , "header":
         { "type": "object"
         , "additionalProperties": false
@@ -1622,13 +1628,13 @@
         , "properties":
           { "blockHeight": { "$ref": "#/definitions/BlockNo" }
           , "slot": { "$ref": "#/definitions/Slot" }
-          , "prevHash": { "$ref": "#/definitions/Hash16" }
-          , "issuerVk": { "$ref": "#/definitions/Hash16" }
+          , "prevHash": { "$ref": "#/definitions/Digest[Blake2b]::Block[*].header" }
+          , "issuerVk": { "$ref": "#/definitions/VerificationKey" }
           , "issuerVrf": { "$ref": "#/definitions/Hash64" }
           , "nonce": { "$ref": "#/definitions/NonceProof" }
           , "leaderValue": { "$ref": "#/definitions/LeaderValue" }
           , "blockSize": { "$ref": "#/definitions/BlockSize" }
-          , "blockHash": { "$ref": "#/definitions/Hash16" }
+          , "blockHash": { "$ref": "#/definitions/Digest[Blake2b]::Block[*].body" }
           , "opCert": { "$ref": "#/definitions/OpCert" }
           , "protocolVersion": { "$ref": "#/definitions/ProtocolVersion" }
           , "signature": { "$ref": "#/definitions/Hash64" }
@@ -1643,7 +1649,7 @@
     , "required": [ "id", "body", "witness", "metadata" ]
     , "$omitted-if-compact": ["witness"]
     , "properties":
-      { "id": { "$ref": "#/definitions/Hash16" }
+      { "id": { "$ref": "#/definitions/Digest[Blake2b]::Block[*].body" }
       , "body":
         { "type": "object"
         , "additionalProperties": false
@@ -1786,7 +1792,7 @@
     , "required": [ "id", "body", "witness", "metadata" ]
     , "$omitted-if-compact": ["witness"]
     , "properties":
-      { "id": { "$ref": "#/definitions/Hash16" }
+      { "id": { "$ref": "#/definitions/Digest[Blake2b]::Block[*].body" }
       , "body":
         { "type": "object"
         , "additionalProperties": false
@@ -1952,7 +1958,7 @@
     , "required": [ "id", "body", "witness", "metadata" ]
     , "$omitted-if-compact": ["witness"]
     , "properties":
-      { "id": { "$ref": "#/definitions/Hash16" }
+      { "id": { "$ref": "#/definitions/Digest[Blake2b]::Block[*].body" }
       , "body":
         { "type": "object"
         , "additionalProperties": false
@@ -2027,7 +2033,7 @@
     , "required": [ "id", "body", "witness", "metadata" ]
     , "$omitted-if-compact": ["witness"]
     , "properties":
-      { "id": { "$ref": "#/definitions/Hash16" }
+      { "id": { "$ref": "#/definitions/Digest[Blake2b]::Block[*].body" }
       , "body":
         { "type": "object"
         , "additionalProperties": false
@@ -2076,13 +2082,13 @@
             }
           , "scriptIntegrityHash":
             { "oneOf":
-              [ { "$ref": "#/definitions/Hash16" }
+              [ { "$ref": "#/definitions/Digest[Blake2b]::ScriptIntegrity" }
               , { "$ref": "#/definitions/Null"}
               ]
             }
           , "requiredExtraSignatures":
             { "type": "array"
-            , "items": { "$ref": "#/definitions/Hash16" }
+            , "items": { "$ref": "#/definitions/Digest[Blake2b]::VerificationKey" }
             }
           }
         }
@@ -2151,12 +2157,12 @@
         , "required": [ "number", "root", "witnessesHash" ]
         , "properties":
           { "number": { "$ref": "#/definitions/UInt32" }
-          , "root": { "$ref": "#/definitions/Hash16" }
-          , "witnessesHash": { "$ref": "#/definitions/Hash16" }
+          , "root": { "$ref": "#/definitions/Digest[Blake2b]::MerkleRoot" }
+          , "witnessesHash": { "$ref": "#/definitions/Digest[Blake2b]::Block[Byron].body.txPayload[].witness" }
           }
         }
-      , "delegation": { "$ref": "#/definitions/Hash16" }
-      , "update": { "$ref": "#/definitions/Hash16" }
+      , "delegation": { "$ref": "#/definitions/Digest[Blake2b]::Block[Byron].body.dlgPayload" }
+      , "update": { "$ref": "#/definitions/Digest[Blake2b]::Block[Byron].body.updatePayload" }
       }
     }
 
@@ -2196,17 +2202,17 @@
       { "signature": { "$ref": "#/definitions/Hash64" }
       , "chainCode":
         { "oneOf":
-          [ { "$ref": "#/definitions/Hash16" }
+          [ { "$ref": "#/definitions/ChainCode" }
           , { "$ref": "#/definitions/Null"}
           ]
         }
       , "addressAttributes":
         { "oneOf":
-          [ { "$ref": "#/definitions/Hash64" }
+          [ { "$ref": "#/definitions/AddressAttributes" }
           , { "$ref": "#/definitions/Null"}
           ]
         }
-      , "key": { "$ref": "#/definitions/Hash16" }
+      , "key": { "$ref": "#/definitions/VerificationKey" }
       }
     }
 
@@ -2235,7 +2241,7 @@
             , "additionalProperties": false
             , "required": ["delegator", "delegatee"]
             , "properties":
-              { "delegator": { "$ref": "#/definitions/Hash16" }
+              { "delegator": { "$ref": "#/definitions/Digest[Blake2b]::Credential" }
               , "delegatee": { "$ref": "#/definitions/PoolId" }
               }
             }
@@ -2254,7 +2260,7 @@
         , "additionalProperties": false
         , "required": ["stakeKeyRegistration"]
         , "properties":
-          { "stakeKeyRegistration": { "$ref": "#/definitions/Hash16" }
+          { "stakeKeyRegistration": { "$ref": "#/definitions/Digest[Blake2b]::Credential" }
           }
         , "examples":
           [ { "stakeKeyRegistration": "6d06fe0a5a8cb6d2bcc352581dea626bb5b2f66edf85678b2f2fa7b5"
@@ -2267,7 +2273,7 @@
         , "additionalProperties": false
         , "required": ["stakeKeyDeregistration"]
         , "properties":
-          { "stakeKeyDeregistration": { "$ref": "#/definitions/Hash16" }
+          { "stakeKeyDeregistration": { "$ref": "#/definitions/Digest[Blake2b]::Credential" }
           }
         , "examples":
           [ { "stakeKeyDeregistration": "6d06fe0a5a8cb6d2bcc352581dea626bb5b2f66edf85678b2f2fa7b5"
@@ -2341,9 +2347,9 @@
             , "additionalProperties": false
             , "required": ["delegateKeyHash","verificationKeyHash","vrfVerificationKeyHash"]
             , "properties":
-              { "delegateKeyHash": { "$ref": "#/definitions/Hash16" }
-              , "verificationKeyHash": { "$ref": "#/definitions/Hash16" }
-              , "vrfVerificationKeyHash": { "$ref": "#/definitions/Hash16" }
+              { "delegateKeyHash": { "$ref": "#/definitions/Digest[Blake2b]::VerificationKey" }
+              , "verificationKeyHash": { "$ref": "#/definitions/Digest[Blake2b]::VerificationKey" }
+              , "vrfVerificationKeyHash": { "$ref": "#/definitions/Digest[Blake2b]::VrfVerificationKey" }
               }
             }
           }
@@ -2367,6 +2373,12 @@
           }
         }
       ]
+    }
+
+  , "ChainCode":
+    { "type": "string"
+    , "description": "An Ed25519-BIP32 chain-code for key deriviation."
+    , "contentEncoding": "base16"
     }
 
   , "CompactGenesis":
@@ -2479,6 +2491,124 @@
       ]
     }
 
+  , "Digest[Blake2b]::AuxiliaryDataBody":
+    { "type": "string"
+    , "description": "A Blake2b 32-byte digest of an 'AuxiliaryDataBody', serialised as CBOR."
+    , "contentEncoding": "base16"
+    , "minLength": 64
+    , "maxLength": 64
+    }
+
+  , "Digest[Blake2b]::Block[*].body":
+    { "type": "string"
+    , "description": "A Blake2b 32-byte digest of an era-independent block body."
+    , "contentEncoding": "base16"
+    , "minLength": 64
+    , "maxLength": 64
+    }
+
+  , "Digest[Blake2b]::Block[*].header":
+    { "type": "string"
+    , "description": "A Blake2b 32-byte digest of an era-independent block header, serialised as CBOR."
+    , "contentEncoding": "base16"
+    , "minLength": 64
+    , "maxLength": 64
+    }
+
+  , "Digest[Blake2b]::Block[Byron].body.dlgPayload":
+    { "type": "string"
+    , "description": "A Blake2b 32-byte digest of a Byron delegation payload, CBOR-encoded."
+    , "contentEncoding": "base16"
+    , "minLength": 64
+    , "maxLength": 64
+    }
+
+  , "Digest[Blake2b]::Block[Byron].body.txPayload[].witness":
+    { "type": "string"
+    , "description": "A Blake2b 32-byte digest of a Byron transaction witness set, CBOR-encoded."
+    , "contentEncoding": "base16"
+    , "minLength": 64
+    , "maxLength": 64
+    }
+
+  , "Digest[Blake2b]::Block[Byron].body.updatePayload":
+    { "type": "string"
+    , "description": "A Blake2b 32-byte digest of a Byron update payload, CBOR-encoded."
+    , "contentEncoding": "base16"
+    , "minLength": 64
+    , "maxLength": 64
+    }
+
+  , "Digest[Blake2b]::Credential":
+    { "type": "string"
+    , "description": "A Blake2b 28-byte digest of a verification key or a script."
+    , "contentEncoding": "base16"
+    , "minLength": 56
+    , "maxLength": 56
+    }
+
+  , "Digest[Blake2b]::Datum":
+    { "type": "string"
+    , "description": "A Blake2b 32-byte digest of a serialized datum, CBOR-encoded."
+    , "contentEncoding": "base16"
+    , "minLength": 64
+    , "maxLength": 64
+    }
+
+  , "Digest[Blake2b]::MerkleRoot":
+    { "type": "string"
+    , "description": "A Blake2b 32-byte digest of a Merkle tree (or all block's transactions) root hash."
+    , "contentEncoding": "base16"
+    , "minLength": 64
+    , "maxLength": 64
+    }
+
+  , "Digest[Blake2b]::Nonce":
+    { "type": "string"
+    , "description": "A Blake2b 32-byte digest of some arbitrary to make a nonce."
+    , "contentEncoding": "base16"
+    , "minLength": 64
+    , "maxLength": 64
+    }
+
+  , "Digest[Blake2b]::PoolMetadata":
+    { "type": "string"
+    , "description": "A Blake2b 32-byte digest of stake pool (canonical) JSON metadata."
+    , "contentEncoding": "base16"
+    }
+
+  , "Digest[Blake2b]::Script":
+    { "type": "string"
+    , "description": "A Blake2b 32-byte digest of a phase-1 or phase-2 script, CBOR-encoded."
+    , "contentEncoding": "base16"
+    , "minLength": 56
+    , "maxLength": 56
+    }
+
+  , "Digest[Blake2b]::ScriptIntegrity":
+    { "type": "string"
+    , "description": "A Blake2b 32-byte digest of a script-integrity hash (i.e redeemers, datums and cost model, CBOR-encoded)."
+    , "contentEncoding": "base16"
+    , "minLength": 64
+    , "maxLength": 64
+    }
+
+  , "Digest[Blake2b]::VerificationKey":
+    { "type": "string"
+    , "description": "A Blake2b 28-byte digest of an Ed25519 verification key."
+    , "contentEncoding": "base16"
+    , "minLength": 56
+    , "maxLength": 56
+    }
+
+  , "Digest[Blake2b]::VrfVerificationKey":
+    { "type": "string"
+    , "description": "A Blake2b 32-byte digest of a VRF verification key."
+    , "contentEncoding": "base16"
+    , "minLength": 64
+    , "maxLength": 64
+    }
+
   , "DlgCertificate":
     { "type": "object"
     , "description": "A (Byron) delegation certificate."
@@ -2486,8 +2616,8 @@
     , "required": [ "epoch", "issuerVk", "delegateVk", "signature" ]
     , "properties":
       { "epoch": { "$ref": "#/definitions/Epoch" }
-      , "issuerVk": { "$ref": "#/definitions/Hash16" }
-      , "delegateVk": { "$ref": "#/definitions/Hash16" }
+      , "issuerVk": { "$ref": "#/definitions/GenesisVerificationKey" }
+      , "delegateVk": { "$ref": "#/definitions/GenesisVerificationKey" }
       , "signature": { "$ref": "#/definitions/Hash64" }
       }
     }
@@ -2532,11 +2662,12 @@
       }
     }
 
-  , "Hash16":
+  , "GenesisVerificationKey":
     { "type": "string"
-    , "description": "A base16-encoded digest."
+    , "description": "An Ed25519-BIP32 Byron genesis delegate verification key with chain-code."
     , "contentEncoding": "base16"
-    , "pattern": "^[0-9a-f]*$"
+    , "minLength": 128
+    , "maxLength": 128
     }
 
   , "Hash64":
@@ -2806,7 +2937,7 @@
         , "enum": ["neutral"]
         , "title": "neutral"
         }
-      , { "$ref": "#/definitions/Hash16" }
+      , { "$ref": "#/definitions/Digest[Blake2b]::Nonce" }
       ]
     }
 
@@ -2893,11 +3024,15 @@
         , "required": [ "slot", "hash" ]
         , "properties":
           { "slot": { "$ref": "#/definitions/Slot" }
-          , "hash": { "$ref": "#/definitions/Hash16" }
+          , "hash": { "$ref": "#/definitions/Digest[Blake2b]::Block[*].header" }
           }
         }
       , { "$ref": "#/definitions/Origin" }
       ]
+    }
+
+  , "PolicyId":
+    { "$ref": "#/definitions/Digest[Blake2b]::Script"
     }
 
   , "PoolDistribution":
@@ -2910,7 +3045,7 @@
       , "required": ["stake", "vrf"]
       , "properties":
         { "stake": { "$ref": "#/definitions/Ratio" }
-        , "vrf": { "$ref": "#/definitions/Hash16" }
+        , "vrf": { "$ref": "#/definitions/Digest[Blake2b]::VrfVerificationKey" }
         }
       }
     , "examples":
@@ -2928,6 +3063,7 @@
 
   , "PoolId":
     { "type": "string"
+    , "description": "A Blake2b 32-byte digest of a pool's verification key."
     , "contentEncoding": "bech32"
     , "pattern": "^pool1[0-9a-z]*$"
     , "examples":
@@ -2943,12 +3079,12 @@
     , "properties":
       { "owners":
         { "type": "array"
-        , "items": { "$ref": "#/definitions/Hash16" }
+        , "items": { "$ref": "#/definitions/Digest[Blake2b]::VerificationKey" }
         }
       , "cost": { "$ref": "#/definitions/Lovelace" }
       , "margin": { "$ref": "#/definitions/Ratio" }
       , "pledge": { "$ref": "#/definitions/Lovelace" }
-      , "vrf": { "$ref": "#/definitions/Hash16" }
+      , "vrf": { "$ref": "#/definitions/Digest[Blake2b]::VrfVerificationKey" }
       , "metadata":
         { "oneOf":
           [ { "$ref": "#/definitions/Null"}
@@ -2957,7 +3093,7 @@
             , "additionalProperties": false
             , "required": ["hash","url"]
             , "properties":
-              { "hash": { "$ref": "#/definitions/Hash16" }
+              { "hash": { "$ref": "#/definitions/Digest[Blake2b]::PoolMetadata" }
               , "url":
                 { "type": "string"
                 , "format": "uri"
@@ -3533,7 +3669,7 @@
           }
         ]
     , "anyOf":
-      [ { "$ref": "#/definitions/Hash16" }
+      [ { "$ref": "#/definitions/Digest[Blake2b]::VerificationKey" }
       , { "type": "object"
         , "title": "any"
         , "additionalProperties": false
@@ -3605,7 +3741,7 @@
         , "additionalProperties": false
         , "required": [ "mint" ]
         , "properties":
-          { "mint": { "$ref": "#/definitions/Hash16" }
+          { "mint": { "$ref": "#/definitions/PolicyId" }
           }
         }
       , { "title": "certificate"
@@ -3738,7 +3874,7 @@
     , "properties":
       { "invalidWitnesses":
         { "type": "array"
-        , "items": { "$ref": "#/definitions/Hash16" }
+        , "items": { "$ref": "#/definitions/VerificationKey" }
         }
       }
     }
@@ -3751,7 +3887,7 @@
     , "properties":
       { "missingVkWitnesses":
         { "type": "array"
-        , "items": { "$ref": "#/definitions/Hash16" }
+        , "items": { "$ref": "#/definitions/Digest[Blake2b]::VerificationKey" }
         }
       }
     }
@@ -3764,7 +3900,7 @@
     , "properties":
       { "missingScriptWitnesses":
         { "type": "array"
-        , "items": { "$ref": "#/definitions/Hash16" }
+        , "items": { "$ref": "#/definitions/Digest[Blake2b]::Script" }
         }
       }
     }
@@ -3777,7 +3913,7 @@
     , "properties":
       { "scriptWitnessNotValidating":
         { "type": "array"
-        , "items": { "$ref": "#/definitions/Hash16" }
+        , "items": { "$ref": "#/definitions/Digest[Blake2b]::Script" }
         }
       }
     }
@@ -3790,7 +3926,7 @@
     , "properties":
       { "insufficientGenesisSignatures":
         { "type": "array"
-        , "items": { "$ref": "#/definitions/Hash16" }
+        , "items": { "$ref": "#/definitions/Digest[Blake2b]::VerificationKey" }
         }
       }
     }
@@ -3801,7 +3937,7 @@
     , "additionalProperties": false
     , "required": [ "missingTxMetadata" ]
     , "properties":
-      { "missingTxMetadata": { "$ref": "#/definitions/Hash16" }
+      { "missingTxMetadata": { "$ref": "#/definitions/Digest[Blake2b]::AuxiliaryDataBody" }
       }
     }
 
@@ -3811,7 +3947,7 @@
     , "additionalProperties": false
     , "required": [ "missingTxMetadataHash" ]
     , "properties":
-      { "missingTxMetadataHash": { "$ref": "#/definitions/Hash16" }
+      { "missingTxMetadataHash": { "$ref": "#/definitions/Digest[Blake2b]::AuxiliaryDataBody" }
       }
     }
 
@@ -3826,8 +3962,8 @@
         , "additionalProperties": false
         , "required": [ "includedHash", "expectedHash" ]
         , "properties":
-          { "includedHash": { "$ref": "#/definitions/Hash16" }
-          , "expectedHash": { "$ref": "#/definitions/Hash16" }
+          { "includedHash": { "$ref": "#/definitions/Digest[Blake2b]::AuxiliaryDataBody" }
+          , "expectedHash": { "$ref": "#/definitions/Digest[Blake2b]::AuxiliaryDataBody" }
           }
         }
       }
@@ -4094,7 +4230,7 @@
     , "additionalProperties": false
     , "required": [ "stakeKeyAlreadyRegistered" ]
     , "properties":
-      { "stakeKeyAlreadyRegistered": { "$ref": "#/definitions/Hash16" }
+      { "stakeKeyAlreadyRegistered": { "$ref": "#/definitions/Digest[Blake2b]::VerificationKey" }
       }
     }
 
@@ -4139,7 +4275,7 @@
     , "additionalProperties": false
     , "required": [ "stakeKeyNotRegistered" ]
     , "properties":
-      { "stakeKeyNotRegistered": { "$ref": "#/definitions/Hash16" }
+      { "stakeKeyNotRegistered": { "$ref": "#/definitions/Digest[Blake2b]::VerificationKey" }
       }
     }
 
@@ -4178,7 +4314,7 @@
     , "additionalProperties": false
     , "required": [ "unknownGenesisKey" ]
     , "properties":
-      { "unknownGenesisKey": { "$ref": "#/definitions/Hash16" }
+      { "unknownGenesisKey": { "$ref": "#/definitions/Digest[Blake2b]::VerificationKey" }
       }
     }
 
@@ -4188,7 +4324,7 @@
     , "additionalProperties": false
     , "required": [ "alreadyDelegating" ]
     , "properties":
-      { "alreadyDelegating": { "$ref": "#/definitions/Hash16" }
+      { "alreadyDelegating": { "$ref": "#/definitions/Digest[Blake2b]::VerificationKey" }
       }
     }
 
@@ -4253,7 +4389,7 @@
     , "additionalProperties": false
     , "required": [ "duplicateGenesisVrf" ]
     , "properties":
-      { "duplicateGenesisVrf": { "$ref": "#/definitions/Hash16" }
+      { "duplicateGenesisVrf": { "$ref": "#/definitions/Digest[Blake2b]::VrfVerificationKey" }
       }
     }
 
@@ -4270,11 +4406,11 @@
         , "properties":
           { "currentlyVoting":
             { "type": "array"
-            , "items": { "$ref": "#/definitions/Hash16" }
+            , "items": { "$ref": "#/definitions/Digest[Blake2b]::VerificationKey" }
             }
           , "shouldBeVoting":
             { "type": "array"
-            , "items": { "$ref": "#/definitions/Hash16" }
+            , "items": { "$ref": "#/definitions/Digest[Blake2b]::VerificationKey" }
             }
           }
         }
@@ -4326,7 +4462,7 @@
             , "items":
               { "type": "object"
               , "additionalProperties": { "$ref": "#/definitions/ScriptPurpose" }
-              , "propertyNames": { "$ref": "#/definitions/Hash16" }
+              , "propertyNames": { "$ref": "#/definitions/Digest[Blake2b]::Script" }
               }
             }
           }
@@ -4347,11 +4483,11 @@
         , "properties":
           { "provided":
             { "type": "array"
-            , "items": { "$ref": "#/definitions/Hash16" }
+            , "items": { "$ref": "#/definitions/Digest[Blake2b]::Datum" }
             }
           , "missing":
             { "type": "array"
-            , "items": { "$ref": "#/definitions/Hash16" }
+            , "items": { "$ref": "#/definitions/Digest[Blake2b]::Datum" }
             }
           }
         }
@@ -4371,11 +4507,11 @@
         , "properties":
           { "nonSpendable":
             { "type": "array"
-            , "items": { "$ref": "#/definitions/Hash16" }
+            , "items": { "$ref": "#/definitions/Digest[Blake2b]::Datum" }
             }
           , "acceptable":
             { "type": "array"
-            , "items": { "$ref": "#/definitions/Hash16" }
+            , "items": { "$ref": "#/definitions/Digest[Blake2b]::Datum" }
             }
           }
         }
@@ -4395,13 +4531,13 @@
         , "properties":
           { "provided":
             { "oneOf":
-              [ { "$ref": "#/definitions/Hash16" }
+              [ { "$ref": "#/definitions/Digest[Blake2b]::ScriptIntegrity" }
               , { "$ref": "#/definitions/Null"}
               ]
             }
           , "inferredFromParameters":
             { "oneOf":
-              [ { "$ref": "#/definitions/Hash16" }
+              [ { "$ref": "#/definitions/Digest[Blake2b]::ScriptIntegrity" }
               , { "$ref": "#/definitions/Null"}
               ]
             }
@@ -4418,7 +4554,7 @@
     , "properties":
       { "missingRequiredSignatures":
         { "type": "array"
-        , "items": { "$ref": "#/definitions/Hash16" }
+        , "items": { "$ref": "#/definitions/Digest[Blake2b]::VerificationKey" }
         }
       }
     }
@@ -4578,7 +4714,7 @@
         , "required": [ "slot", "hash", "blockNo" ]
         , "properties":
           { "slot": { "$ref": "#/definitions/Slot" }
-          , "hash": { "$ref": "#/definitions/Hash16" }
+          , "hash": { "$ref": "#/definitions/Digest[Blake2b]::Block[*].header" }
           , "blockNo": { "$ref": "#/definitions/BlockNo" }
           }
         }
@@ -4612,12 +4748,20 @@
       }
     }
 
+  , "TxId":
+    { "type": "string"
+    , "description": "A Blake2b 32-byte digest of a transaction body, CBOR-encoded."
+    , "contentEncoding": "base16"
+    , "minLength": 64
+    , "maxLength": 64
+    }
+
   , "TxIn":
     { "type": "object"
     , "additionalProperties": false
     , "required": [ "txId", "index" ]
     , "properties":
-      { "txId": { "$ref": "#/definitions/Hash16" }
+      { "txId": { "$ref": "#/definitions/TxId" }
       , "index":
         { "$ref": "#/definitions/UInt32"
         , "minimum": 0
@@ -4665,7 +4809,7 @@
       , "value": { "$ref": "#/definitions/Value" }
       , "datum":
         { "oneOf":
-          [ { "$ref": "#/definitions/Hash16" }
+          [ { "$ref": "#/definitions/Digest[Blake2b]::Datum" }
           , { "$ref": "#/definitions/Null"}
           ]
         }
@@ -4684,7 +4828,7 @@
             , "additionalProperties": false
             , "required": [ "key", "signature" ]
             , "properties":
-              { "key": { "$ref": "#/definitions/Hash16" }
+              { "key": { "$ref": "#/definitions/Digest[Blake2b]::VerificationKey" }
               , "signature": { "$ref": "#/definitions/Hash64" }
               }
             }
@@ -4805,7 +4949,7 @@
     , "required": [ "voterVk", "proposalId", "signature" ]
     , "properties":
       { "voterVk": { "$ref": "#/definitions/Hash64" }
-      , "proposalId": { "$ref": "#/definitions/Hash16" }
+      , "proposalId": { "$ref": "#/definitions/Digest[Blake2b]::VerificationKey" }
       , "signature": { "$ref": "#/definitions/Hash64" }
       }
     }
@@ -4821,5 +4965,12 @@
     , "propertyNames": "^stake(_test)?1[0-9a-z]+$"
     }
 
+  , "VerificationKey":
+    { "type": "string"
+    , "description": "An Ed25519 verification key."
+    , "contentEncoding": "base16"
+    , "minLength": 64
+    , "maxLength": 64
+    }
   }
 }


### PR DESCRIPTION
Fixes #139.

- :round_pushpin: **Replace 'Hash16' with more precise schema definitions.**
    Some of them were actually not even hashes, but just happened to be base16-encoded strings. It's clearer that way.

- :round_pushpin: **Re-generate TypeScript schema and adjust types accordingly.**
  
- :round_pushpin: **Explicitly list TypeScript's workspace packages**
    And in particular, make sure that 'schema' appears before 'client',
  which appears before 'repl'. This is because, changing the schema may
  change the compilation result of the client (and similarly for the repl).

  So, when running `yarn build`, it's best to build the schema first and
  not the other way around.
