### PR TITLE
Skip options for browser WebSocket()

### DIFF
--- a/clients/TypeScript/packages/client/src/IsomorphicWebSocket.ts
+++ b/clients/TypeScript/packages/client/src/IsomorphicWebSocket.ts
@@ -5,7 +5,11 @@ import IsoWebSocket from 'isomorphic-ws'
  */
 export class WebSocket extends IsoWebSocket {
   constructor (addr : string | URL, opts? : IsoWebSocket.ClientOptions) {
-    super(addr, opts)
+    if (isBrowser) {
+      super(addr)
+    } else {
+      super(addr, opts)
+    }
     return isBrowser ? Object.assign(this, browserPolyfill(this as unknown as EventTarget)) : this
   }
 }


### PR DESCRIPTION
Could just skip the second `protocols` argument of `WebSocket` constructor, which accepts a `string` or `string[]`. Here are [details of the value](https://javascript.info/websocket#extensions-and-subprotocols).