### PR TITLE
Make log minimum severity configurable per logging component.

### DIFF
--- a/server/app/Main.hs
+++ b/server/app/Main.hs
@@ -8,8 +8,8 @@ import Ogmios.Prelude
 
 import Ogmios
     ( Command (..)
-    , Options (..)
     , application
+    , mkTracers
     , newEnvironment
     , parseOptions
     , runWith
@@ -21,7 +21,7 @@ main :: IO ()
 main = parseOptions >>= \case
     Version -> do
         putTextLn version
-    Start (Identity network) opts@Options{logLevel} -> do
-        withStdoutTracer version logLevel $ \tr -> do
+    Start (Identity network) opts logLevels -> do
+        withStdoutTracer version $ \(mkTracers logLevels -> tr) -> do
             env <- newEnvironment tr network opts
             application tr `runWith` env

--- a/server/app/Main.hs
+++ b/server/app/Main.hs
@@ -9,12 +9,11 @@ import Ogmios.Prelude
 import Ogmios
     ( Command (..)
     , application
-    , mkTracers
     , newEnvironment
     , parseOptions
     , runWith
     , version
-    , withStdoutTracer
+    , withStdoutTracers
     )
 
 main :: IO ()
@@ -22,6 +21,6 @@ main = parseOptions >>= \case
     Version -> do
         putTextLn version
     Start (Identity network) opts logLevels -> do
-        withStdoutTracer version $ \(mkTracers logLevels -> tr) -> do
+        withStdoutTracers version logLevels $ \tr -> do
             env <- newEnvironment tr network opts
             application tr `runWith` env

--- a/server/cabal.project
+++ b/server/cabal.project
@@ -3,6 +3,7 @@ index-state: 2021-09-15T00:00:00Z
 packages:
   ./
   modules/cardano-client
+  modules/contra-tracers
   modules/fast-bech32
   modules/git-th
   modules/hspec-json-schema

--- a/server/modules/contra-tracers/CHANGELOG.md
+++ b/server/modules/contra-tracers/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## [1.0.0] -- 2021-19-12
+
+### Added
+
+- Initial release. Key features:
+  - Contravariant tracers, easily composable with parent context
+  - Concurrent-safe, simple, structured (JSON), stdout writer
+  - Generic definition of record of tracers for multi-component logging
+
+### Changed 
+
+N/A
+
+### Removed
+
+N/A

--- a/server/modules/contra-tracers/LICENSE
+++ b/server/modules/contra-tracers/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/server/modules/contra-tracers/README.md
+++ b/server/modules/contra-tracers/README.md
@@ -1,0 +1,61 @@
+# contra-tracers
+
+## Overview 
+
+An opinionated, simple and easy-to-use logging library leveraging contravariant functors to provide structured multi-component logger capability to real application. 
+
+## Usage
+
+```hs
+-- Some HTTP log message represented as Haskell values.
+
+data HttpLog
+    = SomeHttpLog
+    | SomeHttpWarning
+    deriving stock (Generic)
+    deriving anyclass (ToJSON)
+
+nstance HasSeverityAnnotation HttpLog
+   getSeverityAnnotation = \case
+       SomeHttpLog -> Info
+       SomeHttpWarning -> Warning
+
+-- Some DB log message represented as Haskell values.
+
+data DbLog = SomeDbLog
+    deriving stock (Generic)
+    deriving anyclass (ToJSON)
+
+nstance HasSeverityAnnotation HttpLog
+   getSeverityAnnotation = \case
+       SomeHttpLog -> Info
+       SomeHttpWarning -> Warning
+
+-- Applications tracers, defined as a record of higher-kinded types. We
+-- have in particular 'TracerHKD Concrete a ~ a', which effectively makes
+-- the 'Tracers' record a plain record of tracers once instantiated.
+
+data Tracers m (kind :: TracerDefinition) = Tracers
+    { tracerHttp :: TracerHKD kind (Tracer m HttpLog)
+    , tracerDb   :: TracerHKD kind (Tracer m DbLog)
+    } deriving stock (Generic)
+
+-- The default configuration, setting all tracers to 'Info' min severity.
+-- In practice, you may want to obtain the configuration from a config
+-- file or from command-line options.
+emptyConfiguration :: Tracers m MinSeverities
+emptyConfiguration = defaultTracers Info
+
+main :: IO ()
+main = do
+    withStdoutTracer mempty emptyConfiguration $ \tracers -> do
+        concurrently_
+            (myHttpApplication (tracerHttp tracers))
+            (myDbApplication (tracerDb  tracers))
+```
+
+<p align="center">
+  <a href="../../../CONTRIBUTING.md">:gift: Contributing</a>
+  |
+  <a href="CHANGELOG.md">:floppy_disk: Changelog</a>
+</p>

--- a/server/modules/contra-tracers/contra-tracers.cabal
+++ b/server/modules/contra-tracers/contra-tracers.cabal
@@ -1,0 +1,79 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.4.
+--
+-- see: https://github.com/sol/hpack
+
+name:           contra-tracers
+version:        1.0.0
+synopsis:       A logging library built on top of contra-tracer to make configuring and declaring multiple tracers easy (via generics).
+description:    Please see the README on GitHub at <https://github.com/cardanosolutions/ogmios/tree/master/server/modules/contra-tracers>
+category:       Logging, Contravariant, Generics
+homepage:       https://github.com/cardanosolutions/ogmios#readme
+bug-reports:    https://github.com/cardanosolutions/ogmios/issues
+author:         KtorZ <matthias.benkort@gmail.com>
+maintainer:     matthias.benkort@gmail.com
+copyright:      2021 KtorZ
+license:        MPL-2.0
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    LICENSE
+    README.md
+    CHANGELOG.md
+
+source-repository head
+  type: git
+  location: https://github.com/cardanosolutions/ogmios
+
+library
+  exposed-modules:
+      Data.Generics.Tracers
+      Data.Severity
+  other-modules:
+      Paths_contra_tracers
+  hs-source-dirs:
+      src
+  default-extensions:
+      BangPatterns
+      BinaryLiterals
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveTraversable
+      EmptyDataDecls
+      ExistentialQuantification
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      NoImplicitPrelude
+      NumericUnderscores
+      OverloadedStrings
+      PartialTypeSignatures
+      PatternGuards
+      RankNTypes
+      ScopedTypeVariables
+      StandaloneDeriving
+      TupleSections
+      TypeFamilies
+      TypeSynonymInstances
+      ViewPatterns
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints -Wunused-packages
+  build-depends:
+      aeson
+    , base >=4.7 && <5
+    , contra-tracer
+  if true
+    ghc-options: -O2
+  default-language: Haskell2010

--- a/server/modules/contra-tracers/package.yaml
+++ b/server/modules/contra-tracers/package.yaml
@@ -1,0 +1,33 @@
+_config: !include "../../.hpack.config.yaml"
+
+name:                contra-tracers
+version:             1.0.0
+github:              "cardanosolutions/ogmios"
+license:             MPL-2.0
+author:              "KtorZ <matthias.benkort@gmail.com>"
+maintainer:          "matthias.benkort@gmail.com"
+copyright:           "2021 KtorZ"
+description:         Please see the README on GitHub at <https://github.com/cardanosolutions/ogmios/tree/master/server/modules/contra-tracers>
+synopsis:            A logging library built on top of contra-tracer to make configuring and declaring multiple tracers easy (via generics).
+category:            Logging, Contravariant, Generics
+
+extra-source-files:
+- LICENSE
+- README.md
+- CHANGELOG.md
+
+dependencies:
+- base >= 4.7 && < 5
+
+default-extensions: *default-extensions
+
+library:
+  source-dirs: src
+  ghc-options: *ghc-options-lib
+  when:
+    condition: true
+    ghc-options:
+    - -O2
+  dependencies:
+    - aeson
+    - contra-tracer

--- a/server/modules/contra-tracers/src/Data/Generics/Tracers.hs
+++ b/server/modules/contra-tracers/src/Data/Generics/Tracers.hs
@@ -1,0 +1,181 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+{-# LANGUAGE TypeOperators #-}
+
+{-# OPTIONS_GHC -fno-warn-unticked-promoted-constructors #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+-- | This module provides a way to generically define and configure multiple
+-- tracers for multiple logging components.
+--
+-- This is useful in order to associate separate configuration (e.g. minimum
+-- severity) to tracers corresponding to different parts of an application. For
+-- example, in a webserver, one may imagine wanting to lower the verbosity of a
+-- tracer used for all HTTP requests, but keep the database tracer at a debug
+-- level.
+--
+-- While this is possible to do without generics, it usually requires a bit of
+-- boilerplate and repetitions. This module makes it easy to define one-single
+-- data object as a record, for representing both severities configurations and
+-- concrete instantiated tracers. Type signatures are a bit frightening, but the
+-- usage is pretty simple (see 'Control.Tracer' for examples)
+--
+module Data.Generics.Tracers
+    ( -- * Definition
+      IsRecordOfTracers
+    , TracerDefinition (..)
+    , type TracerHKD
+
+    -- * Construction
+    , configureTracers
+    , defaultTracers
+
+    -- Internal
+    , SomeMsg (..)
+    ) where
+
+import Prelude
+
+import GHC.Generics
+
+import Control.Tracer
+    ( Tracer (..), nullTracer )
+import Data.Aeson
+    ( ToJSON (..) )
+import Data.Functor.Const
+    ( Const (..) )
+import Data.Functor.Contravariant
+    ( contramap )
+import Data.Kind
+    ( Type )
+import Data.Severity
+    ( HasSeverityAnnotation (..), Severity )
+
+-- * Definition
+
+-- | A constraint-alias defining generic record of tracers.
+type IsRecordOfTracers tracers m =
+    ( GConfigureTracers m (Rep (tracers m MinSeverities)) (Rep (tracers m Concrete))
+    , Generic (tracers m MinSeverities)
+    , Generic (tracers m Concrete)
+    )
+
+-- | A data kind to control what's defined in a generic record of tracer.
+--
+-- Use 'configureTracers' to turn a record of configuration into a record of
+-- concrete tracers.
+data TracerDefinition = Concrete | MinSeverities
+
+-- | A high-kinded type family to make definitions of tracers more readable. For
+-- example, one can define a multi-component set of tracers as such:
+--
+--     data Tracers m (kind :: TracerDefinition) = Tracers
+--         { tracerHttp  :: TracerHKD kind (Tracer m HttpLog)
+--         , tracerStart :: TracerHKD kind (Tracer m StartLog)
+--         }
+type family TracerHKD (definition :: TracerDefinition) (tracer :: Type) :: Type where
+    TracerHKD MinSeverities tracer = Const (Maybe Severity) tracer
+    TracerHKD Concrete tracer = tracer
+
+-- * Construction
+
+-- | Convert a 'MinSeverities' of tracers into a 'Concrete' record of tracers,
+-- using a base opaque 'Tracer'.
+configureTracers
+    :: ( IsRecordOfTracers tracers m )
+    => tracers m MinSeverities
+    -> Tracer m SomeMsg
+    -> tracers m Concrete
+configureTracers f tr =
+    to . gConfigureTracers tr . from $ f
+
+class GConfigureTracers m (f :: Type -> Type) (g :: Type -> Type) where
+    gConfigureTracers
+        :: Tracer m SomeMsg
+        -> f (Const (Maybe Severity) tr)
+        -> g tr
+
+instance GConfigureTracers m f g => GConfigureTracers m (D1 c f) (D1 c g) where
+    gConfigureTracers tr = M1 . gConfigureTracers tr . unM1
+
+instance GConfigureTracers m f g => GConfigureTracers m (C1 c f) (C1 c g) where
+    gConfigureTracers tr = M1 . gConfigureTracers tr . unM1
+
+instance GConfigureTracers m f g => GConfigureTracers m (S1 c f) (S1 c g) where
+    gConfigureTracers tr = M1 . gConfigureTracers tr . unM1
+
+instance (GConfigureTracers m f0 g0, GConfigureTracers m f1 g1)
+    => GConfigureTracers m (f0 :*: f1) (g0 :*: g1)
+  where
+    gConfigureTracers tr (f0 :*: f1) =
+        gConfigureTracers tr f0
+        :*:
+        gConfigureTracers tr f1
+
+instance (ToJSON msg, HasSeverityAnnotation msg, Applicative m)
+    => GConfigureTracers m (K1 i (Const (Maybe Severity) (Tracer m msg))) (K1 i (Tracer m msg))
+  where
+    gConfigureTracers tr = \case
+        K1 (Const (Just minSeverity)) ->
+            K1 (contramap (SomeMsg minSeverity) tr)
+        K1 (Const Nothing) ->
+            K1 nullTracer
+
+-- | Assign a default value to a record of tracers.
+--
+-- This is useful when used in conjunction with 'Const' and a record of tracer
+-- severities:
+--
+--     defaultTracers Info == Tracers
+--         { tracerHttp = Const (Just Info)
+--         , tracerDb = Const (Just Info)
+--         }
+--
+defaultTracers
+    :: forall tracers (m :: Type -> Type).
+        ( Generic (tracers m MinSeverities)
+        , GDefaultRecord (Rep (tracers m MinSeverities))
+        , GDefaultRecordType (Rep (tracers m MinSeverities)) ~ Maybe Severity
+        )
+    => Maybe Severity
+    -> tracers m MinSeverities
+defaultTracers =
+    to . gDefaultRecord
+
+-- | This generic class allows for defining a default value to a record of
+-- functors wrapping some type 'a'.
+class GDefaultRecord (f :: Type -> Type) where
+    type GDefaultRecordType f :: Type
+    gDefaultRecord :: GDefaultRecordType f -> f (Const (GDefaultRecordType f) b)
+
+instance GDefaultRecord f => GDefaultRecord (D1 c f) where
+    type GDefaultRecordType (D1 c f) = GDefaultRecordType f
+    gDefaultRecord a = M1 (gDefaultRecord a)
+
+instance GDefaultRecord f => GDefaultRecord (C1 c f) where
+    type GDefaultRecordType (C1 c f) = GDefaultRecordType f
+    gDefaultRecord a = M1 (gDefaultRecord a)
+
+instance GDefaultRecord f => GDefaultRecord (S1 c f) where
+    type GDefaultRecordType (S1 c f) = GDefaultRecordType f
+    gDefaultRecord a = M1 (gDefaultRecord a)
+
+instance (GDefaultRecord f, GDefaultRecord g, GDefaultRecordType f ~ GDefaultRecordType g) => GDefaultRecord (f :*: g) where
+    type GDefaultRecordType (f :*: g) = GDefaultRecordType f
+    gDefaultRecord a = gDefaultRecord a :*: gDefaultRecord a
+
+instance GDefaultRecord (K1 i (Const a b)) where
+    type GDefaultRecordType (K1 i (Const a b)) = a
+    gDefaultRecord a = K1 (Const a)
+
+-- Internal
+
+-- A GADT capturing constraints as existential.
+data SomeMsg where
+    SomeMsg
+        :: forall msg. (ToJSON msg, HasSeverityAnnotation msg)
+        => Severity
+        -> msg
+        -> SomeMsg

--- a/server/modules/contra-tracers/src/Data/Severity.hs
+++ b/server/modules/contra-tracers/src/Data/Severity.hs
@@ -1,0 +1,49 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+
+module Data.Severity
+    ( Severity (..)
+    , HasSeverityAnnotation (..)
+    ) where
+
+import Prelude
+
+import Data.Aeson
+    ( FromJSON, ToJSON )
+import GHC.Generics
+    ( Generic )
+
+-- | Define a log-level severity.
+--
+-- +----------+----------------------------------------------------------------------------------+
+-- | Severity | Semantic                                                                         |
+-- +==========+==================================================================================+
+-- | Debug	  | Messages that contain information normally of use only when debugging a program. |
+-- | Info	  | Informational messages.                                                          |
+-- | Notice	  | Normal but significant conditions.                                               |
+-- | Warning  | A situation that may become an error.                                            |
+-- | Error	  | Unexpected problem.                                                              |
+-- +----------+----------------------------------------------------------------------------------+
+--
+data Severity
+    = Debug
+    | Info
+    | Notice
+    | Warning
+    | Error
+    deriving stock (Generic, Eq, Ord, Enum, Bounded, Show, Read)
+    deriving anyclass (ToJSON, FromJSON)
+
+-- | Associate a 'Severity' to a typed log message.
+--
+--     data MyLog = MyLog
+--     instance HasSeverityAnnotation MyLog where
+--         getSeverityAnnotation = \case
+--             MyLog -> Info
+--
+class HasSeverityAnnotation a where
+    getSeverityAnnotation :: a -> Severity

--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -138,6 +138,7 @@ library
     , cborg
     , containers
     , contra-tracer
+    , contra-tracers
     , directory
     , ekg-core
     , fast-bech32

--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -36,9 +36,9 @@ flag production
 library
   exposed-modules:
       Ogmios
+      Ogmios.App.Configuration
       Ogmios.App.Health
       Ogmios.App.Metrics
-      Ogmios.App.Options
       Ogmios.App.Protocol
       Ogmios.App.Protocol.ChainSync
       Ogmios.App.Protocol.StateQuery
@@ -69,6 +69,7 @@ library
       Ogmios.Data.Protocol.ChainSync
       Ogmios.Data.Protocol.StateQuery
       Ogmios.Data.Protocol.TxSubmission
+      Ogmios.Options
       Ogmios.Prelude
       Ogmios.Version
   other-modules:

--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -239,13 +239,13 @@ test-suite unit
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
-      Ogmios.App.OptionsSpec
       Ogmios.App.Protocol.ChainSyncSpec
       Ogmios.App.Protocol.StateQuerySpec
       Ogmios.App.ProtocolSpec
       Ogmios.Data.HealthSpec
       Ogmios.Data.JsonSpec
       Ogmios.Data.MetricsSpec
+      Ogmios.OptionsSpec
       Test.App.Protocol.Util
       Test.Generators
       Test.Instances.Util

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -58,6 +58,7 @@ library:
     - cborg
     - containers
     - contra-tracer
+    - contra-tracers
     - directory
     - ekg-core
     - fast-bech32

--- a/server/src/Ogmios.hs
+++ b/server/src/Ogmios.hs
@@ -22,12 +22,11 @@ module Ogmios
 
     -- * Command & Options
     , Command (..)
-    , Options (..)
-    , NetworkParameters (..)
     , parseOptions
 
     -- * Logging
-    , TraceOgmios (..)
+    , Tracers (..)
+    , mkTracers
     , withStdoutTracer
     ) where
 
@@ -38,24 +37,19 @@ import Cardano.Network.Protocol.NodeToClient
 import Control.Monad.Class.MonadST
     ( MonadST )
 import Data.Aeson
-    ( ToJSON, genericToEncoding )
+    ( ToJSON )
+import Ogmios.App.Configuration
+    ( Configuration (..), NetworkParameters (..), TraceConfiguration (..) )
 import Ogmios.App.Health
-    ( Health
-    , TraceHealth
-    , connectHealthCheckClient
-    , emptyHealth
-    , newHealthCheckClient
-    )
+    ( Health, connectHealthCheckClient, emptyHealth, newHealthCheckClient )
 import Ogmios.App.Metrics
-    ( RuntimeStats, Sampler, Sensors, TraceMetrics, newSampler, newSensors )
-import Ogmios.App.Options
-    ( Command (..), NetworkParameters (..), Options (..), parseOptions )
+    ( RuntimeStats, Sampler, Sensors, newSampler, newSensors )
 import Ogmios.App.Server
-    ( TraceServer, connectHybridServer )
+    ( connectHybridServer )
 import Ogmios.App.Server.Http
     ( mkHttpApp )
 import Ogmios.App.Server.WebSocket
-    ( TraceWebSocket, newWebSocketApp )
+    ( newWebSocketApp )
 import Ogmios.Control.Exception
     ( MonadCatch, MonadMask, MonadThrow )
 import Ogmios.Control.MonadAsync
@@ -63,10 +57,11 @@ import Ogmios.Control.MonadAsync
 import Ogmios.Control.MonadClock
     ( MonadClock, getCurrentTime, withDebouncer, _10s )
 import Ogmios.Control.MonadLog
-    ( HasSeverityAnnotation (..)
-    , Logger
+    ( HasSeverityAnnotation
     , MonadLog (..)
     , Severity (..)
+    , SomeMsg (..)
+    , Tracer
     , withStdoutTracer
     )
 import Ogmios.Control.MonadMetrics
@@ -75,6 +70,8 @@ import Ogmios.Control.MonadSTM
     ( MonadSTM (..), TVar, newTVar )
 import Ogmios.Control.MonadWebSocket
     ( MonadWebSocket )
+import Ogmios.Options
+    ( Command (..), Tracers (..), parseOptions )
 import Ogmios.Version
     ( version )
 import System.Posix.Signals
@@ -84,8 +81,6 @@ import System.Posix.Signals
     , raiseSignal
     , softwareTermination
     )
-
-import qualified Data.Aeson as Json
 
 --
 -- App
@@ -111,22 +106,22 @@ runWith :: forall a. App a -> Env App -> IO a
 runWith app = runReaderT (unApp app)
 
 -- | Ogmios, where everything gets stitched together.
-application :: Logger TraceOgmios -> App ()
-application tr = hijackSigTerm >> withDebouncer _10s (\debouncer -> do
+application :: Tracers IO Identity -> App ()
+application tracers = hijackSigTerm >> withDebouncer _10s (\debouncer -> do
     env@Env{network} <- ask
-    logWith tr (OgmiosNetwork network)
+    logWith tracerConfiguration (ConfigurationNetwork network)
 
-    healthCheckClient <- newHealthCheckClient (contramap OgmiosHealth tr) debouncer
+    healthCheckClient <- newHealthCheckClient tracerHealth debouncer
 
-    webSocketApp <- newWebSocketApp (contramap OgmiosWebSocket tr) (`runWith` env)
+    webSocketApp <- newWebSocketApp tracerWebSocket (`runWith` env)
     httpApp      <- mkHttpApp @_ @_ @Block (`runWith` env)
 
     concurrently_
-        (connectHealthCheckClient
-            (contramap OgmiosHealth tr) (`runWith` env) healthCheckClient)
-        (connectHybridServer
-            (contramap OgmiosServer tr) webSocketApp httpApp)
+        (connectHealthCheckClient tracerHealth (`runWith` env) healthCheckClient)
+        (connectHybridServer tracerServer webSocketApp httpApp)
     )
+  where
+    Tracers { tracerHealth, tracerWebSocket, tracerServer, tracerConfiguration } = tracers
 
 -- | The runtime does not let the application terminate gracefully when a
 -- SIGTERM is received. It does however for SIGINT which allows the application
@@ -146,57 +141,49 @@ hijackSigTerm =
 -- | Environment of the application, carrying around what's needed for the
 -- application to run.
 data Env (m :: Type -> Type) = Env
-    { health  :: !(TVar m (Health Block))
+    { health :: !(TVar m (Health Block))
     , sensors :: !(Sensors m)
     , sampler :: !(Sampler RuntimeStats m)
     , network :: !NetworkParameters
-    , options :: !Options
+    , configuration :: !Configuration
     } deriving stock (Generic)
 
 newEnvironment
-    :: Logger TraceOgmios
+    :: Tracers IO Identity
     -> NetworkParameters
-    -> Options
+    -> Configuration
     -> IO (Env App)
-newEnvironment tr network options = do
+newEnvironment Tracers{tracerMetrics} network configuration = do
     health  <- getCurrentTime >>= atomically . newTVar . emptyHealth
     sensors <- newSensors
-    sampler <- newSampler (contramap OgmiosMetrics tr)
-    pure $ Env{health,sensors,sampler,network,options}
+    sampler <- newSampler tracerMetrics
+    pure $ Env{health,sensors,sampler,network,configuration}
 
 --
 -- Logging
 --
 
-data TraceOgmios where
-    OgmiosHealth
-        :: { healthCheck :: TraceHealth (Health Block) }
-        -> TraceOgmios
-
-    OgmiosMetrics
-        :: { metrics :: TraceMetrics }
-        -> TraceOgmios
-
-    OgmiosWebSocket
-        :: { webSocket :: TraceWebSocket }
-        -> TraceOgmios
-
-    OgmiosServer
-        :: { server :: TraceServer }
-        -> TraceOgmios
-
-    OgmiosNetwork
-        :: { networkParameters :: NetworkParameters }
-        -> TraceOgmios
-    deriving stock (Generic, Show)
-
-instance ToJSON TraceOgmios where
-    toEncoding = genericToEncoding Json.defaultOptions
-
-instance HasSeverityAnnotation TraceOgmios where
-    getSeverityAnnotation = \case
-        OgmiosHealth msg    -> getSeverityAnnotation msg
-        OgmiosMetrics msg   -> getSeverityAnnotation msg
-        OgmiosWebSocket msg -> getSeverityAnnotation msg
-        OgmiosServer msg    -> getSeverityAnnotation msg
-        OgmiosNetwork{}     -> Info
+mkTracers
+    :: forall m. ()
+    => Tracers m (Const Severity)
+    -> Tracer m SomeMsg
+    -> Tracers m Identity
+mkTracers tracers tr =
+    Tracers
+        { tracerHealth =
+            useTracer tracerHealth
+        , tracerMetrics =
+            useTracer tracerMetrics
+        , tracerWebSocket =
+            useTracer tracerWebSocket
+        , tracerServer =
+            useTracer tracerServer
+        , tracerConfiguration =
+            useTracer tracerConfiguration
+        }
+  where
+    useTracer
+        :: forall msg. (ToJSON msg, HasSeverityAnnotation msg)
+        => (Tracers m (Const Severity) -> Const Severity (Tracer m msg))
+        -> Tracer m msg
+    useTracer getter = contramap (SomeMsg . getConst . getter $ tracers) tr

--- a/server/src/Ogmios.hs
+++ b/server/src/Ogmios.hs
@@ -26,8 +26,7 @@ module Ogmios
 
     -- * Logging
     , Tracers (..)
-    , mkTracers
-    , withStdoutTracer
+    , withStdoutTracers
     ) where
 
 import Ogmios.Prelude
@@ -55,7 +54,7 @@ import Ogmios.Control.MonadAsync
 import Ogmios.Control.MonadClock
     ( MonadClock, getCurrentTime, withDebouncer, _10s )
 import Ogmios.Control.MonadLog
-    ( MonadLog (..), mkTracers, withStdoutTracer )
+    ( MonadLog (..), TracerDefinition (..), withStdoutTracers )
 import Ogmios.Control.MonadMetrics
     ( MonadMetrics )
 import Ogmios.Control.MonadSTM
@@ -98,7 +97,7 @@ runWith :: forall a. App a -> Env App -> IO a
 runWith app = runReaderT (unApp app)
 
 -- | Ogmios, where everything gets stitched together.
-application :: Tracers IO Identity -> App ()
+application :: Tracers IO 'Concrete -> App ()
 application tracers = hijackSigTerm >> withDebouncer _10s (\debouncer -> do
     env@Env{network} <- ask
     logWith tracerConfiguration (ConfigurationNetwork network)
@@ -141,7 +140,7 @@ data Env (m :: Type -> Type) = Env
     } deriving stock (Generic)
 
 newEnvironment
-    :: Tracers IO Identity
+    :: Tracers IO 'Concrete
     -> NetworkParameters
     -> Configuration
     -> IO (Env App)

--- a/server/src/Ogmios/App/Configuration.hs
+++ b/server/src/Ogmios/App/Configuration.hs
@@ -1,0 +1,88 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Ogmios.App.Configuration
+    (
+    -- * Configuration
+    Configuration (..)
+    , Severity (..)
+
+    -- * NetworkParameters
+    , NetworkParameters (..)
+    , NetworkMagic (..)
+    , EpochSlots (..)
+    , SystemStart (..)
+    , mkSystemStart
+
+    -- * Logging
+    , TraceConfiguration (..)
+    ) where
+
+import Ogmios.Prelude
+
+import Ogmios.Control.MonadLog
+    ( HasSeverityAnnotation (..), Severity (..) )
+
+import Cardano.Chain.Slotting
+    ( EpochSlots (..) )
+import Data.Aeson
+    ( ToJSON, genericToEncoding )
+import Data.Time.Clock.POSIX
+    ( posixSecondsToUTCTime )
+import Ouroboros.Consensus.BlockchainTime.WallClock.Types
+    ( SystemStart (..) )
+import Ouroboros.Network.Magic
+    ( NetworkMagic (..) )
+
+import qualified Data.Aeson as Json
+
+data Configuration = Configuration
+    { nodeSocket :: !FilePath
+    , nodeConfig :: !FilePath
+    , serverHost :: !String
+    , serverPort :: !Int
+    , connectionTimeout :: !Int
+    , maxInFlight :: !Int
+    } deriving (Generic, Eq, Show)
+
+data NetworkParameters = NetworkParameters
+    { networkMagic :: !NetworkMagic
+    , systemStart :: !SystemStart
+    , slotsPerEpoch :: !EpochSlots
+    } deriving stock (Generic, Eq, Show)
+      deriving anyclass (ToJSON)
+
+mkSystemStart :: Int -> SystemStart
+mkSystemStart =
+    SystemStart . posixSecondsToUTCTime . toPicoResolution . toEnum
+  where
+    toPicoResolution = (*1000000000000)
+
+deriving newtype instance ToJSON EpochSlots
+deriving newtype instance ToJSON SystemStart
+deriving newtype instance ToJSON NetworkMagic
+
+--
+-- Logging
+--
+
+data TraceConfiguration where
+    ConfigurationNetwork
+        :: { networkParameters :: NetworkParameters }
+        -> TraceConfiguration
+    deriving stock (Generic, Show)
+
+instance ToJSON TraceConfiguration where
+    toEncoding =
+        genericToEncoding Json.defaultOptions
+
+instance HasSeverityAnnotation TraceConfiguration where
+    getSeverityAnnotation = \case
+        ConfigurationNetwork{} -> Info

--- a/server/src/Ogmios/App/Health.hs
+++ b/server/src/Ogmios/App/Health.hs
@@ -24,10 +24,10 @@ module Ogmios.App.Health
 
 import Ogmios.Prelude
 
+import Ogmios.App.Configuration
+    ( Configuration (..), NetworkParameters (..) )
 import Ogmios.App.Metrics
     ( RuntimeStats, Sampler, Sensors )
-import Ogmios.App.Options
-    ( NetworkParameters (..), Options (..) )
 import Ogmios.Control.Exception
     ( IOException
     , MonadCatch (..)
@@ -157,7 +157,7 @@ connectHealthCheckClient
         , MonadOuroboros m
         , MonadReader env m
         , HasType NetworkParameters env
-        , HasType Options env
+        , HasType Configuration env
         )
     => Logger (TraceHealth (Health Block))
     -> (forall a. m a -> IO a)
@@ -165,7 +165,7 @@ connectHealthCheckClient
     -> m ()
 connectHealthCheckClient tr embed (HealthCheckClient clients) = do
     NetworkParameters{slotsPerEpoch,networkMagic} <- asks (view typed)
-    Options{nodeSocket} <- asks (view typed)
+    Configuration{nodeSocket} <- asks (view typed)
     let client = mkClient embed nullTracer slotsPerEpoch clients
     connectClient nullTracer client (NodeToClientVersionData networkMagic) nodeSocket
         & onExceptions nodeSocket

--- a/server/src/Ogmios/App/Server.hs
+++ b/server/src/Ogmios/App/Server.hs
@@ -17,8 +17,8 @@ module Ogmios.App.Server
 
 import Ogmios.Prelude
 
-import Ogmios.App.Options
-    ( Options (..) )
+import Ogmios.App.Configuration
+    ( Configuration (..) )
 import Ogmios.Control.MonadLog
     ( HasSeverityAnnotation (..), Logger, MonadLog (..), Severity (..) )
 import Ogmios.Control.MonadWebSocket
@@ -49,7 +49,7 @@ connectHybridServer
     :: forall m env.
         ( MonadIO m
         , MonadReader env m
-        , HasType Options env
+        , HasType Configuration env
         )
     => Logger TraceServer
     -> WebSocketApp
@@ -61,15 +61,15 @@ connectHybridServer tr webSocketApp httpApp = do
         $ Warp.runSettings (serverSettings opts)
         $ Wai.websocketsOr WS.defaultConnectionOptions webSocketApp httpApp
   where
-    serverSettings opts@Options{serverHost, serverPort, connectionTimeout} =
+    serverSettings opts@Configuration{serverHost, serverPort, connectionTimeout} =
         Warp.defaultSettings
         & Warp.setHost (fromString serverHost)
         & Warp.setPort serverPort
         & Warp.setBeforeMainLoop (beforeMainLoop opts)
         & Warp.setTimeout connectionTimeout
 
-    beforeMainLoop :: Options -> IO ()
-    beforeMainLoop Options{nodeSocket,serverHost,serverPort} = do
+    beforeMainLoop :: Configuration -> IO ()
+    beforeMainLoop Configuration{nodeSocket,serverHost,serverPort} = do
         socketExist <- doesPathExist nodeSocket
         unless socketExist $ logWith tr $ ServerNodeSocketNotFound nodeSocket
         logWith tr $ ServerStarted{dashboardUrl, nodeSocket}

--- a/server/src/Ogmios/App/Server/WebSocket.hs
+++ b/server/src/Ogmios/App/Server/WebSocket.hs
@@ -42,6 +42,7 @@ import Ogmios.Control.MonadLog
     , Logger
     , MonadLog (..)
     , Severity (..)
+    , getSeverityAnnotation'
     , natTracer
     )
 import Ogmios.Control.MonadMetrics
@@ -319,7 +320,7 @@ data TraceWebSocket where
 
 instance HasSeverityAnnotation TraceWebSocket where
     getSeverityAnnotation = \case
-        WebSocketClient msg           -> getSeverityAnnotation msg
+        WebSocketClient msg           -> getSeverityAnnotation' msg
         WebSocketStateQuery msg       -> getSeverityAnnotation msg
         WebSocketWorkerExited{}       -> Debug
         WebSocketConnectionAccepted{} -> Info

--- a/server/src/Ogmios/App/Server/WebSocket.hs
+++ b/server/src/Ogmios/App/Server/WebSocket.hs
@@ -19,10 +19,10 @@ module Ogmios.App.Server.WebSocket
 
 import Ogmios.Prelude
 
+import Ogmios.App.Configuration
+    ( Configuration (..), NetworkParameters (..) )
 import Ogmios.App.Metrics
     ( Sensors (..), recordSession )
-import Ogmios.App.Options
-    ( NetworkParameters (..), Options (..) )
 import Ogmios.App.Protocol
     ( onUnmatchedMessage )
 import Ogmios.App.Protocol.ChainSync
@@ -115,7 +115,7 @@ newWebSocketApp
         , MonadReader env m
         , MonadLog m
         , HasType NetworkParameters env
-        , HasType Options env
+        , HasType Configuration env
         , HasType (Sensors m) env
         )
     => Logger TraceWebSocket
@@ -123,7 +123,7 @@ newWebSocketApp
     -> m WebSocketApp
 newWebSocketApp tr unliftIO = do
     NetworkParameters{slotsPerEpoch,networkMagic} <- asks (view typed)
-    Options{nodeSocket,maxInFlight} <- asks (view typed)
+    Configuration{nodeSocket,maxInFlight} <- asks (view typed)
     sensors <- asks (view typed)
     return $ \pending -> unliftIO $ do
         let (mode, sub) = choseSerializationMode pending

--- a/server/src/Ogmios/Control/MonadLog.hs
+++ b/server/src/Ogmios/Control/MonadLog.hs
@@ -2,13 +2,15 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE UndecidableInstances #-}
-
 module Ogmios.Control.MonadLog
     ( -- * Class
       MonadLog (..)
     , Logger
+
+      -- * Severity
+    , Severity (..)
+    , HasSeverityAnnotation (..)
+    , getSeverityAnnotation'
 
       -- * Tracer
     , Tracer
@@ -17,32 +19,35 @@ module Ogmios.Control.MonadLog
     , contramap
     , traceWith
 
-      -- * Severity
-    , Severity (..)
-    , HasSeverityAnnotation (..)
-
-      -- * Instantiation
-    , mkTracers
+      -- * Tracers
+    , TracerDefinition(..)
+    , type TracerHKD
     , defaultTracers
-    , withStdoutTracer
+    , withStdoutTracers
     ) where
 
 import Ogmios.Prelude
 
-import Cardano.BM.Data.Severity
-    ( Severity (..) )
-import Cardano.BM.Data.Tracer
-    ( HasSeverityAnnotation (..) )
+import Control.Concurrent
+    ( myThreadId )
 import Control.Monad.IOSim
     ( IOSim )
 import Control.Tracer
     ( Tracer (..), natTracer, nullTracer, traceWith )
 import Data.Aeson
-    ( ToJSON (..) )
+    ( ToJSON (..), toEncoding )
 import Data.Aeson.Encoding
-    ( pair, pairs )
-import GHC.Conc
-    ( myThreadId )
+    ( Encoding, encodingToLazyByteString, pair, pairs )
+import Data.Generics.Tracers
+    ( IsRecordOfTracers
+    , SomeMsg (..)
+    , TracerDefinition (..)
+    , TracerHKD
+    , configureTracers
+    , defaultTracers
+    )
+import Data.Severity
+    ( HasSeverityAnnotation (..), Severity (..) )
 import Ogmios.Control.MonadClock
     ( getCurrentTime )
 import Ogmios.Control.MonadSTM
@@ -50,17 +55,14 @@ import Ogmios.Control.MonadSTM
 import System.IO
     ( BufferMode (..), hSetBuffering, hSetEncoding, utf8 )
 
-import GHC.Generics
-
-import qualified Data.Aeson.Encoding as Json
-import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
+import qualified Cardano.BM.Data.Severity as BM
+import qualified Cardano.BM.Data.Tracer as BM
+import qualified Data.ByteString.Lazy.Char8 as BL8
 
 class Monad m => MonadLog (m :: Type -> Type) where
     logWith :: Logger msg -> msg -> m ()
 
 type Logger = Tracer IO
-type AppVersion = Text
 
 instance MonadLog IO where
     logWith = traceWith
@@ -73,26 +75,38 @@ instance MonadLog (IOSim s) where
 instance MonadLog m => MonadLog (ReaderT env m) where
     logWith tr = lift . logWith tr
 
--- | Acquire a tracer to use across the app lifecycle.
-withStdoutTracer
-    :: AppVersion
-    -> (Tracer IO SomeMsg -> IO ())
+type AppVersion = Text
+
+-- | Acquire and configure multiple tracers which outputs structured JSON on the
+-- standard output. The tracer is concurrent-safe but none buffered, while it is
+-- okay for a vast majority of applications, it also relies on a simple
+-- implementation and does not perform any caching or hardcore optimizations;
+-- For example timestamps are computed on-the-fly for every log messages.
+--
+withStdoutTracers
+    :: forall tracers. (IsRecordOfTracers tracers IO)
+    => AppVersion
+        -- ^ Extra information to embed in the logging envelope.
+    -> tracers IO 'MinSeverities
+        -- ^ A configuration of tracers.
+    -> (tracers IO 'Concrete -> IO ())
+        -- ^ Callback with acquired and configured tracers.
     -> IO ()
-withStdoutTracer version action = do
+withStdoutTracers version tracers action = do
     hSetBuffering stdout LineBuffering
     hSetEncoding stdout utf8
     lock <- newTMVarIO ()
-    action (tracer lock)
+    action (configureTracers tracers (tracer lock))
   where
     tracer lock = Tracer $ \(SomeMsg minSeverity msg) -> do
         let severity = getSeverityAnnotation msg
         when (severity >= minSeverity) $ liftIO $ withTMVar lock $ \() -> do
-            mkEnvelop msg severity >>= liftIO . TIO.putStrLn . decodeUtf8 . Json.encodingToLazyByteString
+            mkEnvelop msg severity >>= liftIO . BL8.putStrLn . encodingToLazyByteString
 
-    mkEnvelop :: forall m msg. (ToJSON msg, MonadIO m) => msg -> Severity -> m Json.Encoding
+    mkEnvelop :: forall m msg. (ToJSON msg, MonadIO m) => msg -> Severity -> m Encoding
     mkEnvelop msg severity = do
         timestamp <- liftIO getCurrentTime
-        threadId <- T.drop 9 . show <$> liftIO myThreadId
+        threadId <- drop 9 . show <$> liftIO myThreadId
         pure $ pairs $ mempty
             <> pair "severity"  (toEncoding severity)
             <> pair "timestamp" (toEncoding timestamp)
@@ -100,106 +114,22 @@ withStdoutTracer version action = do
             <> pair "message"   (toEncoding msg)
             <> pair "version"   (toEncoding version)
 
---
--- Declaring Tracers
---
-
-data SomeMsg where
-    SomeMsg :: forall msg. (ToJSON msg, HasSeverityAnnotation msg) => Severity -> msg -> SomeMsg
-
--- | Generically instantiate tracers from a record type. The record is
--- parameterized by a functor which is intended to be one of:
---
--- - Const
--- - Identity
---
--- 'Const' is used to define a record of minimum severities, for configuring the
--- tracers independently. This function then instantiates each field of the
--- record to an actual tracer with a configured minimum severity.
---
---     data Tracers m (f :: Type -> Type) = Tracers
---         { tracerFoo
---             :: HKD f (Tracer m Foo)
---         , tracerBar
---             :: HKD f (Tracer m Bar)
---         } deriving (Generic)
---
---     mkTracersSpecialized
---       :: Tracers m (Const Severity)
---       -> Tracer m SomeMsg
---       -> Tracers m Identity
---
-mkTracers
-    :: ( Generic (f m Identity)
-       , Generic (f m (Const Severity))
-       , GMkTracers m (Rep (f m (Const Severity))) (Rep (f m Identity))
-       )
-    => f m (Const Severity)
-    -> Tracer m SomeMsg
-    -> f m Identity
-mkTracers f tr =
-    to . gMkTracers tr . from $ f
-
-defaultTracers
-    :: ( Generic (f (Const Severity))
-       , GDefaultTracers (Rep (f (Const Severity)))
-       )
-    => Severity
-    -> f (Const Severity)
-defaultTracers =
-    to . gDefaultTracers
-
-
-class GMkTracers m (f :: Type -> Type) (g :: Type -> Type) where
-    gMkTracers
-        :: Tracer m SomeMsg
-        -> f (Const Severity tr)
-        -> g tr
-
-instance GMkTracers m f g => GMkTracers m (D1 c f) (D1 c g) where
-    gMkTracers tr =
-        M1 . gMkTracers tr . unM1
-
-instance GMkTracers m f g => GMkTracers m (C1 c f) (C1 c g) where
-    gMkTracers tr =
-        M1 . gMkTracers tr . unM1
-
-instance GMkTracers m f g => GMkTracers m (S1 c f) (S1 c g) where
-    gMkTracers tr =
-        M1 . gMkTracers tr . unM1
-
-instance (GMkTracers m f0 g0, GMkTracers m f1 g1) => GMkTracers m (f0 :*: f1) (g0 :*: g1) where
-    gMkTracers tr (f0 :*: f1) =
-        gMkTracers tr f0 :*: gMkTracers tr f1
-
-instance (ToJSON msg, HasSeverityAnnotation msg)
-    => GMkTracers m (K1 i (Const Severity (Tracer m msg))) (K1 i (Tracer m msg))
+-- | Working around iohk-monitoring. Ogmios doesn't use 'Severity' from
+-- iohk-monitoring because the JSON instances are bonkers and, it defines way
+-- too many severity levels. Still, there are places where we need to convert
+-- from existing severity types (when wrapping traces from ouroboros-network in
+-- particular).
+getSeverityAnnotation' :: BM.HasSeverityAnnotation msg => msg -> Severity
+getSeverityAnnotation' =
+    toSeverity . BM.getSeverityAnnotation
   where
-    gMkTracers tr (K1 msg) =
-        K1 (contramap (SomeMsg (getConst msg)) tr :: Tracer m msg)
-
-
-class GDefaultTracers (f :: Type -> Type) where
-    gDefaultTracers
-        :: Severity
-        -> f (Const Severity b)
-
-instance GDefaultTracers f => GDefaultTracers (D1 c f) where
-    gDefaultTracers minSeverity =
-        M1 (gDefaultTracers minSeverity)
-
-instance GDefaultTracers f => GDefaultTracers (C1 c f) where
-    gDefaultTracers minSeverity =
-        M1 (gDefaultTracers minSeverity)
-
-instance GDefaultTracers f => GDefaultTracers (S1 c f) where
-    gDefaultTracers minSeverity =
-        M1 (gDefaultTracers minSeverity)
-
-instance (GDefaultTracers f, GDefaultTracers g) => GDefaultTracers (f :*: g) where
-    gDefaultTracers minSeverity =
-        gDefaultTracers minSeverity :*: gDefaultTracers minSeverity
-
-instance GDefaultTracers (K1 i (Const Severity b))  where
-    gDefaultTracers minSeverity =
-        K1 (Const minSeverity)
+    toSeverity :: BM.Severity -> Severity
+    toSeverity = \case
+        BM.Debug -> Debug
+        BM.Info -> Info
+        BM.Notice -> Notice
+        BM.Warning -> Warning
+        BM.Error -> Error
+        BM.Critical -> Error
+        BM.Alert -> Error
+        BM.Emergency -> Error

--- a/server/src/Ogmios/Options.hs
+++ b/server/src/Ogmios/Options.hs
@@ -40,7 +40,7 @@ import Ogmios.App.Server
 import Ogmios.App.Server.WebSocket
     ( TraceWebSocket )
 import Ogmios.Control.MonadLog
-    ( Severity (..), Tracer )
+    ( Severity (..), Tracer, defaultTracers )
 
 import Cardano.Network.Protocol.NodeToClient
     ( Block )
@@ -192,7 +192,7 @@ maxInFlightOption = option auto $ mempty
 
 -- | [--log-level=SEVERITY]
 tracersOption :: Parser (Tracers m (Const Severity))
-tracersOption = fmap mkDefaultTracers $ option caseInsensitive $ mempty
+tracersOption = fmap defaultTracers $ option caseInsensitive $ mempty
     <> long "log-level"
     <> metavar "SEVERITY"
     <> helpDoc (Just doc)
@@ -296,19 +296,10 @@ data Tracers m (f :: Type -> Type) = Tracers
         :: HKD f (Tracer m TraceServer)
     , tracerConfiguration
         :: HKD f (Tracer m TraceConfiguration)
-    }
+    } deriving (Generic)
 
 deriving instance Show (Tracers m (Const Severity))
 deriving instance Eq (Tracers m (Const Severity))
