### PR TITLE
`currentEpoch` & `slotInEpoch` in health object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,16 @@ pre: "<b>6. </b>"
 >
 >   A version of `cardano-node@1.33.1` patched with the necessary commits can be found at [CardanoSolutions/cardano-node@1.33.1+local-tx-monitor](https://github.com/CardanoSolutions/cardano-node/releases/tag/1.33.1+local-tx-monitor).
 >
-> - `connectionStatus` in the health object, taking `"connected"` or `"disconnected"` as values to reflect the current connection status with the node. [#154](https://github.com/CardanoSolutions/ogmios/issues/154)
+> - New fields in the health object:
+>   - `connectionStatus` → `"connected"` or `"disconnected"`, to reflect status with the node. [#154](https://github.com/CardanoSolutions/ogmios/issues/154)
+>   - `currentEpoch` → which returns the current known epoch of the linked node [#164](https://github.com/CardanoSolutions/ogmios/issues/164)
+>   - `slotInEpoch` → which returns the relative number of slots elapsed in the current epoch [#164](https://github.com/CardanoSolutions/ogmios/issues/154)
 >
 > - New `ogmios health-check` command, useful to perform simple health check on a running server. For example, to monitor a container via Docker health check mechanism:
 >   ```Dockerfile
 >   HEALTHCHECK --interval=10s --timeout=5s --retries=1 CMD /bin/ogmios health-check
 >   ```
-> - Bumped internal dependencies to Cardano's 1.33.0 eco-system.
+> - Bumped internal dependencies to Cardano's 1.33.* eco-system.
 
 #### Changed
 

--- a/clients/TypeScript/packages/client/test/ServerHealth.test.ts
+++ b/clients/TypeScript/packages/client/test/ServerHealth.test.ts
@@ -9,8 +9,12 @@ const expectHealth = (obj: any): void => {
       'lastTipUpdate',
       'metrics',
       'startTime',
-      'networkSynchronization'
+      'networkSynchronization',
+      'currentEpoch',
+      'slotInEpoch'
     ]))
+  expect(obj.currentEpoch).not.toBe(null)
+  expect(obj.slotInEra).not.toBe(null)
 }
 
 describe('ServerHealth', () => {

--- a/docs/content/getting-started/monitoring.md
+++ b/docs/content/getting-started/monitoring.md
@@ -45,7 +45,9 @@ $ curl -H 'Accept: application/json' http://localhost:1337/health
     },
     "networkSynchronization": 0.99,
     "currentEra": "Mary",
-    "connectionStatus": "disconnected"
+    "connectionStatus": "disconnected",
+    "currentEpoch": 164,
+    "slotInEpoch": 324543
 }
 ```
 
@@ -59,6 +61,8 @@ All information are computed at runtime and **not preserved between restarts** (
 | `lastKnownTip`                         | Last known chain tip received from the node (can be `null`)                                                                       |
 | `networkSynchronization`               | A **(nullable)** percentage indicator of how far the server/node is from the network tip. `1` means it is synchronized.           |
 | `currentEra`                           | The **(nullable)** current Cardano era of the underlying node. Useful for state-queries and debugging.                            |
+| `currentEpoch`                         | The **(nullable)** current epoch number known of the underlying node.                                                             |
+| `slotInEpoch`                          | The **(nullable)** relative slot number within the current epoch.                                                                 |
 | `metrics.activeConnections`            | Number of WebSocket connections currently established with the server.                                                            |
 | `metrics.totalConnections`             | Total number of WebSocket connections established with the server since it's started.                                             |
 | `metrics.sessionDurations`             | Some time measures (`min`, `max`, `mean`) of the duration of each sessions, in milliseconds.                                      |

--- a/server/test/unit/Ogmios/Data/HealthSpec.hs
+++ b/server/test/unit/Ogmios/Data/HealthSpec.hs
@@ -52,6 +52,8 @@ spec = parallel $ do
             currentEra health `shouldBe` Nothing
             metrics health `shouldBe` emptyMetrics
             connectionStatus health `shouldBe` Disconnected
+            currentEpoch health `shouldBe` Nothing
+            slotInEpoch health `shouldBe` Nothing
 
     context "NetworkSynchronization" $ do
         let matrix =


### PR DESCRIPTION
Fixes #164

- :round_pushpin: **Extend 'Health' with current epoch number and slot within epoch.**
  
- :round_pushpin: **Get epoch number and slot in epoch from the time interpreter.**
  
- :round_pushpin: **Unit and smoke test 'currentEpoch' & 'slotInEra' in health**
    From logs, on testnet:

  ```json
  {
      "severity": "Info",
      "timestamp": "2022-01-24T14:56:58.61614791Z",
      "thread": "16",
      "message": {
          "Health": {
              "tag": "HealthTick",
              "status": {
                  "startTime": "2022-01-24T14:56:38.537958011Z",
                  "lastKnownTip": {
                      "slot": 47729097,
                      "hash": "81d7b92d06ee966550153bbd41295a177b73ba9e7f59db770c57fcbeb0ba7217",
                      "blockNo": 3234906
                  },
                  "lastTipUpdate": "2022-01-24T14:56:58.615657341Z",
                  "networkSynchronization": 0.98813,
                  "currentEra": "Alonzo",
                  "metrics": {
                      "totalUnrouted": 0,
                      "totalMessages": 0,
                      "runtimeStats": {
                          "gcCpuTime": 17822836,
                          "cpuTime": 263435464,
                          "maxHeapSize": 334,
                          "currentHeapSize": 333
                      },
                      "totalConnections": 0,
                      "sessionDurations": {
                          "max": 0,
                          "mean": 0,
                          "min": 0
                      },
                      "activeConnections": 0
                  },
                  "connectionStatus": "connected",
                  "currentEpoch": 180,
                  "slotInEpoch": 338697
              }
          }
      },
      "version": "v5.0.0-47-g5646160c"
  }
  ```

  + TypeScript client specs.
