### PR TITLE
EvaluateTx: allows user-specified additional UTXO set

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "server/config"]
 	path = server/config
 	url = https://github.com/input-output-hk/cardano-configurations.git
+[submodule "clients/Go"]
+	path = clients/Go
+	url = https://github.com/savaki/ogmigo.git

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@
 
 ## Features
 
-- Fast synchronization of blocks from the Cardano network(s)
-- Transaction submission with enhanced error messages
-- Local mempool monitoring 
-- Full ledger state query support:
+- [Fast synchronization of blocks from the Cardano network(s)](https://ogmios.dev/mini-protocols/local-chain-sync/)
+- [Transaction submission with enhanced error messages](https://ogmios.dev/mini-protocols/local-tx-submission/#submittx)
+- [Evaluation of Plutus script execution units](https://ogmios.dev/mini-protocols/local-tx-submission/#evaluatetx)
+- [Local mempool monitoring](https://ogmios.dev/mini-protocols/local-tx-monitor/)
+- [Full ledger state query support:](https://ogmios.dev/mini-protocols/local-state-query/)
   - `blockHeight`
   - `chainTip`
   - `currentEpoch`
@@ -30,11 +31,10 @@
   - `stakeDistribution`
   - `systemStart`
   - `utxo`
-- TypeScript client & REPL
-- Structured JSON logging 
-- Health monitoring, with runtime and application statistics
-- Fully documented API with JSON-schema
-
+- [TypeScript client & REPL](https://github.com/CardanoSolutions/ogmios/tree/master/clients/TypeScript#cardano-ogmios-typescript-client-packages)
+- [Structured JSON logging](https://ogmios.dev/getting-started/monitoring/)
+- [Health monitoring, with runtime and application statistics](https://ogmios.dev/getting-started/monitoring/)
+- [Fully documented API with JSON-schema](https://ogmios.dev/api-reference/)
 
 ## Preview
 

--- a/clients/TypeScript/packages/client/src/TxSubmission/evaluateTx.ts
+++ b/clients/TypeScript/packages/client/src/TxSubmission/evaluateTx.ts
@@ -1,7 +1,7 @@
 import { InteractionContext } from '../Connection'
 import { UnknownResultError } from '../errors'
 import { errors } from './evaluationErrors'
-import { Ogmios, ExUnits } from '@cardano-ogmios/schema'
+import { Ogmios, ExUnits, Utxo } from '@cardano-ogmios/schema'
 import { Query } from '../StateQuery'
 
 export interface EvaluationResult {
@@ -15,14 +15,17 @@ export interface EvaluationResult {
  *
  * @category TxSubmission
  */
-export const evaluateTx = (context: InteractionContext, bytes: string) =>
+export const evaluateTx = (context: InteractionContext, bytes: string, additionalUtxoSet?: Utxo) =>
   Query<
     Ogmios['EvaluateTx'],
     Ogmios['EvaluateTxResponse'],
     EvaluationResult
   >({
     methodName: 'EvaluateTx',
-    args: { evaluate: bytes }
+    args: {
+      ...(additionalUtxoSet !== undefined ? {} : { additionalUtxoSet }),
+      evaluate: bytes
+    }
   }, {
     handler: (response, resolve, reject) => {
       if (response.methodname === 'EvaluateTx') {

--- a/clients/TypeScript/packages/client/src/TxSubmission/evaluateTx.ts
+++ b/clients/TypeScript/packages/client/src/TxSubmission/evaluateTx.ts
@@ -62,6 +62,8 @@ export const evaluateTx = (context: InteractionContext, bytes: string) =>
             return reject([new errors.IncompatibleEra.Error(EvaluationFailure)])
           } else if (errors.UncomputableSlotArithmetic.assert(EvaluationFailure)) {
             return reject([new errors.UncomputableSlotArithmetic.Error(EvaluationFailure)])
+          } else if (errors.AdditionalUtxoOverlap.assert(EvaluationFailure)) {
+            return reject([new errors.AdditionalUtxoOverlap.Error(EvaluationFailure)])
           }
         }
       }

--- a/clients/TypeScript/packages/client/src/TxSubmission/evaluationErrors.ts
+++ b/clients/TypeScript/packages/client/src/TxSubmission/evaluationErrors.ts
@@ -1,6 +1,7 @@
 import { CustomError } from 'ts-custom-error'
 import { safeJSON } from '../util'
 import {
+  EvaluationFailureAdditionalUtxoOverlap,
   EvaluationFailureUnknownInputs,
   EvaluationFailureIncompatibleEra,
   EvaluationFailureUncomputableSlotArithmetic,
@@ -14,11 +15,13 @@ import {
   ValidatorFailed
 } from '@cardano-ogmios/schema'
 
-export type UnknownInputs = EvaluationFailureUnknownInputs;
+export type AdditionalUtxoOverlap = EvaluationFailureAdditionalUtxoOverlap;
 export type IncompatibleEra = EvaluationFailureIncompatibleEra;
 export type UncomputableSlotArithmetic = EvaluationFailureUncomputableSlotArithmetic;
+export type UnknownInputs = EvaluationFailureUnknownInputs;
 
 export type EvaluateTxError =
+  | AdditionalUtxoOverlap
   | ExtraRedeemers
   | IllFormedExecutionBudget
   | IncompatibleEra
@@ -33,6 +36,16 @@ export type EvaluateTxError =
 
 /** @category TxSubmission */
 export const errors = {
+  AdditionalUtxoOverlap: {
+    assert: (item: EvaluateTxError): item is AdditionalUtxoOverlap =>
+      (item as AdditionalUtxoOverlap).AdditionalUtxoOverlap !== undefined,
+    Error: class AdditionalUtxoOverlapError extends CustomError {
+      public constructor (rawError: AdditionalUtxoOverlap) {
+        super()
+        this.message = safeJSON.stringify(rawError.AdditionalUtxoOverlap)
+      }
+    }
+  },
   ExtraRedeemers: {
     assert: (item: EvaluateTxError): item is ExtraRedeemers =>
       (item as ExtraRedeemers).extraRedeemers !== undefined,

--- a/clients/TypeScript/packages/client/test/TxSubmission/TxSubmission.test.ts
+++ b/clients/TypeScript/packages/client/test/TxSubmission/TxSubmission.test.ts
@@ -1,3 +1,4 @@
+import { TxIn, TxOut, Utxo } from '@cardano-ogmios/schema'
 import { InteractionContext, TxSubmission, UnknownResultError } from '../../src'
 import { dummyInteractionContext } from '../util'
 
@@ -103,6 +104,41 @@ describe('TxSubmission', () => {
         expect(error).toHaveLength(1)
         expect(error[0]).toBeInstanceOf(TxSubmission.evaluationErrors.errors.UnknownInputs.Error)
       }
+    })
+
+    it('successfully evaluate execution units when unknown inputs are provided as additional utxo', async () => {
+      const additionalUtxoSet = [
+        [{
+          txId: '97b2af6dfc6a4825e934146f424cdd6ede43ff98c355d2ae3aa95b0f70b63949',
+          index: 3
+        } as TxIn,
+         {
+           address: 'addr_test1qp9zjnc775anpndl0jh3w7vyy25syfezf70m7qmleaky0fdu9mqe2tg33xyxlcqcy98w630c82cyzuwyrumn65cv57nqwxm2yd',
+           value: { coins: BigInt(10000000) }
+         } as TxOut
+        ]
+      ] as Utxo
+
+      const result = await TxSubmission.evaluateTx(
+        context,
+        ('84a6008282582078e963207a3fa50f5db363439a246d9c5631d398c7b7' +
+         '397435b6ec133432a64701825820db7dbf9eaa6094982ed4b9b735ce27' +
+         '5345f348194a7e8e9200fec7d1cad008eb010d81825820db7dbf9eaa60' +
+         '94982ed4b9b735ce275345f348194a7e8e9200fec7d1cad008eb010181' +
+         '825839004a294f1ef53b30cdbf7caf17798422a90227224f9fbf037fcf' +
+         '6c47a5bc2ec1952d1189886fe018214eed45f83ab04171c41f373d530c' +
+         'a7a61a3bb94e8002000e800b58206df8859ec92c3ff6bc0e2964793789' +
+         'e44e4c5abbcc9ff6f2387b94f4c2020e6ea303814e4d01000033222220' +
+         '0512001200110481800581840000182a820000f5f6'
+        ),
+        additionalUtxoSet
+      )
+      expect(result).toEqual({
+        'spend:0': {
+          memory: 1700,
+          steps: 476468
+        }
+      })
     })
 
     it('fails to evaluate execution units of non-Alonzo tx', async () => {

--- a/clients/TypeScript/packages/schema/src/index.ts
+++ b/clients/TypeScript/packages/schema/src/index.ts
@@ -1939,7 +1939,8 @@ export interface EvaluationFailure {
     | EvaluationFailureScriptFailures
     | EvaluationFailureUnknownInputs
     | EvaluationFailureIncompatibleEra
-    | EvaluationFailureUncomputableSlotArithmetic;
+    | EvaluationFailureUncomputableSlotArithmetic
+    | EvaluationFailureAdditionalUtxoOverlap;
 }
 export interface EvaluationFailureScriptFailures {
   ScriptFailures: {
@@ -2007,6 +2008,12 @@ export interface EvaluationFailureUncomputableSlotArithmetic {
    * An error message, possibly meaningful but likely unreadable.
    */
   UncomputableSlotArithmetic: string;
+}
+/**
+ * Happens when providing an additional UTXO set which overlaps with the UTXO on-chain.
+ */
+export interface EvaluationFailureAdditionalUtxoOverlap {
+  AdditionalUtxoOverlap: TxIn[];
 }
 export interface AcquireSuccess {
   AcquireSuccess: {

--- a/docs/static/ogmios.wsp.json
+++ b/docs/static/ogmios.wsp.json
@@ -360,6 +360,9 @@
             , "contentEncoding": "base64"
             , "pattern": "^[A-Za-z0-9+/]=?=?$"
             }
+          , "additionalUtxoSet":
+            { "$ref": "#/definitions/Utxo"
+            }
           }
         }
       , "mirror":

--- a/docs/static/ogmios.wsp.json
+++ b/docs/static/ogmios.wsp.json
@@ -3207,6 +3207,7 @@
             , { "$ref": "#/definitions/EvaluationFailure[UnknownInputs]" }
             , { "$ref": "#/definitions/EvaluationFailure[IncompatibleEra]" }
             , { "$ref": "#/definitions/EvaluationFailure[UncomputableSlotArithmetic]" }
+            , { "$ref": "#/definitions/EvaluationFailure[AdditionalUtxoOverlap]" }
             ]
         }
       }
@@ -3260,6 +3261,19 @@
       { "UncomputableSlotArithmetic":
         { "type": "string"
         , "description": "An error message, possibly meaningful but likely unreadable."
+        }
+      }
+    }
+
+  , "EvaluationFailure[AdditionalUtxoOverlap]":
+    { "type": "object"
+    , "description": "Happens when providing an additional UTXO set which overlaps with the UTXO on-chain."
+    , "additionalProperties": false
+    , "required": [ "AdditionalUtxoOverlap" ]
+    , "properties":
+      { "AdditionalUtxoOverlap":
+        { "type": "array"
+        , "items": { "$ref": "#/definitions/TxIn" }
         }
       }
     }

--- a/server/modules/json-wsp/src/Codec/Json/Wsp.hs
+++ b/server/modules/json-wsp/src/Codec/Json/Wsp.hs
@@ -64,6 +64,8 @@ import Data.Void
     ( Void )
 import GHC.TypeLits
     ( KnownSymbol, Symbol, symbolVal )
+import Type.Reflection
+    ( TypeRep, typeRep )
 
 import GHC.Generics
 
@@ -101,13 +103,14 @@ type ToFault = FaultCode -> String -> Fault
 data Options = Options
     { fieldLabelModifier :: String -> String
     , constructorTagModifier :: String -> String
+    , onMissingField :: forall a. TypeRep a -> Text -> Json.Parser a
     }
 
 -- | Default options for the generic parsing: do nothing.
 --
 -- @since 1.0.0
 defaultOptions :: Options
-defaultOptions = Options id id
+defaultOptions = Options id id (\_ k -> fail $ "key " ++ show k ++ " not found")
 
 -- | Parse a given Json 'Value' as a JSON-WSP 'Request'.
 --
@@ -296,7 +299,10 @@ instance (GWSPFromJSON f, GWSPFromJSON g) => GWSPFromJSON (f :*: g) where
 instance (Selector s, GWSPFromJSON f) => GWSPFromJSON (S1 s f) where
     gWSPFromJSON opts = Json.withObject "S1" $ \obj -> do
         let fieldName = T.pack $ fieldLabelModifier opts $ selName (undefined :: S1 s f a)
-        (_, k1) <- obj .: "args" >>= (.: fieldName) >>= gWSPFromJSON opts
+        (_, k1) <- obj .: "args"
+            >>= (.:? fieldName)
+            >>= maybe (onMissingField opts typeRep fieldName) pure
+            >>= gWSPFromJSON opts
         pure (Nothing, M1 k1)
 
 -- Unary constructor, nothing to do, the constructor name has been verified

--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -305,6 +305,7 @@ test-suite unit
   build-depends:
       QuickCheck
     , aeson
+    , aeson-pretty
     , base >=4.7 && <5
     , bytestring
     , cardano-client
@@ -313,6 +314,7 @@ test-suite unit
     , cardano-ledger-shelley
     , cardano-ledger-shelley-test
     , cardano-slotting
+    , containers
     , directory
     , file-embed
     , generic-arbitrary

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -134,6 +134,7 @@ tests:
     ghc-options: *ghc-options-test
     dependencies:
     - aeson
+    - aeson-pretty
     - bytestring
     - cardano-client
     - cardano-ledger-alonzo
@@ -141,6 +142,7 @@ tests:
     - cardano-ledger-shelley
     - cardano-ledger-shelley-test
     - cardano-slotting
+    - containers
     - directory
     - file-embed
     - generic-arbitrary

--- a/server/src/Ogmios/App/Protocol.hs
+++ b/server/src/Ogmios/App/Protocol.hs
@@ -14,7 +14,7 @@ import Ogmios.Prelude
 import Ogmios.Data.Json
     ( FromJSON, Json )
 import Ogmios.Data.Protocol
-    ( MethodName )
+    ( MethodName, MostRecentEra )
 import Ogmios.Data.Protocol.ChainSync
     ( FindIntersect, RequestNext, _decodeFindIntersect, _decodeRequestNext )
 import Ogmios.Data.Protocol.StateQuery
@@ -33,7 +33,7 @@ import Ogmios.Data.Protocol.TxMonitor
     , _decodeSizeAndCapacity
     )
 import Ogmios.Data.Protocol.TxSubmission
-    ( EvaluateTx, SubmitTx, _decodeEvaluateTx, _decodeSubmitTx )
+    ( EvaluateTx, SubmitTx, UTxO, _decodeEvaluateTx, _decodeSubmitTx )
 import Ouroboros.Network.Block
     ( Point (..) )
 
@@ -81,6 +81,9 @@ onUnmatchedMessage
         , FromJSON (Query Proxy block)
         , FromJSON (Point block)
         , FromJSON (GenTxId block)
+        , FromJSON (UTxO (MostRecentEra block))
+        , Monoid (UTxO (MostRecentEra block))
+        , Typeable (MostRecentEra block)
         )
     => ByteString
     -> Json

--- a/server/src/Ogmios/App/Protocol.hs
+++ b/server/src/Ogmios/App/Protocol.hs
@@ -82,8 +82,6 @@ onUnmatchedMessage
         , FromJSON (Point block)
         , FromJSON (GenTxId block)
         , FromJSON (UTxO (MostRecentEra block))
-        , Monoid (UTxO (MostRecentEra block))
-        , Typeable (MostRecentEra block)
         )
     => ByteString
     -> Json

--- a/server/src/Ogmios/Data/Json.hs
+++ b/server/src/Ogmios/Data/Json.hs
@@ -29,6 +29,7 @@ module Ogmios.Data.Json
     , encodeTxId
     , Shelley.encodeTxIn
     , Alonzo.stringifyRdmrPtr
+    , Alonzo.encodeUtxo
 
       -- * Decoders
     , decodeOneEraHash
@@ -47,12 +48,16 @@ import Cardano.Crypto.Hash
     ( hashFromBytes )
 import Cardano.Crypto.Hashing
     ( decodeHash, hashToBytes )
+import Cardano.Ledger.Alonzo.TxBody
+    ( TxOut )
 import Cardano.Ledger.Crypto
     ( Crypto )
 import Cardano.Ledger.Shelley.API
     ( ApplyTxError (..), PraosCrypto )
 import Cardano.Ledger.Shelley.UTxO
     ( UTxO (..) )
+import Cardano.Ledger.TxIn
+    ( TxIn )
 import Cardano.Network.Protocol.NodeToClient
     ( GenTx, GenTxId, SerializedTx, SubmitTxError )
 import Cardano.Slotting.Block
@@ -62,7 +67,12 @@ import Cardano.Slotting.Slot
 import Formatting.Buildable
     ( build )
 import Ogmios.Data.Json.Query
-    ( encodeEraMismatch, encodeOneEraHash, encodePoint )
+    ( decodeTxIn
+    , decodeTxOut
+    , encodeEraMismatch
+    , encodeOneEraHash
+    , encodePoint
+    )
 import Ouroboros.Consensus.Byron.Ledger.Block
     ( ByronBlock (..) )
 import Ouroboros.Consensus.Byron.Ledger.Mempool
@@ -94,6 +104,7 @@ import qualified Cardano.Ledger.SafeHash as Ledger
 import qualified Cardano.Ledger.TxIn as Ledger
 import qualified Codec.CBOR.Encoding as Cbor
 import qualified Codec.CBOR.Write as Cbor
+import qualified Data.Map.Strict as Map
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TL
 
@@ -299,10 +310,22 @@ decodeSerializedTx = Json.withText "Tx" $ \(encodeUtf8 -> utf8) -> do
                 . build
 
 decodeUtxo
-    :: Json.Value
+    :: forall crypto. (Crypto crypto)
+    => Json.Value
     -> Json.Parser (UTxO (AlonzoEra crypto))
-decodeUtxo =
-    undefined
+decodeUtxo v = do
+    xs <- Json.parseJSONList v >>= traverse decodeUtxoEntry
+    pure $ UTxO (Map.fromList xs)
+  where
+    decodeUtxoEntry :: Json.Value -> Json.Parser (TxIn crypto, TxOut (AlonzoEra crypto))
+    decodeUtxoEntry =
+        Json.parseJSONList >=> \case
+            [i, o] ->
+                (,) <$> decodeTxIn i <*> decodeTxOut o
+            _ ->
+                fail
+                    "Failed to decode utxo entry. Expected an array of length \
+                    \2 as [output-reference, output]"
 
 decodeTip
     :: Json.Value

--- a/server/src/Ogmios/Data/Json.hs
+++ b/server/src/Ogmios/Data/Json.hs
@@ -36,6 +36,7 @@ module Ogmios.Data.Json
     , decodeSerializedTx
     , decodeTip
     , decodeTxId
+    , decodeUtxo
     ) where
 
 import Ogmios.Data.Json.Prelude
@@ -50,6 +51,8 @@ import Cardano.Ledger.Crypto
     ( Crypto )
 import Cardano.Ledger.Shelley.API
     ( ApplyTxError (..), PraosCrypto )
+import Cardano.Ledger.Shelley.UTxO
+    ( UTxO (..) )
 import Cardano.Network.Protocol.NodeToClient
     ( GenTx, GenTxId, SerializedTx, SubmitTxError )
 import Cardano.Slotting.Block
@@ -75,7 +78,7 @@ import Ouroboros.Consensus.Cardano.Block
 import Ouroboros.Consensus.HardFork.Combinator
     ( OneEraHash (..) )
 import Ouroboros.Consensus.Shelley.Eras
-    ( MaryEra )
+    ( AlonzoEra, MaryEra )
 import Ouroboros.Consensus.Shelley.Ledger
     ( ShelleyBlock )
 import Ouroboros.Consensus.Shelley.Ledger.Mempool
@@ -294,6 +297,12 @@ decodeSerializedTx = Json.withText "Tx" $ \(encodeUtf8 -> utf8) -> do
                     " "
                 . TL.toLazyText
                 . build
+
+decodeUtxo
+    :: Json.Value
+    -> Json.Parser (UTxO (AlonzoEra crypto))
+decodeUtxo =
+    undefined
 
 decodeTip
     :: Json.Value

--- a/server/src/Ogmios/Data/Json/Orphans.hs
+++ b/server/src/Ogmios/Data/Json/Orphans.hs
@@ -77,7 +77,7 @@ instance PraosCrypto crypto => FromJSON (GenTx (CardanoBlock crypto)) where
 instance PraosCrypto crypto => FromJSON (GenTxId (CardanoBlock crypto)) where
     parseJSON = decodeTxId
 
-instance FromJSON (UTxO (AlonzoEra crypto)) where
+instance Crypto crypto => FromJSON (UTxO (AlonzoEra crypto)) where
     parseJSON = decodeUtxo
 
 instance Crypto crypto => FromJSON (Point (CardanoBlock crypto)) where

--- a/server/src/Ogmios/Data/Json/Orphans.hs
+++ b/server/src/Ogmios/Data/Json/Orphans.hs
@@ -2,6 +2,10 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Ogmios.Data.Json.Orphans () where
@@ -12,6 +16,8 @@ import Cardano.Ledger.Crypto
     ( Crypto )
 import Cardano.Ledger.Shelley.API
     ( PraosCrypto )
+import Cardano.Ledger.Shelley.UTxO
+    ( UTxO (..) )
 import Cardano.Network.Protocol.NodeToClient
     ( GenTx, GenTxId )
 import Cardano.Network.Protocol.NodeToClient.Trace
@@ -21,6 +27,7 @@ import Ogmios.Data.Json
     , decodeSerializedTx
     , decodeTip
     , decodeTxId
+    , decodeUtxo
     , encodeSerializedTx
     , encodeSubmitTxError
     , encodeTip
@@ -29,6 +36,8 @@ import Ogmios.Data.Json.Query
     ( encodePoint )
 import Ouroboros.Consensus.Cardano.Block
     ( CardanoBlock, CardanoEras, HardForkApplyTxErr (..) )
+import Ouroboros.Consensus.Shelley.Eras
+    ( AlonzoEra )
 import Ouroboros.Network.Block
     ( Point (..), Tip (..) )
 
@@ -68,8 +77,18 @@ instance PraosCrypto crypto => FromJSON (GenTx (CardanoBlock crypto)) where
 instance PraosCrypto crypto => FromJSON (GenTxId (CardanoBlock crypto)) where
     parseJSON = decodeTxId
 
+instance FromJSON (UTxO (AlonzoEra crypto)) where
+    parseJSON = decodeUtxo
+
 instance Crypto crypto => FromJSON (Point (CardanoBlock crypto)) where
     parseJSON = decodePoint
 
 instance Crypto crypto => FromJSON (Tip (CardanoBlock crypto)) where
     parseJSON = decodeTip
+
+--
+-- Monoid / Semigroup
+--
+
+deriving newtype instance Semigroup (UTxO (AlonzoEra crypto))
+deriving newtype instance Monoid (UTxO (AlonzoEra crypto))

--- a/server/src/Ogmios/Data/Json/Prelude.hs
+++ b/server/src/Ogmios/Data/Json/Prelude.hs
@@ -18,6 +18,7 @@ module Ogmios.Data.Json.Prelude
     , choice
     , inefficientEncodingToValue
     , (.:)
+    , (.:?)
     , at
 
       -- * Re-Exports
@@ -113,7 +114,7 @@ import Cardano.Slotting.Slot
 import Cardano.Slotting.Time
     ( SlotLength (..), SystemStart (..), slotLengthToSec )
 import Data.Aeson
-    ( FromJSON, ToJSON, (.:) )
+    ( FromJSON, ToJSON, (.:), (.:?) )
 import Data.ByteArray
     ( ByteArrayAccess )
 import Data.ByteString.Base16

--- a/server/src/Ogmios/Data/Protocol.hs
+++ b/server/src/Ogmios/Data/Protocol.hs
@@ -4,12 +4,21 @@
 
 module Ogmios.Data.Protocol
     ( MethodName
+    , MostRecentEra
     ) where
 
 import Ogmios.Prelude
+
+import Ouroboros.Consensus.Cardano
+    ( CardanoBlock )
+import Ouroboros.Consensus.Cardano.Block
+    ( ShelleyBasedEras )
 
 import qualified Codec.Json.Wsp as Wsp
 
 type instance Wsp.ServiceName (Wsp.Request _) = "ogmios"
 
 type MethodName = String
+
+type family MostRecentEra block :: Type where
+    MostRecentEra (CardanoBlock crypto) = LastElem (ShelleyBasedEras crypto)

--- a/server/src/Ogmios/Data/Protocol/TxSubmission.hs
+++ b/server/src/Ogmios/Data/Protocol/TxSubmission.hs
@@ -61,7 +61,7 @@ module Ogmios.Data.Protocol.TxSubmission
     , SystemStart
     , Tx
     , TxIn
-    , UTxO
+    , UTxO (..)
     ) where
 
 import Ogmios.Data.Json.Prelude
@@ -338,6 +338,7 @@ data EvaluateTxError block
     | EvaluateTxUnknownInputs (Set (TxIn (Crypto block)))
     | EvaluateTxIncompatibleEra Text
     | EvaluateTxUncomputableSlotArithmetic PastHorizonException
+    | EvaluateTxAdditionalUtxoOverlap (Set (TxIn (Crypto block)))
     deriving (Show)
 
 -- | Shorthand constructor for 'EvaluateTxResponse'
@@ -392,6 +393,15 @@ _encodeEvaluateTxResponse _proxy stringifyRdmrPtr encodeExUnits encodeScriptFail
               , encodeObject
                 [ ( "UncomputableSlotArithmetic"
                   , encodeText (show pastHorizon)
+                  )
+                ]
+              )
+            ]
+        EvaluationFailure (EvaluateTxAdditionalUtxoOverlap inputs) -> encodeObject
+            [ ( "EvaluationFailure"
+              , encodeObject
+                [ ( "AdditionalUtxoOverlap"
+                  , encodeFoldable encodeTxIn inputs
                   )
                 ]
               )

--- a/server/test/unit/Test/Generators.hs
+++ b/server/test/unit/Test/Generators.hs
@@ -20,6 +20,8 @@ import Cardano.Ledger.Keys
     ( KeyRole (..) )
 import Cardano.Ledger.Serialization
     ( ToCBORGroup )
+import Cardano.Ledger.Shelley.UTxO
+    ( UTxO (..) )
 import Cardano.Network.Protocol.NodeToClient
     ( Block, GenTxId )
 import Cardano.Slotting.Slot
@@ -91,6 +93,7 @@ import Test.QuickCheck
     , listOf1
     , oneof
     , scale
+    , shrinkList
     , vector
     )
 import Test.QuickCheck.Gen
@@ -106,6 +109,7 @@ import Test.Consensus.Cardano.Generators
     ()
 
 import qualified Data.Aeson as Json
+import qualified Data.Map as Map
 import qualified Ouroboros.Network.Point as Point
 
 import qualified Cardano.Ledger.Block as Ledger
@@ -611,6 +615,17 @@ genMirror = oneof
     [ pure Nothing
     , Just . Json.toJSON <$> arbitrary @Int
     ]
+
+genUtxo
+    :: Gen (UTxO (AlonzoEra StandardCrypto))
+genUtxo =
+    reasonablySized arbitrary
+
+shrinkUtxo
+    :: UTxO (AlonzoEra StandardCrypto)
+    -> [UTxO (AlonzoEra StandardCrypto)]
+shrinkUtxo (UTxO u) =
+    UTxO . Map.fromList <$> shrinkList shrink (Map.toList u)
 
 --
 -- Helpers

--- a/server/test/unit/Test/Generators.hs
+++ b/server/test/unit/Test/Generators.hs
@@ -198,6 +198,7 @@ genEvaluateTxError = frequency
       ))
     , (1, EvaluateTxUnknownInputs <$> reasonablySized arbitrary)
     , (1, EvaluateTxIncompatibleEra <$> elements [ "Byron", "Shelley", "Allegra", "Mary" ])
+    , (1, EvaluateTxAdditionalUtxoOverlap <$> reasonablySized arbitrary)
     ]
 
 genScriptFailure :: Gen (ScriptFailure StandardCrypto)


### PR DESCRIPTION
- :round_pushpin: **Introduce additional utxo set to the 'EvaluateTx' request message.**
    The idea is to let clients provide an extra utxo set to complete the existing one from the network. This is useful for testing and playing around in a more reliable manner but is also useful to calculate execution units of chained transactions. It is fully optional.

- :round_pushpin: **Allow passing additional UTXO to the execution units evaluator.**
  
- :round_pushpin: **Write decoder for UTXO**
    Property-tested in roundtrips against the UTXO encoders, for which there already exists a slew of tests ensuring they match the JSON-schema. This gives guarantees that the JSON decoders are following the right JSON-schema and works accordingly.
    
 - :round_pushpin: **Fix type-reflection assertions not picking up the right type**
    Actually 'fixed' them by removing them :grimacing:. It was a bit
  overkill in the first place and only adds complexity. Getting in to
  work requires actually even more type wrangling that I am willing to
  put in for that feature.

- :round_pushpin: **Add 'additionalUtxoSet' support to the TypeScript client.**
    As well as and e2e integration test showing its good functioning.

- :round_pushpin: **Document additional utxo set in user guide and JSON-schema.**
  
- :round_pushpin: **Add script execution evaluation to README**
    Also converted the current list of features into a list of links, pointing to relevant part of the documentation in the hope that this will help people to better navigate through the documentation.

- :round_pushpin: **Add ogmigo (as a submodule) in the clients directory.**

---

Without additional UTXO set:

```json
{ 
    "type": "jsonwsp/request",
    "version": "1.0",
    "servicename": "ogmios",
    "methodname": "EvaluateTx",
    "args": { "evaluate": "84a60081...8180f5f6" }
}

{
  "type": "jsonwsp/response",
  "version": "1.0",
  "servicename": "ogmios",
  "methodname": "EvaluateTx",
  "result": {
    "EvaluationFailure": {
      "UnknownInputs": [
        {
          "txId": "97b2af6dfc6a4825e934146f424cdd6ede43ff98c355d2ae3aa95b0f70b63949",
          "index": 3
        }
      ]
    }
  },
  "reflection": null
}
```

With additional UTXO set:

```json
{ 
    "type": "jsonwsp/request",
    "version": "1.0",
    "servicename": "ogmios",
    "methodname": "EvaluateTx",
    "args": { 
       "evaluate": "84a60081...8180f5f6" 
       "additionalUtxoSet": [
         [ 
           { "txId":"97b2af6dfc6a4825e934146f424cdd6ede43ff98c355d2ae3aa95b0f70b63949"
           , "index": 3
           },
           { "address": "addr_test1qp9zjnc775anpndl0jh3w7vyy25syfezf70m7qmleaky0fdu9mqe2tg33xyxlcqcy98w630c82cyzuwyrumn65cv57nqwxm2yd"
           , "value": { "coins": 10000000 }
           } 
         ]
       ]
    }
}

{
  "type": "jsonwsp/response",
  "version": "1.0",
  "servicename": "ogmios",
  "methodname": "EvaluateTx",
  "result": {
    "EvaluationResult": {
      "spend:0": {
        "memory": 1700,
        "steps": 476468
      }
    }
  },
  "reflection": null
}
```
