### PR TITLE
Rework Docker Images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,8 @@
 
 !scripts/
 
+!default.nix
+
 !server/cabal.project
 !server/*.cabal
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,7 @@ COPY --from=build /app/cardano-configurations/network/${NETWORK} /config
 
 EXPOSE 1337/tcp
 STOPSIGNAL SIGINT
-HEALTHCHECK --interval=10s --timeout=5s --retries=1 CMD \
-  [ connected == $(wget http://localhost:1337 | sed 's/.*"connectionStatus":"\([a-z]\+\)".*/\1/') ]
+HEALTHCHECK --interval=10s --timeout=5s --retries=1 CMD /bin/ogmios health-check
 ENTRYPOINT ["/bin/ogmios"]
 
 #                                                                              #
@@ -63,6 +62,5 @@ COPY scripts/cardano-node-ogmios.sh cardano-node-ogmios.sh
  # Ogmios, cardano-node, ekg, prometheus
 EXPOSE 1337/tcp 3000/tcp 12788/tcp 12798/tcp
 STOPSIGNAL SIGINT
-HEALTHCHECK --interval=10s --timeout=5s --retries=1 CMD \
-  [ connected == $(wget http://localhost:1337 | sed 's/.*"connectionStatus":"\([a-z]\+\)".*/\1/') ]
+HEALTHCHECK --interval=10s --timeout=5s --retries=1 CMD /bin/ogmios health-check
 CMD ["bash", "cardano-node-ogmios.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,8 @@ COPY --from=build /app/cardano-configurations/network/${NETWORK} /config
 
 EXPOSE 1337/tcp
 STOPSIGNAL SIGINT
+HEALTHCHECK --interval=10s --timeout=5s --retries=1 CMD \
+  [ connected == $(wget http://localhost:1337 | sed 's/.*"connectionStatus":"\([a-z]\+\)".*/\1/') ]
 ENTRYPOINT ["/bin/ogmios"]
 
 #                                                                              #
@@ -61,4 +63,6 @@ COPY scripts/cardano-node-ogmios.sh cardano-node-ogmios.sh
  # Ogmios, cardano-node, ekg, prometheus
 EXPOSE 1337/tcp 3000/tcp 12788/tcp 12798/tcp
 STOPSIGNAL SIGINT
+HEALTHCHECK --interval=10s --timeout=5s --retries=1 CMD \
+  [ connected == $(wget http://localhost:1337 | sed 's/.*"connectionStatus":"\([a-z]\+\)".*/\1/') ]
 CMD ["bash", "cardano-node-ogmios.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,122 +1,64 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 #                                                                              #
 # ------------------------------- SETUP  ------------------------------------- #
 #                                                                              #
 
-FROM haskell:8.10.4 as setup
-ARG CARDANO_NODE_REV=1.31.0
-# https://github.com/input-output-hk/iohk-nix/blob/master/overlays/crypto/libsodium.nix
-ARG IOHK_LIBSODIUM_GIT_REV=66f017f16633f2060db25e17c170c2afa0f2a8a1
-WORKDIR /build
-RUN apt-get update && apt-get install --no-install-recommends -y \
-  automake=1:1.16.* \
-  build-essential=12.6 \
-  g++=4:8.3.* \
-  git=1:2.20.* \
-  libffi-dev=3.* \
-  libgmp-dev=2:6.1.* \
-  libpcre3-dev=2:8.* \
-  libncursesw5=6.* \
-  libssl-dev=1.1.* \
-  libsystemd-dev=241-* \
-  libtool=2.4.* \
-  make=4.2.* \
-  pkg-config=0.29-* \
-  zlib1g-dev=1:1.2.* \
-  && rm -rf /var/lib/apt/lists/*
+FROM nixos/nix:2.3.11 as build
 
-RUN cabal update
+RUN echo "substituters = https://cache.nixos.org https://hydra.iohk.io" >> /etc/nix/nix.conf &&\
+    echo "trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" >> /etc/nix/nix.conf
 
-# Build IOHK's libsodium fork, needed by cardano-node
-WORKDIR /app/src/libsodium
-RUN git clone https://github.com/input-output-hk/libsodium.git /app/src/libsodium &&\
-  git fetch --all --tags &&\
-  git checkout ${IOHK_LIBSODIUM_GIT_REV}
-WORKDIR /app/src/libsodium
-RUN ./autogen.sh && ./configure && make && make install
-ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
-ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
+WORKDIR /app
+RUN nix-shell -p git --command "git clone --depth 1 https://github.com/input-output-hk/cardano-configurations.git"
 
-# Build cardano-node.
-WORKDIR /app/src/cardano-node
-RUN git clone https://github.com/input-output-hk/cardano-node.git /app/src/cardano-node &&\
-  git fetch --all --tags &&\
-  git checkout ${CARDANO_NODE_REV}
-WORKDIR /app/src/cardano-node
-RUN cabal install cardano-node \
-  --overwrite-policy=always \
-  --install-method=copy \
-  --installdir=/app/bin
+WORKDIR /app/ogmios
+RUN nix-env -iA cachix -f https://cachix.org/api/v1/install && cachix use cardano-ogmios
+COPY . .
+RUN nix-build -A ogmios.components.exes.ogmios -o dist
+RUN cp -r dist/* . && chmod +w dist/bin && chmod +x dist/bin/ogmios
 
 #                                                                              #
 # --------------------------- BUILD (ogmios) --------------------------------- #
 #                                                                              #
 
-FROM setup as build
+FROM busybox as ogmios
 
-WORKDIR /app/src/ogmios/server
-
-COPY server/ .
-
-RUN cabal install exe:ogmios \
-  --overwrite-policy=always \
-  --install-method=copy \
-  --installdir=/app/bin
-
-WORKDIR /app
-RUN git clone --depth 1 https://github.com/input-output-hk/cardano-configurations.git
-
-#                                                                              #
-# --------------------------- RUN (ogmios-only) ------------------------------ #
-#                                                                              #
-
-FROM debian:buster-slim as ogmios
+ARG NETWORK=mainnet
 
 LABEL name=ogmios
 LABEL description="A JSON WebSocket bridge for cardano-node."
 
-COPY --from=build /usr/local/lib/libsodium.so.23 /usr/lib/x86_64-linux-gnu/libsodium.so.23
-COPY --from=build /app/bin/ogmios /bin/ogmios
-
-RUN mkdir -p /etc/bash_completion.d
-RUN ogmios --bash-completion-script ogmios > /etc/bash_completion.d/ogmios
-RUN echo "source /etc/bash_completion.d/ogmios" >> ~/.bashrc
+COPY --from=build /app/ogmios/bin/ogmios /bin/ogmios
+COPY --from=build /app/cardano-configurations/network/${NETWORK} /config
 
 EXPOSE 1337/tcp
-ENTRYPOINT ["ogmios"]
+STOPSIGNAL SIGINT
+ENTRYPOINT ["/bin/ogmios"]
 
 #                                                                              #
 # --------------------- RUN (cardano-node & ogmios) -------------------------- #
 #                                                                              #
 
-FROM debian:buster-slim as cardano-node-ogmios
+FROM inputoutput/cardano-node:1.31.0 as cardano-node-ogmios
 
 ARG NETWORK=mainnet
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 LABEL name=cardano-node-ogmios
-LABEL description="A JSON WebSocket bridge for cardano-node w/ a cardano-node."
+LABEL description="A Cardano node, side-by-side with its JSON WebSocket bridge."
 
-# Ogmios, cardano-node, ekg, prometheus
-EXPOSE 1337/tcp 3000/tcp 12788/tcp 12798/tcp
-
-RUN apt-get update && apt-get install --no-install-recommends -y \
-  wget=1.20.1-* \
-  netbase=5.6 \
-  ca-certificates=20200601* \
-  && rm -rf /var/lib/apt/lists/*
-RUN apt-get -y purge && apt-get -y clean && apt-get -y autoremove
-
-COPY --from=setup /usr/local/lib/libsodium.so.23 /usr/lib/x86_64-linux-gnu/libsodium.so.23
-COPY --from=setup /app/bin/cardano-node /bin/cardano-node
-COPY --from=build /app/bin/ogmios /bin/ogmios
+COPY --from=build /app/ogmios/bin/ogmios /bin/ogmios
 COPY --from=build /app/cardano-configurations/network/${NETWORK} /config
 
-RUN mkdir /ipc
+RUN mkdir -p /ipc
 
 WORKDIR /root
 COPY scripts/cardano-node-ogmios.sh cardano-node-ogmios.sh
+ # Ogmios, cardano-node, ekg, prometheus
+EXPOSE 1337/tcp 3000/tcp 12788/tcp 12798/tcp
+STOPSIGNAL SIGINT
 CMD ["bash", "cardano-node-ogmios.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,3 +64,4 @@ EXPOSE 1337/tcp 3000/tcp 12788/tcp 12798/tcp
 STOPSIGNAL SIGINT
 HEALTHCHECK --interval=10s --timeout=5s --retries=1 CMD /bin/ogmios health-check
 CMD ["bash", "cardano-node-ogmios.sh" ]
+ENTRYPOINT [ "/root/cardano-node-ogmios.sh" ]

--- a/server/app/Main.hs
+++ b/server/app/Main.hs
@@ -9,6 +9,7 @@ import Ogmios.Prelude
 import Ogmios
     ( Command (..)
     , application
+    , healthCheck
     , newEnvironment
     , parseOptions
     , runWith
@@ -18,9 +19,11 @@ import Ogmios
 
 main :: IO ()
 main = parseOptions >>= \case
-    Version -> do
-        putTextLn version
     Start (Identity network) opts logLevels -> do
         withStdoutTracers version logLevels $ \tr -> do
             env <- newEnvironment tr network opts
             application tr `runWith` env
+    HealthCheck{healthCheckPort} ->
+        healthCheck healthCheckPort
+    Version -> do
+        putTextLn version

--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -146,6 +146,7 @@ library
     , filepath
     , generic-lens
     , git-th
+    , http-client
     , http-types
     , io-classes
     , io-sim

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -66,6 +66,7 @@ library:
     - filepath
     - generic-lens
     - git-th
+    - http-client
     - http-types
     - io-classes
     - io-sim

--- a/server/src/Ogmios.hs
+++ b/server/src/Ogmios.hs
@@ -15,6 +15,7 @@ module Ogmios
     , application
     , runWith
     , version
+    , healthCheck
 
     -- * Environment
     , Env (..)
@@ -44,7 +45,7 @@ import Ogmios.App.Metrics
 import Ogmios.App.Server
     ( connectHybridServer )
 import Ogmios.App.Server.Http
-    ( mkHttpApp )
+    ( healthCheck, mkHttpApp )
 import Ogmios.App.Server.WebSocket
     ( newWebSocketApp )
 import Ogmios.Control.Exception

--- a/server/src/Ogmios/Options.hs
+++ b/server/src/Ogmios/Options.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fno-warn-partial-fields #-}
 
 module Ogmios.Options
     ( -- * Command
@@ -79,6 +80,7 @@ import qualified Data.Yaml.Pretty as Yaml
 data Command (f :: Type -> Type)
     = Start (f NetworkParameters) Configuration (Tracers IO 'MinSeverities)
     | Version
+    | HealthCheck { healthCheckPort :: !Int }
 
 deriving instance Eq (f NetworkParameters) => Eq (Command f)
 deriving instance Show (f NetworkParameters) => Show (Command f)
@@ -87,6 +89,7 @@ parseOptions :: IO (Command Identity)
 parseOptions =
     customExecParser (prefs showHelpOnEmpty) parserInfo >>= \case
         Version -> pure Version
+        HealthCheck{healthCheckPort} -> pure HealthCheck{healthCheckPort}
         Start _ cfg@Configuration{nodeConfig} lvl -> do
             networkParameters <- parseNetworkParameters nodeConfig
             pure $ Start (Identity networkParameters) cfg lvl
@@ -113,7 +116,9 @@ parserInfo = info (helper <*> parser) $ mempty
         ])
   where
     parser =
-        versionOption
+        versionOptionOrCommand
+        <|>
+        healthCheckCommand
         <|>
         (Start Proxy
             <$> (Configuration
@@ -221,8 +226,8 @@ logLevelOption component =
         string $ "Minimal severity of " <> toString component <> " log messages."
 
 -- | [--version|-v] | version
-versionOption :: Parser (Command f)
-versionOption =
+versionOptionOrCommand :: Parser (Command f)
+versionOptionOrCommand =
     flag' Version (mconcat
         [ long "version"
         , short 'v'
@@ -235,6 +240,26 @@ versionOption =
         ])
   where
     helpText = "Show the software current version and build revision."
+
+-- | health-check
+healthCheckCommand :: Parser (Command f)
+healthCheckCommand =
+    subparser $ command "health-check" $ info (helper <*> parser) $ mempty
+        <> progDesc helpText
+        <> headerDoc (Just $ vsep
+            [ string $ toString $ unwords
+                [ "Handy command to check whether an Ogmios server is up-and-running,"
+                , "and correctly connected to a network / cardano-node."
+                ]
+            , mempty
+            , string $ toString $ unwords
+                [ "This can, for example, be wired to Docker's HEALTHCHECK"
+                , "feature easily."
+                ]
+            ])
+  where
+    parser = HealthCheck <$> serverPortOption
+    helpText = "Performs a health check against a running server."
 
 --
 -- Environment


### PR DESCRIPTION
- :round_pushpin: **Rework Dockerfile to leverage Nix-produced static binary and caching.**
  
- :round_pushpin: **Add HEALTHCHECK to Docker images.**
  
- :round_pushpin: **Add 'health-check' command to easily perform a health check.**
    In  essence, this is just making an HTTP request to Ogmios' health endpoint to look at the 'connectionStatus' field. While this is perfectly doable with wget or curl + jq or sed...

  (a) It is more convenient to have a simple command for this, which directly conveys the intent.
  (b) It doesn't require to make builds any more complex, in particular for containers which may not have curl, wget or even netcat available.

  However, containers do already have 'ogmios' available, statically linked. So little manoeuver becomes very handy.

- :round_pushpin: **Use 'ogmios health-check' as docker HEALTHCHECK command.**
  
- :round_pushpin: **Override ENTRYPOINT for cardano-node-ogmios.**