-
-mkDefaultTracers :: Severity -> Tracers m (Const Severity)
-mkDefaultTracers minSeverity = Tracers
-    { tracerHealth = Const minSeverity
-    , tracerMetrics = Const minSeverity
-    , tracerWebSocket = Const minSeverity
-    , tracerServer = Const minSeverity
-    , tracerConfiguration = Const minSeverity
-    }
 
 --
 -- Helpers

--- a/server/src/Ogmios/Prelude.hs
+++ b/server/src/Ogmios/Prelude.hs
@@ -27,6 +27,7 @@ module Ogmios.Prelude
     , keepRedundantConstraint
     , LastElem
     , Or
+    , HKD
     ) where
 
 import Data.Generics.Internal.VL.Lens
@@ -98,3 +99,7 @@ type family Or (a :: Constraint) (b :: Constraint) :: Constraint where
     Or (x ~ x) b = Or () b
     Or a () = ()
     Or a (x ~ x) = Or a ()
+
+type family HKD f a where
+  HKD Identity a = a
+  HKD f a = f a

--- a/server/stack.yaml
+++ b/server/stack.yaml
@@ -5,6 +5,7 @@ compiler: ghc-8.10.4 # Simply for reference, already inferred from the resolver.
 packages:
 - .
 - modules/cardano-client
