### PR TITLE
Fixing issue when restarting the docker image

### DIFF
--- a/scripts/cardano-node-ogmios.sh
+++ b/scripts/cardano-node-ogmios.sh
@@ -19,7 +19,7 @@ cardano-node run\
   --port 3000\
   --host-addr 0.0.0.0\
   --config /config/cardano-node/config.json\
-  --socket-path /ipc/node.socket&
+  --socket-path /ipc/node.socket &
 status=$?
 if [ $status -ne 0 ]; then
   echo "Failed to start cardano-node: $status"


### PR DESCRIPTION
When restarting the docker image, I was getting the following error

---------------------------------
{"severity":"Error","timestamp":"2022-01-11T12:39:45.998611484Z","thread":"179","message":{"WebSocket":{"ioException":"Network.Socket.connect: <socket: 19>: does not exist (No such file or directory)","tag":"WebSocketFailedToConnect"}},"version":"v5.0.0"}
---------------------------------

The /ipc/node.socket was being removed when restarting the cardanosolutions/cardano-node-ogmios docker container.

Changing this and rebuilding the image worked.