+- modules/contra-tracers
 - modules/fast-bech32
 - modules/git-th
 - modules/hspec-json-schema

--- a/server/test/unit/Ogmios/App/Protocol/ChainSyncSpec.hs
+++ b/server/test/unit/Ogmios/App/Protocol/ChainSyncSpec.hs
@@ -23,7 +23,7 @@ import Data.Aeson
     ( ToJSON (..) )
 import Network.TypedProtocol.Codec
     ( Codec (..), PeerHasAgency (..), SomeMessage (..), runDecoder )
-import Ogmios.App.Options
+import Ogmios.App.Configuration
     ( EpochSlots (..) )
 import Ogmios.App.Protocol.ChainSync
     ( MaxInFlight, mkChainSyncClient )

--- a/server/test/unit/Ogmios/App/Protocol/StateQuerySpec.hs
+++ b/server/test/unit/Ogmios/App/Protocol/StateQuerySpec.hs
@@ -30,7 +30,7 @@ import GHC.TypeLits
     ( KnownSymbol )
 import Network.TypedProtocol.Codec
     ( Codec (..), PeerHasAgency (..), SomeMessage (..), runDecoder )
-import Ogmios.App.Options
+import Ogmios.App.Configuration
     ( EpochSlots (..) )
 import Ogmios.App.Protocol.StateQuery
     ( mkStateQueryClient )

--- a/server/test/unit/Ogmios/OptionsSpec.hs
+++ b/server/test/unit/Ogmios/OptionsSpec.hs
@@ -9,7 +9,7 @@
 -- because it's test code and, having it fail would be instantly caught.
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 
-module Ogmios.App.OptionsSpec
+module Ogmios.OptionsSpec
     ( spec
     ) where
 
@@ -17,14 +17,18 @@ import Ogmios.Prelude
 
 import Data.List
     ( isInfixOf )
-import Ogmios.App.Options
-    ( Command (..)
+import Ogmios.App.Configuration
+    ( Configuration (..)
     , EpochSlots (..)
     , NetworkMagic (..)
     , NetworkParameters (..)
-    , Options (..)
-    , Severity (..)
     , mkSystemStart
+    )
+import Ogmios.Control.MonadLog
+    ( Severity (..), TracerDefinition (..), defaultTracers )
+import Ogmios.Options
+    ( Command (..)
+    , Tracers (..)
     , parseNetworkParameters
     , parseOptions
     , parseOptionsPure
@@ -71,14 +75,14 @@ spec = parallel $ do
                 , "--node-config", getConfigFile "testnet"
                 ]
         specify (show args) $ withArgs args parseOptions >>= \case
-            Start (Identity _) opts -> do
+            Start (Identity _) opts logLevels -> do
                 nodeSocket opts `shouldBe` "./node.socket"
                 nodeConfig opts `shouldBe` getConfigFile "testnet"
                 serverHost opts `shouldBe` "127.0.0.1"
                 serverPort opts `shouldBe` 1337
                 connectionTimeout opts `shouldBe` 90
                 maxInFlight opts `shouldBe` 1000
-                logLevel opts `shouldBe` Info
+                logLevels `shouldBe` defaultTracersInfo
             Version -> expectationFailure "Expected Start but got Version."
 
     context "parseNetworkParameters" $ do
@@ -108,69 +112,107 @@ spec = parallel $ do
         , ( [ "--node-socket", "/path/to/socket"
             , "--node-config", "./node.config"
             ]
-          , shouldSucceed defaultOptions { nodeSocket = "/path/to/socket" }
+          , shouldSucceed
+                (defaultConfiguration { nodeSocket = "/path/to/socket" })
+                defaultTracersInfo
           )
 
         , ( [ "--node-socket", "./node.socket"
             , "--node-config", "/path/to/config"
             ]
-          , shouldSucceed defaultOptions { nodeConfig = "/path/to/config" }
+          , shouldSucceed
+                (defaultConfiguration { nodeConfig = "/path/to/config" })
+                defaultTracersInfo
           )
 
         , ( defaultArgs ++ [ "--host", "0.0.0.0" ]
-          , shouldSucceed defaultOptions { serverHost = "0.0.0.0" }
+          , shouldSucceed
+                (defaultConfiguration { serverHost = "0.0.0.0" })
+                defaultTracersInfo
           )
 
         , ( defaultArgs ++ [ "--port", "42" ]
-          , shouldSucceed defaultOptions { serverPort = 42 }
+          , shouldSucceed
+                (defaultConfiguration { serverPort = 42 })
+                defaultTracersInfo
           )
         , ( defaultArgs ++ [ "--port", "#" ]
           , shouldFail
           )
 
         , ( defaultArgs ++ [ "--timeout", "42" ]
-          , shouldSucceed defaultOptions { connectionTimeout = 42 }
+          , shouldSucceed
+                (defaultConfiguration { connectionTimeout = 42 })
+                defaultTracersInfo
           )
         , ( defaultArgs ++ [ "--timeout", "#" ]
           , shouldFail
           )
 
         , ( defaultArgs ++ [ "--max-in-flight", "42" ]
-          , shouldSucceed defaultOptions { maxInFlight = 42 }
+          , shouldSucceed
+                (defaultConfiguration { maxInFlight = 42 })
+                defaultTracersInfo
           )
         , ( defaultArgs ++ [ "--max-in-flight", "#" ]
           , shouldFail
           )
 
         , ( defaultArgs ++ [ "--log-level", "Debug" ]
-          , shouldSucceed defaultOptions { logLevel = Debug }
+          , shouldSucceed defaultConfiguration (defaultTracersDebug)
           )
         , ( defaultArgs ++ [ "--log-level", "debug" ]
-          , shouldSucceed defaultOptions { logLevel = Debug }
+          , shouldSucceed defaultConfiguration (defaultTracersDebug)
           )
         , ( defaultArgs ++ [ "--log-level", "Info" ]
-          , shouldSucceed defaultOptions { logLevel = Info }
+          , shouldSucceed defaultConfiguration defaultTracersInfo
           )
         , ( defaultArgs ++ [ "--log-level", "info" ]
-          , shouldSucceed defaultOptions { logLevel = Info }
+          , shouldSucceed defaultConfiguration defaultTracersInfo
           )
         , ( defaultArgs ++ [ "--log-level", "Notice" ]
-          , shouldSucceed defaultOptions { logLevel = Notice }
+          , shouldSucceed defaultConfiguration (defaultTracersNotice)
           )
         , ( defaultArgs ++ [ "--log-level", "notice" ]
-          , shouldSucceed defaultOptions { logLevel = Notice }
+          , shouldSucceed defaultConfiguration (defaultTracersNotice)
           )
         , ( defaultArgs ++ [ "--log-level", "Warning" ]
-          , shouldSucceed defaultOptions { logLevel = Warning }
+          , shouldSucceed defaultConfiguration (defaultTracersWarning)
           )
         , ( defaultArgs ++ [ "--log-level", "warning" ]
-          , shouldSucceed defaultOptions { logLevel = Warning }
+          , shouldSucceed defaultConfiguration (defaultTracersWarning)
           )
         , ( defaultArgs ++ [ "--log-level", "Error" ]
-          , shouldSucceed defaultOptions { logLevel = Error }
+          , shouldSucceed defaultConfiguration (defaultTracersError)
           )
         , ( defaultArgs ++ [ "--log-level", "error" ]
-          , shouldSucceed defaultOptions { logLevel = Error }
+          , shouldSucceed defaultConfiguration (defaultTracersError)
+          )
+
+        , ( defaultArgs ++ [ "--log-level-health", "Notice" ]
+          , shouldSucceed
+                defaultConfiguration
+                (defaultTracersInfo { tracerHealth = Const (Just Notice) })
+          )
+
+        , ( defaultArgs ++
+                [ "--log-level-metrics", "Debug"
+                , "--log-level-websocket", "Warning"
+                ]
+          , shouldSucceed
+                defaultConfiguration
+                (defaultTracersInfo
+                    { tracerMetrics = Const (Just Debug)
+                    , tracerWebSocket = Const (Just Warning)
+                    }
+                )
+          )
+
+        , ( defaultArgs ++
+                [ "--log-level", "Error"
+                , "--log-level-health", "Debug"
+                ]
+          , shouldFail
           )
 
         , ( [ "version" ], flip shouldBe $ Right Version )
@@ -191,9 +233,24 @@ spec = parallel $ do
 -- Helper
 --
 
-defaultOptions :: Options
-defaultOptions = parseOptionsPure defaultArgs
-    & either (error . toText) (\(Start _ opts) -> opts)
+defaultConfiguration :: Configuration
+defaultConfiguration = parseOptionsPure defaultArgs
+    & either (error . toText) (\(Start _ cfg _) -> cfg)
+
+defaultTracersDebug :: Tracers IO 'MinSeverities
+defaultTracersDebug = defaultTracers (Just Debug)
+
+defaultTracersInfo :: Tracers IO 'MinSeverities
+defaultTracersInfo = defaultTracers (Just Info)
+
+defaultTracersNotice :: Tracers IO 'MinSeverities
+defaultTracersNotice = defaultTracers (Just Notice)
+
+defaultTracersWarning :: Tracers IO 'MinSeverities
+defaultTracersWarning = defaultTracers (Just Warning)
+
+defaultTracersError :: Tracers IO 'MinSeverities
+defaultTracersError = defaultTracers (Just Error)
 
 defaultArgs :: [String]
 defaultArgs =
@@ -201,9 +258,12 @@ defaultArgs =
     , "--node-config", "./node.config"
     ]
 
-shouldSucceed :: Options -> (Either String (Command Proxy) -> Expectation)
-shouldSucceed =
-    flip shouldBe . Right . Start Proxy
+shouldSucceed
+    :: Configuration
+    -> Tracers IO 'MinSeverities
+    -> (Either String (Command Proxy) -> Expectation)
+shouldSucceed cfg =
+    flip shouldBe . Right . Start Proxy cfg
 
 shouldFail :: (Either String (Command Proxy)) -> Expectation
 shouldFail = flip shouldSatisfy isLeft


### PR DESCRIPTION
# Overview

Fixes #145 

```
$ ogmios --help
Provides a bridge between cardano-node and WebSocket clients. Ogmios translates
the existing CBOR-based Ouroboros mini-protocols into JSON-WSP-based protocols,
through WebSocket channels.

Usage: ogmios ((-v|--version) | --node-socket FILEPATH --node-config FILEPATH 
                [--host IPv4] [--port TCP/PORT] [--timeout SECONDS] 
                [--max-in-flight INT] 
                [--log-level SEVERITY | [--log-level-health SEVERITY] 
                  [--log-level-metrics SEVERITY] 
                  [--log-level-websocket SEVERITY] [--log-level-server SEVERITY]
                  [--log-level-options SEVERITY]])
  Ogmios - A JSON-WSP WebSocket adaptor for cardano-node

Available options:
  -h,--help                Show this help text
  -v,--version             Show the software current version and build revision.
  --node-socket FILEPATH   Path to the node socket.
  --node-config FILEPATH   Path to the node configuration file.
  --host IPv4              Address to bind to. (default: "127.0.0.1")
  --port TCP/PORT          Port to listen on. (default: 1337)
  --timeout SECONDS        Number of seconds of inactivity after which the
                           server should close client connections. (default: 90)
  --max-in-flight INT      Max number of ChainSync requests which can be
                           pipelined at once. Only applies to the chain-sync
                           protocol. (default: 1000)
  --log-level SEVERITY     Minimal severity of all log messages.
                           - Debug
                           - Info
                           - Notice
                           - Warning
                           - Error
                           - Critical
                           - Alert
                           - Emergency
  --log-level-health SEVERITY
                           Minimal severity of health log messages. (default: Info)
  --log-level-metrics SEVERITY
                           Minimal severity of metrics log messages. (default: Info)
  --log-level-websocket SEVERITY
                           Minimal severity of websocket log messages. (default: Info)
  --log-level-server SEVERITY
                           Minimal severity of server log messages. (default: Info)
  --log-level-options SEVERITY
                           Minimal severity of options log messages. (default: Info)
```

# History

 - :round_pushpin: **Allow logging min severity to be configured per-component.**
    And still, allow to configure it globally if necessary via
  `--log-level`.

- :round_pushpin: **Replace tracer boilerplate with generics.**
    Probably want to move that to a separate package 'generic-tracers'

- :round_pushpin: **Define 'contra-tracers' module to generically declare many tracers from a record.**
    The generic part here is maybe a bit 'overkill', in the sense that it alleviates quite a bunch of boilerplate and repetition but it's not vital to the approach. Using type family, type constraints synonyms and type classes, it's also possible to craft a high-level API which makes it quite easy to read and follow on call-sites. The main benefit of this approach (beyond readability on call sites) is ease of maintenance in the future. Adding new logging components should 'just-work' since the record construction and instantiation is done fully generically.

- :round_pushpin: **Use 'contra-tracers' to define multi-component loggers in Ogmios.**
  
- :round_pushpin: **Add unit tests for option parsing covering new per-component log levels.**
  
- :round_pushpin: **Wrap log messages in generic context from field selector name.**
