### PR TITLE
Avoid setting multiple event handlers for each evaluateTx/submitTx calls. 

### DIFF
--- a/clients/TypeScript/.eslintrc.js
+++ b/clients/TypeScript/.eslintrc.js
@@ -6,6 +6,9 @@ module.exports = {
   "plugins": [
     "@typescript-eslint"
   ],
+  "globals": {
+    "AsyncGenerator": true
+  },
   "rules": {
     "no-unused-vars": 0,
     "linebreak-style": [

--- a/clients/TypeScript/packages/client/package.json
+++ b/clients/TypeScript/packages/client/package.json
@@ -23,9 +23,11 @@
     "test:chrome": "jest -c ./jest.config.puppeteer.js"
   },
   "devDependencies": {
+    "@types/events": "^3.0.0",
     "@types/expect-puppeteer": "^4.4.5",
     "@types/jest": "^26.0.20",
     "@types/jest-environment-puppeteer": "^4.4.1",
+    "@types/json-bigint": "^1.0.1",
     "@types/node": "^14.14.32",
     "@types/node-fetch": "^2.5.10",
     "@types/puppeteer": "^5.4.3",
@@ -54,7 +56,7 @@
     "@cardano-ogmios/schema": "5.2.0",
     "@cardanosolutions/json-bigint": "^1.0.0",
     "@types/json-bigint": "^1.0.1",
-    "cross-fetch": "^3.1.5",
+    "cross-fetch": "^3.1.4",
     "fastq": "^1.11.0",
     "isomorphic-ws": "^4.0.1",
     "nanoid": "^3.1.31",

--- a/clients/TypeScript/packages/client/src/TxSubmission/TxSubmissionClient.ts
+++ b/clients/TypeScript/packages/client/src/TxSubmission/TxSubmissionClient.ts
@@ -1,7 +1,9 @@
 import { InteractionContext } from '../Connection'
-import { ensureSocketIsOpen } from '../util'
-import { submitTx } from './submitTx'
+import { ensureSocketIsOpen, eventEmitterToGenerator, safeJSON } from '../util'
+import { handleSubmitTxResponse, isTxId } from './submitTx'
 import { evaluateTx } from './evaluateTx'
+import { Ogmios, TxId } from '@cardano-ogmios/schema'
+import { baseRequest, send } from '../Request'
 
 /**
  * See also {@link createTxSubmissionClient} for creating a client.
@@ -11,7 +13,7 @@ import { evaluateTx } from './evaluateTx'
 export interface TxSubmissionClient {
   context: InteractionContext
   evaluateTx: (bytes: string) => ReturnType<typeof evaluateTx>
-  submitTx: (bytes: string) => ReturnType<typeof submitTx>
+  submitTx: (bytes: string) => Promise<TxId>
   shutdown: () => Promise<void>
 }
 
@@ -24,15 +26,40 @@ export const createTxSubmissionClient = async (
   context: InteractionContext
 ): Promise<TxSubmissionClient> => {
   const { socket } = context
+
+  const matchSubmitTx = (data: string) => {
+    const response = safeJSON.parse(data) as Ogmios['SubmitTxResponse']
+    if (response.methodname !== 'SubmitTx') {
+      return null
+    }
+    return response
+  }
+  const submitTxResponse = eventEmitterToGenerator(socket, 'message', matchSubmitTx)() as
+    AsyncGenerator<Ogmios['SubmitTxResponse']>
+
   return Promise.resolve({
     context,
     evaluateTx: (bytes) => {
       ensureSocketIsOpen(socket)
       return evaluateTx(context, bytes)
     },
-    submitTx: (bytes) => {
+    submitTx: async (bytes) => {
       ensureSocketIsOpen(socket)
-      return submitTx(context, bytes)
+      return send<TxId>(async (socket) => {
+        socket.send(safeJSON.stringify({
+          ...baseRequest,
+          methodname: 'SubmitTx',
+          args: { submit: bytes }
+        } as unknown as Ogmios['SubmitTx']))
+
+        const response = handleSubmitTxResponse((await submitTxResponse.next()).value)
+
+        if (isTxId(response)) {
+          return response
+        } else {
+          throw response
+        }
+      }, context)
     },
     shutdown: () => new Promise(resolve => {
       ensureSocketIsOpen(socket)

--- a/clients/TypeScript/packages/client/src/TxSubmission/evaluateTx.ts
+++ b/clients/TypeScript/packages/client/src/TxSubmission/evaluateTx.ts
@@ -52,46 +52,50 @@ export const evaluateTx = (context: InteractionContext, bytes: string, additiona
 
 /** @Internal */
 export const handleEvaluateTxResponse = (response: Ogmios['EvaluateTxResponse']) : (EvaluationResult | Error[]) => {
-  const { result } = response
-  if ('EvaluationResult' in result) {
-    return result.EvaluationResult
-  } else if ('EvaluationFailure' in result) {
-    const { EvaluationFailure } = result
-    if ('ScriptFailures' in EvaluationFailure) {
-      const { ScriptFailures } = EvaluationFailure
-      if (Array.isArray(ScriptFailures)) {
-        return ScriptFailures.map(failure => {
-          if (errors.ExtraRedeemers.assert(failure)) {
-            return new errors.ExtraRedeemers.Error(failure)
-          } else if (errors.IllFormedExecutionBudget.assert(failure)) {
-            return new errors.IllFormedExecutionBudget.Error(failure)
-          } else if (errors.MissingRequiredDatums.assert(failure)) {
-            return new errors.MissingRequiredDatums.Error(failure)
-          } else if (errors.MissingRequiredScripts.assert(failure)) {
-            return new errors.MissingRequiredScripts.Error(failure)
-          } else if (errors.NoCostModelForLanguage.assert(failure)) {
-            return new errors.NoCostModelForLanguage.Error(failure)
-          } else if (errors.NonScriptInputReferencedByRedeemer.assert(failure)) {
-            return new errors.NonScriptInputReferencedByRedeemer.Error(failure)
-          } else if (errors.UnknownInputReferencedByRedeemer.assert(failure)) {
-            return new errors.UnknownInputReferencedByRedeemer.Error(failure)
-          } else if (errors.ValidatorFailed.assert(failure)) {
-            return new errors.ValidatorFailed.Error(failure)
-          } else {
-            return new Error(failure)
-          }
-        })
+  try {
+    const { result } = response
+    if ('EvaluationResult' in result) {
+      return result.EvaluationResult
+    } else if ('EvaluationFailure' in result) {
+      const { EvaluationFailure } = result
+      if ('ScriptFailures' in EvaluationFailure) {
+        const { ScriptFailures } = EvaluationFailure
+        if (Array.isArray(ScriptFailures)) {
+          return ScriptFailures.map(failure => {
+            if (errors.ExtraRedeemers.assert(failure)) {
+              return new errors.ExtraRedeemers.Error(failure)
+            } else if (errors.IllFormedExecutionBudget.assert(failure)) {
+              return new errors.IllFormedExecutionBudget.Error(failure)
+            } else if (errors.MissingRequiredDatums.assert(failure)) {
+              return new errors.MissingRequiredDatums.Error(failure)
+            } else if (errors.MissingRequiredScripts.assert(failure)) {
+              return new errors.MissingRequiredScripts.Error(failure)
+            } else if (errors.NoCostModelForLanguage.assert(failure)) {
+              return new errors.NoCostModelForLanguage.Error(failure)
+            } else if (errors.NonScriptInputReferencedByRedeemer.assert(failure)) {
+              return new errors.NonScriptInputReferencedByRedeemer.Error(failure)
+            } else if (errors.UnknownInputReferencedByRedeemer.assert(failure)) {
+              return new errors.UnknownInputReferencedByRedeemer.Error(failure)
+            } else if (errors.ValidatorFailed.assert(failure)) {
+              return new errors.ValidatorFailed.Error(failure)
+            } else {
+              return new Error(failure)
+            }
+          })
+        }
+      } else if (errors.UnknownInputs.assert(EvaluationFailure)) {
+        return [new errors.UnknownInputs.Error(EvaluationFailure)]
+      } else if (errors.IncompatibleEra.assert(EvaluationFailure)) {
+        return [new errors.IncompatibleEra.Error(EvaluationFailure)]
+      } else if (errors.UncomputableSlotArithmetic.assert(EvaluationFailure)) {
+        return [new errors.UncomputableSlotArithmetic.Error(EvaluationFailure)]
+      } else if (errors.AdditionalUtxoOverlap.assert(EvaluationFailure)) {
+        return [new errors.AdditionalUtxoOverlap.Error(EvaluationFailure)]
       }
-    } else if (errors.UnknownInputs.assert(EvaluationFailure)) {
-      return [new errors.UnknownInputs.Error(EvaluationFailure)]
-    } else if (errors.IncompatibleEra.assert(EvaluationFailure)) {
-      return [new errors.IncompatibleEra.Error(EvaluationFailure)]
-    } else if (errors.UncomputableSlotArithmetic.assert(EvaluationFailure)) {
-      return [new errors.UncomputableSlotArithmetic.Error(EvaluationFailure)]
-    } else if (errors.AdditionalUtxoOverlap.assert(EvaluationFailure)) {
-      return [new errors.AdditionalUtxoOverlap.Error(EvaluationFailure)]
+    } else {
+      return [new UnknownResultError(response)]
     }
-  } else {
+  } catch (e) {
     return [new UnknownResultError(response)]
   }
 }

--- a/clients/TypeScript/packages/client/src/TxSubmission/evaluateTx.ts
+++ b/clients/TypeScript/packages/client/src/TxSubmission/evaluateTx.ts
@@ -4,9 +4,22 @@ import { errors } from './evaluationErrors'
 import { Ogmios, ExUnits, Utxo } from '@cardano-ogmios/schema'
 import { Query } from '../StateQuery'
 
+/**
+ * Evaluation results, as a map of redeemer pointers to execution units. Points are in the form of
+ *
+ *     {tag}:{index}
+ *
+ * where {tag} can be one of spend | mint  | certificate | withdrawal and {index} is a positive integer.
+ *
+ * @category TxSubmission
+ */
 export interface EvaluationResult {
   [k: string]: ExUnits
 }
+
+/** @Internal */
+export const isEvaluationResult = (result: EvaluationResult | Error[]): result is EvaluationResult =>
+  (typeof (result as EvaluationResult) === 'object' && Object.keys(result).every(x => /^(spend|mint|certificate|withdrawal):\d+$/.test(x)))
 
 /**
  * Evaluate execution units of a serialized transaction. This expects a base16 or base64 CBOR-encoded
@@ -28,48 +41,57 @@ export const evaluateTx = (context: InteractionContext, bytes: string, additiona
     }
   }, {
     handler: (response, resolve, reject) => {
-      if (response.methodname === 'EvaluateTx') {
-        const { result } = response
-        if ('EvaluationResult' in result) {
-          return resolve(result.EvaluationResult)
-        } else if ('EvaluationFailure' in result) {
-          const { EvaluationFailure } = result
-          if ('ScriptFailures' in EvaluationFailure) {
-            const { ScriptFailures } = EvaluationFailure
-            if (Array.isArray(ScriptFailures)) {
-              return reject(ScriptFailures.map(failure => {
-                if (errors.ExtraRedeemers.assert(failure)) {
-                  return new errors.ExtraRedeemers.Error(failure)
-                } else if (errors.IllFormedExecutionBudget.assert(failure)) {
-                  return new errors.IllFormedExecutionBudget.Error(failure)
-                } else if (errors.MissingRequiredDatums.assert(failure)) {
-                  return new errors.MissingRequiredDatums.Error(failure)
-                } else if (errors.MissingRequiredScripts.assert(failure)) {
-                  return new errors.MissingRequiredScripts.Error(failure)
-                } else if (errors.NoCostModelForLanguage.assert(failure)) {
-                  return new errors.NoCostModelForLanguage.Error(failure)
-                } else if (errors.NonScriptInputReferencedByRedeemer.assert(failure)) {
-                  return new errors.NonScriptInputReferencedByRedeemer.Error(failure)
-                } else if (errors.UnknownInputReferencedByRedeemer.assert(failure)) {
-                  return new errors.UnknownInputReferencedByRedeemer.Error(failure)
-                } else if (errors.ValidatorFailed.assert(failure)) {
-                  return new errors.ValidatorFailed.Error(failure)
-                } else {
-                  return new Error(failure)
-                }
-              }))
-            }
-          } else if (errors.UnknownInputs.assert(EvaluationFailure)) {
-            return reject([new errors.UnknownInputs.Error(EvaluationFailure)])
-          } else if (errors.IncompatibleEra.assert(EvaluationFailure)) {
-            return reject([new errors.IncompatibleEra.Error(EvaluationFailure)])
-          } else if (errors.UncomputableSlotArithmetic.assert(EvaluationFailure)) {
-            return reject([new errors.UncomputableSlotArithmetic.Error(EvaluationFailure)])
-          } else if (errors.AdditionalUtxoOverlap.assert(EvaluationFailure)) {
-            return reject([new errors.AdditionalUtxoOverlap.Error(EvaluationFailure)])
-          }
-        }
+      const result = handleEvaluateTxResponse(response)
+      if (isEvaluationResult(result)) {
+        return resolve(result as EvaluationResult)
+      } else {
+        return reject(result as Error[])
       }
-      return reject(new UnknownResultError(response))
     }
   }, context)
+
+/** @Internal */
+export const handleEvaluateTxResponse = (response: Ogmios['EvaluateTxResponse']) : (EvaluationResult | Error[]) => {
+  const { result } = response
+  if ('EvaluationResult' in result) {
+    return result.EvaluationResult
+  } else if ('EvaluationFailure' in result) {
+    const { EvaluationFailure } = result
+    if ('ScriptFailures' in EvaluationFailure) {
+      const { ScriptFailures } = EvaluationFailure
+      if (Array.isArray(ScriptFailures)) {
+        return ScriptFailures.map(failure => {
+          if (errors.ExtraRedeemers.assert(failure)) {
+            return new errors.ExtraRedeemers.Error(failure)
+          } else if (errors.IllFormedExecutionBudget.assert(failure)) {
+            return new errors.IllFormedExecutionBudget.Error(failure)
+          } else if (errors.MissingRequiredDatums.assert(failure)) {
+            return new errors.MissingRequiredDatums.Error(failure)
+          } else if (errors.MissingRequiredScripts.assert(failure)) {
+            return new errors.MissingRequiredScripts.Error(failure)
+          } else if (errors.NoCostModelForLanguage.assert(failure)) {
+            return new errors.NoCostModelForLanguage.Error(failure)
+          } else if (errors.NonScriptInputReferencedByRedeemer.assert(failure)) {
+            return new errors.NonScriptInputReferencedByRedeemer.Error(failure)
+          } else if (errors.UnknownInputReferencedByRedeemer.assert(failure)) {
+            return new errors.UnknownInputReferencedByRedeemer.Error(failure)
+          } else if (errors.ValidatorFailed.assert(failure)) {
+            return new errors.ValidatorFailed.Error(failure)
+          } else {
+            return new Error(failure)
+          }
+        })
+      }
+    } else if (errors.UnknownInputs.assert(EvaluationFailure)) {
+      return [new errors.UnknownInputs.Error(EvaluationFailure)]
+    } else if (errors.IncompatibleEra.assert(EvaluationFailure)) {
+      return [new errors.IncompatibleEra.Error(EvaluationFailure)]
+    } else if (errors.UncomputableSlotArithmetic.assert(EvaluationFailure)) {
+      return [new errors.UncomputableSlotArithmetic.Error(EvaluationFailure)]
+    } else if (errors.AdditionalUtxoOverlap.assert(EvaluationFailure)) {
+      return [new errors.AdditionalUtxoOverlap.Error(EvaluationFailure)]
+    }
+  } else {
+    return [new UnknownResultError(response)]
+  }
+}

--- a/clients/TypeScript/packages/client/src/TxSubmission/submitTx.ts
+++ b/clients/TypeScript/packages/client/src/TxSubmission/submitTx.ts
@@ -35,146 +35,150 @@ export const submitTx = (context: InteractionContext, bytes: string) =>
 
 /** @Internal */
 export const handleSubmitTxResponse = (response: Ogmios['SubmitTxResponse']) : (TxId | Error[]) => {
-  const { result } = response
-  if ('SubmitSuccess' in result) {
-    const { SubmitSuccess } = result
-    return SubmitSuccess.txId
-  } else if ('SubmitFail' in result) {
-    const { SubmitFail } = result
-    if (Array.isArray(SubmitFail)) {
-      return SubmitFail.map(failure => {
-        if (errors.EraMismatch.assert(failure)) {
-          return new errors.EraMismatch.Error(failure)
-        } else if (errors.InvalidWitnesses.assert(failure)) {
-          return new errors.InvalidWitnesses.Error(failure)
-        } else if (errors.MissingVkWitnesses.assert(failure)) {
-          return new errors.MissingVkWitnesses.Error(failure)
-        } else if (errors.MissingScriptWitnesses.assert(failure)) {
-          return new errors.MissingScriptWitnesses.Error(failure)
-        } else if (errors.ScriptWitnessNotValidating.assert(failure)) {
-          return new errors.ScriptWitnessNotValidating.Error(failure)
-        } else if (errors.InsufficientGenesisSignatures.assert(failure)) {
-          return new errors.InsufficientGenesisSignatures.Error(failure)
-        } else if (errors.MissingTxMetadata.assert(failure)) {
-          return new errors.MissingTxMetadata.Error(failure)
-        } else if (errors.MissingTxMetadataHash.assert(failure)) {
-          return new errors.MissingTxMetadataHash.Error(failure)
-        } else if (errors.TxMetadataHashMismatch.assert(failure)) {
-          return new errors.TxMetadataHashMismatch.Error(failure)
-        } else if (errors.BadInputs.assert(failure)) {
-          return new errors.BadInputs.Error(failure)
-        } else if (errors.ExpiredUtxo.assert(failure)) {
-          return new errors.ExpiredUtxo.Error(failure)
-        } else if (errors.TxTooLarge.assert(failure)) {
-          return new errors.TxTooLarge.Error(failure)
-        } else if (errors.MissingAtLeastOneInputUtxo.assert(failure)) {
-          return new errors.MissingAtLeastOneInputUtxo.Error(failure)
-        } else if (errors.InvalidMetadata.assert(failure)) {
-          return new errors.InvalidMetadata.Error(failure)
-        } else if (errors.FeeTooSmall.assert(failure)) {
-          return new errors.FeeTooSmall.Error(failure)
-        } else if (errors.ValueNotConserved.assert(failure)) {
-          return new errors.ValueNotConserved.Error(failure)
-        } else if (errors.NetworkMismatch.assert(failure)) {
-          return new errors.NetworkMismatch.Error(failure)
-        } else if (errors.OutputTooSmall.assert(failure)) {
-          return new errors.OutputTooSmall.Error(failure)
-        } else if (errors.AddressAttributesTooLarge.assert(failure)) {
-          return new errors.AddressAttributesTooLarge.Error(failure)
-        } else if (errors.DelegateNotRegistered.assert(failure)) {
-          return new errors.DelegateNotRegistered.Error(failure)
-        } else if (errors.UnknownOrIncompleteWithdrawals.assert(failure)) {
-          return new errors.UnknownOrIncompleteWithdrawals.Error(failure)
-        } else if (errors.StakePoolNotRegistered.assert(failure)) {
-          return new errors.StakePoolNotRegistered.Error(failure)
-        } else if (errors.WrongRetirementEpoch.assert(failure)) {
-          return new errors.WrongRetirementEpoch.Error(failure)
-        } else if (errors.WrongPoolCertificate.assert(failure)) {
-          return new errors.WrongPoolCertificate.Error(failure)
-        } else if (errors.StakeKeyAlreadyRegistered.assert(failure)) {
-          return new errors.StakeKeyAlreadyRegistered.Error(failure)
-        } else if (errors.PoolCostTooSmall.assert(failure)) {
-          return new errors.PoolCostTooSmall.Error(failure)
-        } else if (errors.StakeKeyNotRegistered.assert(failure)) {
-          return new errors.StakeKeyNotRegistered.Error(failure)
-        } else if (errors.RewardAccountNotExisting.assert(failure)) {
-          return new errors.RewardAccountNotExisting.Error(failure)
-        } else if (errors.RewardAccountNotEmpty.assert(failure)) {
-          return new errors.RewardAccountNotEmpty.Error(failure)
-        } else if (errors.WrongCertificateType.assert(failure)) {
-          return new errors.WrongCertificateType.Error(failure)
-        } else if (errors.UnknownGenesisKey.assert(failure)) {
-          return new errors.UnknownGenesisKey.Error(failure)
-        } else if (errors.AlreadyDelegating.assert(failure)) {
-          return new errors.AlreadyDelegating.Error(failure)
-        } else if (errors.InsufficientFundsForMir.assert(failure)) {
-          return new errors.InsufficientFundsForMir.Error(failure)
-        } else if (errors.TooLateForMir.assert(failure)) {
-          return new errors.TooLateForMir.Error(failure)
-        } else if (errors.MirTransferNotCurrentlyAllowed.assert(failure)) {
-          return new errors.MirTransferNotCurrentlyAllowed.Error(failure)
-        } else if (errors.MirNegativeTransferNotCurrentlyAllowed.assert(failure)) {
-          return new errors.MirNegativeTransferNotCurrentlyAllowed.Error(failure)
-        } else if (errors.MirProducesNegativeUpdate.assert(failure)) {
-          return new errors.MirProducesNegativeUpdate.Error(failure)
-        } else if (errors.DuplicateGenesisVrf.assert(failure)) {
-          return new errors.DuplicateGenesisVrf.Error(failure)
-        } else if (errors.NonGenesisVoters.assert(failure)) {
-          return new errors.NonGenesisVoters.Error(failure)
-        } else if (errors.UpdateWrongEpoch.assert(failure)) {
-          return new errors.UpdateWrongEpoch.Error(failure)
-        } else if (errors.ProtocolVersionCannotFollow.assert(failure)) {
-          return new errors.ProtocolVersionCannotFollow.Error(failure)
-        } else if (errors.OutsideOfValidityInterval.assert(failure)) {
-          return new errors.OutsideOfValidityInterval.Error(failure)
-        } else if (errors.TriesToForgeAda.assert(failure)) {
-          return new errors.TriesToForgeAda.Error(failure)
-        } else if (errors.TooManyAssetsInOutput.assert(failure)) {
-          return new errors.TooManyAssetsInOutput.Error(failure)
-        } else if (errors.MissingRequiredRedeemers.assert(failure)) {
-          return new errors.MissingRequiredRedeemers.Error(failure)
-        } else if (errors.ExtraDataMismatch.assert(failure)) {
-          return new errors.ExtraDataMismatch.Error(failure)
-        } else if (errors.MissingRequiredSignatures.assert(failure)) {
-          return new errors.MissingRequiredSignatures.Error(failure)
-        } else if (errors.MissingDatumHashesForInputs.assert(failure)) {
-          return new errors.MissingDatumHashesForInputs.Error(failure)
-        } else if (errors.MissingCollateralInputs.assert(failure)) {
-          return new errors.MissingCollateralInputs.Error(failure)
-        } else if (errors.CollateralTooSmall.assert(failure)) {
-          return new errors.CollateralTooSmall.Error(failure)
-        } else if (errors.CollateralIsScript.assert(failure)) {
-          return new errors.CollateralIsScript.Error(failure)
-        } else if (errors.CollateralHasNonAdaAssets.assert(failure)) {
-          return new errors.CollateralHasNonAdaAssets.Error(failure)
-        } else if (errors.TooManyCollateralInputs.assert(failure)) {
-          return new errors.TooManyCollateralInputs.Error(failure)
-        } else if (errors.ExecutionUnitsTooLarge.assert(failure)) {
-          return new errors.ExecutionUnitsTooLarge.Error(failure)
-        } else if (errors.OutsideForecast.assert(failure)) {
-          return new errors.OutsideForecast.Error(failure)
-        } else if (errors.ValidationTagMismatch.assert(failure)) {
-          return new errors.ValidationTagMismatch.Error(failure)
-        } else if (errors.CollectErrors.assert(failure)) {
-          return new errors.CollectErrors.Error(failure)
-        } else if (errors.PoolMetadataHashTooBig.assert(failure)) {
-          return new errors.PoolMetadataHashTooBig.Error(failure)
-        } else if (errors.MissingRequiredDatums.assert(failure)) {
-          return new errors.MissingRequiredDatums.Error(failure)
-        } else if (errors.UnspendableDatums.assert(failure)) {
-          return new errors.UnspendableDatums.Error(failure)
-        } else if (errors.UnspendableScriptInputs.assert(failure)) {
-          return new errors.UnspendableScriptInputs.Error(failure)
-        } else if (errors.ExtraRedeemers.assert(failure)) {
-          return new errors.ExtraRedeemers.Error(failure)
-        } else if (errors.ExtraScriptWitnesses.assert(failure)) {
-          return new errors.ExtraScriptWitnesses.Error(failure)
-        } else {
-          return new Error(failure)
-        }
-      })
+  try {
+    const { result } = response
+    if ('SubmitSuccess' in result) {
+      const { SubmitSuccess } = result
+      return SubmitSuccess.txId
+    } else if ('SubmitFail' in result) {
+      const { SubmitFail } = result
+      if (Array.isArray(SubmitFail)) {
+        return SubmitFail.map(failure => {
+          if (errors.EraMismatch.assert(failure)) {
+            return new errors.EraMismatch.Error(failure)
+          } else if (errors.InvalidWitnesses.assert(failure)) {
+            return new errors.InvalidWitnesses.Error(failure)
+          } else if (errors.MissingVkWitnesses.assert(failure)) {
+            return new errors.MissingVkWitnesses.Error(failure)
+          } else if (errors.MissingScriptWitnesses.assert(failure)) {
+            return new errors.MissingScriptWitnesses.Error(failure)
+          } else if (errors.ScriptWitnessNotValidating.assert(failure)) {
+            return new errors.ScriptWitnessNotValidating.Error(failure)
+          } else if (errors.InsufficientGenesisSignatures.assert(failure)) {
+            return new errors.InsufficientGenesisSignatures.Error(failure)
+          } else if (errors.MissingTxMetadata.assert(failure)) {
+            return new errors.MissingTxMetadata.Error(failure)
+          } else if (errors.MissingTxMetadataHash.assert(failure)) {
+            return new errors.MissingTxMetadataHash.Error(failure)
+          } else if (errors.TxMetadataHashMismatch.assert(failure)) {
+            return new errors.TxMetadataHashMismatch.Error(failure)
+          } else if (errors.BadInputs.assert(failure)) {
+            return new errors.BadInputs.Error(failure)
+          } else if (errors.ExpiredUtxo.assert(failure)) {
+            return new errors.ExpiredUtxo.Error(failure)
+          } else if (errors.TxTooLarge.assert(failure)) {
+            return new errors.TxTooLarge.Error(failure)
+          } else if (errors.MissingAtLeastOneInputUtxo.assert(failure)) {
+            return new errors.MissingAtLeastOneInputUtxo.Error(failure)
+          } else if (errors.InvalidMetadata.assert(failure)) {
+            return new errors.InvalidMetadata.Error(failure)
+          } else if (errors.FeeTooSmall.assert(failure)) {
+            return new errors.FeeTooSmall.Error(failure)
+          } else if (errors.ValueNotConserved.assert(failure)) {
+            return new errors.ValueNotConserved.Error(failure)
+          } else if (errors.NetworkMismatch.assert(failure)) {
+            return new errors.NetworkMismatch.Error(failure)
+          } else if (errors.OutputTooSmall.assert(failure)) {
+            return new errors.OutputTooSmall.Error(failure)
+          } else if (errors.AddressAttributesTooLarge.assert(failure)) {
+            return new errors.AddressAttributesTooLarge.Error(failure)
+          } else if (errors.DelegateNotRegistered.assert(failure)) {
+            return new errors.DelegateNotRegistered.Error(failure)
+          } else if (errors.UnknownOrIncompleteWithdrawals.assert(failure)) {
+            return new errors.UnknownOrIncompleteWithdrawals.Error(failure)
+          } else if (errors.StakePoolNotRegistered.assert(failure)) {
+            return new errors.StakePoolNotRegistered.Error(failure)
+          } else if (errors.WrongRetirementEpoch.assert(failure)) {
+            return new errors.WrongRetirementEpoch.Error(failure)
+          } else if (errors.WrongPoolCertificate.assert(failure)) {
+            return new errors.WrongPoolCertificate.Error(failure)
+          } else if (errors.StakeKeyAlreadyRegistered.assert(failure)) {
+            return new errors.StakeKeyAlreadyRegistered.Error(failure)
+          } else if (errors.PoolCostTooSmall.assert(failure)) {
+            return new errors.PoolCostTooSmall.Error(failure)
+          } else if (errors.StakeKeyNotRegistered.assert(failure)) {
+            return new errors.StakeKeyNotRegistered.Error(failure)
+          } else if (errors.RewardAccountNotExisting.assert(failure)) {
+            return new errors.RewardAccountNotExisting.Error(failure)
+          } else if (errors.RewardAccountNotEmpty.assert(failure)) {
+            return new errors.RewardAccountNotEmpty.Error(failure)
+          } else if (errors.WrongCertificateType.assert(failure)) {
+            return new errors.WrongCertificateType.Error(failure)
+          } else if (errors.UnknownGenesisKey.assert(failure)) {
+            return new errors.UnknownGenesisKey.Error(failure)
+          } else if (errors.AlreadyDelegating.assert(failure)) {
+            return new errors.AlreadyDelegating.Error(failure)
+          } else if (errors.InsufficientFundsForMir.assert(failure)) {
+            return new errors.InsufficientFundsForMir.Error(failure)
+          } else if (errors.TooLateForMir.assert(failure)) {
+            return new errors.TooLateForMir.Error(failure)
+          } else if (errors.MirTransferNotCurrentlyAllowed.assert(failure)) {
+            return new errors.MirTransferNotCurrentlyAllowed.Error(failure)
+          } else if (errors.MirNegativeTransferNotCurrentlyAllowed.assert(failure)) {
+            return new errors.MirNegativeTransferNotCurrentlyAllowed.Error(failure)
+          } else if (errors.MirProducesNegativeUpdate.assert(failure)) {
+            return new errors.MirProducesNegativeUpdate.Error(failure)
+          } else if (errors.DuplicateGenesisVrf.assert(failure)) {
+            return new errors.DuplicateGenesisVrf.Error(failure)
+          } else if (errors.NonGenesisVoters.assert(failure)) {
+            return new errors.NonGenesisVoters.Error(failure)
+          } else if (errors.UpdateWrongEpoch.assert(failure)) {
+            return new errors.UpdateWrongEpoch.Error(failure)
+          } else if (errors.ProtocolVersionCannotFollow.assert(failure)) {
+            return new errors.ProtocolVersionCannotFollow.Error(failure)
+          } else if (errors.OutsideOfValidityInterval.assert(failure)) {
+            return new errors.OutsideOfValidityInterval.Error(failure)
+          } else if (errors.TriesToForgeAda.assert(failure)) {
+            return new errors.TriesToForgeAda.Error(failure)
+          } else if (errors.TooManyAssetsInOutput.assert(failure)) {
+            return new errors.TooManyAssetsInOutput.Error(failure)
+          } else if (errors.MissingRequiredRedeemers.assert(failure)) {
+            return new errors.MissingRequiredRedeemers.Error(failure)
+          } else if (errors.ExtraDataMismatch.assert(failure)) {
+            return new errors.ExtraDataMismatch.Error(failure)
+          } else if (errors.MissingRequiredSignatures.assert(failure)) {
+            return new errors.MissingRequiredSignatures.Error(failure)
+          } else if (errors.MissingDatumHashesForInputs.assert(failure)) {
+            return new errors.MissingDatumHashesForInputs.Error(failure)
+          } else if (errors.MissingCollateralInputs.assert(failure)) {
+            return new errors.MissingCollateralInputs.Error(failure)
+          } else if (errors.CollateralTooSmall.assert(failure)) {
+            return new errors.CollateralTooSmall.Error(failure)
+          } else if (errors.CollateralIsScript.assert(failure)) {
+            return new errors.CollateralIsScript.Error(failure)
+          } else if (errors.CollateralHasNonAdaAssets.assert(failure)) {
+            return new errors.CollateralHasNonAdaAssets.Error(failure)
+          } else if (errors.TooManyCollateralInputs.assert(failure)) {
+            return new errors.TooManyCollateralInputs.Error(failure)
+          } else if (errors.ExecutionUnitsTooLarge.assert(failure)) {
+            return new errors.ExecutionUnitsTooLarge.Error(failure)
+          } else if (errors.OutsideForecast.assert(failure)) {
+            return new errors.OutsideForecast.Error(failure)
+          } else if (errors.ValidationTagMismatch.assert(failure)) {
+            return new errors.ValidationTagMismatch.Error(failure)
+          } else if (errors.CollectErrors.assert(failure)) {
+            return new errors.CollectErrors.Error(failure)
+          } else if (errors.PoolMetadataHashTooBig.assert(failure)) {
+            return new errors.PoolMetadataHashTooBig.Error(failure)
+          } else if (errors.MissingRequiredDatums.assert(failure)) {
+            return new errors.MissingRequiredDatums.Error(failure)
+          } else if (errors.UnspendableDatums.assert(failure)) {
+            return new errors.UnspendableDatums.Error(failure)
+          } else if (errors.UnspendableScriptInputs.assert(failure)) {
+            return new errors.UnspendableScriptInputs.Error(failure)
+          } else if (errors.ExtraRedeemers.assert(failure)) {
+            return new errors.ExtraRedeemers.Error(failure)
+          } else if (errors.ExtraScriptWitnesses.assert(failure)) {
+            return new errors.ExtraScriptWitnesses.Error(failure)
+          } else {
+            return new Error(failure)
+          }
+        })
+      }
+    } else {
+      return [new UnknownResultError(response)]
     }
-  } else {
+  } catch (e) {
     return [new UnknownResultError(response)]
   }
 }

--- a/clients/TypeScript/packages/client/src/TxSubmission/submitTx.ts
+++ b/clients/TypeScript/packages/client/src/TxSubmission/submitTx.ts
@@ -24,15 +24,11 @@ export const submitTx = (context: InteractionContext, bytes: string) =>
     args: { submit: bytes }
   }, {
     handler: (response, resolve, reject) => {
-      if (response.methodname === 'SubmitTx') {
-        const result = handleSubmitTxResponse(response)
-        if (isTxId(result)) {
-          return resolve(result as TxId)
-        } else {
-          return reject(result as Error[])
-        }
+      const result = handleSubmitTxResponse(response)
+      if (isTxId(result)) {
+        return resolve(result as TxId)
       } else {
-        return reject([new UnknownResultError(response)])
+        return reject(result as Error[])
       }
     }
   }, context)

--- a/clients/TypeScript/packages/client/src/TxSubmission/submitTx.ts
+++ b/clients/TypeScript/packages/client/src/TxSubmission/submitTx.ts
@@ -4,6 +4,10 @@ import { errors } from './submissionErrors'
 import { Ogmios, TxId } from '@cardano-ogmios/schema'
 import { Query } from '../StateQuery'
 
+/** @Internal */
+export const isTxId = (result: TxId | Error[]): result is TxId =>
+  (typeof (result as TxId) === 'string')
+
 /**
  * Submit a serialized transaction. This expects a base16 or base64 CBOR-encoded
  * transaction as obtained from the cardano-cli or cardano-serialization-lib.
@@ -21,148 +25,160 @@ export const submitTx = (context: InteractionContext, bytes: string) =>
   }, {
     handler: (response, resolve, reject) => {
       if (response.methodname === 'SubmitTx') {
-        const { result } = response
-        if ('SubmitSuccess' in result) {
-          const { SubmitSuccess } = result
-          return resolve(SubmitSuccess.txId)
-        } else if ('SubmitFail' in result) {
-          const { SubmitFail } = result
-          if (Array.isArray(SubmitFail)) {
-            reject(SubmitFail.map(failure => {
-              if (errors.EraMismatch.assert(failure)) {
-                return new errors.EraMismatch.Error(failure)
-              } else if (errors.InvalidWitnesses.assert(failure)) {
-                return new errors.InvalidWitnesses.Error(failure)
-              } else if (errors.MissingVkWitnesses.assert(failure)) {
-                return new errors.MissingVkWitnesses.Error(failure)
-              } else if (errors.MissingScriptWitnesses.assert(failure)) {
-                return new errors.MissingScriptWitnesses.Error(failure)
-              } else if (errors.ScriptWitnessNotValidating.assert(failure)) {
-                return new errors.ScriptWitnessNotValidating.Error(failure)
-              } else if (errors.InsufficientGenesisSignatures.assert(failure)) {
-                return new errors.InsufficientGenesisSignatures.Error(failure)
-              } else if (errors.MissingTxMetadata.assert(failure)) {
-                return new errors.MissingTxMetadata.Error(failure)
-              } else if (errors.MissingTxMetadataHash.assert(failure)) {
-                return new errors.MissingTxMetadataHash.Error(failure)
-              } else if (errors.TxMetadataHashMismatch.assert(failure)) {
-                return new errors.TxMetadataHashMismatch.Error(failure)
-              } else if (errors.BadInputs.assert(failure)) {
-                return new errors.BadInputs.Error(failure)
-              } else if (errors.ExpiredUtxo.assert(failure)) {
-                return new errors.ExpiredUtxo.Error(failure)
-              } else if (errors.TxTooLarge.assert(failure)) {
-                return new errors.TxTooLarge.Error(failure)
-              } else if (errors.MissingAtLeastOneInputUtxo.assert(failure)) {
-                return new errors.MissingAtLeastOneInputUtxo.Error(failure)
-              } else if (errors.InvalidMetadata.assert(failure)) {
-                return new errors.InvalidMetadata.Error(failure)
-              } else if (errors.FeeTooSmall.assert(failure)) {
-                return new errors.FeeTooSmall.Error(failure)
-              } else if (errors.ValueNotConserved.assert(failure)) {
-                return new errors.ValueNotConserved.Error(failure)
-              } else if (errors.NetworkMismatch.assert(failure)) {
-                return new errors.NetworkMismatch.Error(failure)
-              } else if (errors.OutputTooSmall.assert(failure)) {
-                return new errors.OutputTooSmall.Error(failure)
-              } else if (errors.AddressAttributesTooLarge.assert(failure)) {
-                return new errors.AddressAttributesTooLarge.Error(failure)
-              } else if (errors.DelegateNotRegistered.assert(failure)) {
-                return new errors.DelegateNotRegistered.Error(failure)
-              } else if (errors.UnknownOrIncompleteWithdrawals.assert(failure)) {
-                return new errors.UnknownOrIncompleteWithdrawals.Error(failure)
-              } else if (errors.StakePoolNotRegistered.assert(failure)) {
-                return new errors.StakePoolNotRegistered.Error(failure)
-              } else if (errors.WrongRetirementEpoch.assert(failure)) {
-                return new errors.WrongRetirementEpoch.Error(failure)
-              } else if (errors.WrongPoolCertificate.assert(failure)) {
-                return new errors.WrongPoolCertificate.Error(failure)
-              } else if (errors.StakeKeyAlreadyRegistered.assert(failure)) {
-                return new errors.StakeKeyAlreadyRegistered.Error(failure)
-              } else if (errors.PoolCostTooSmall.assert(failure)) {
-                return new errors.PoolCostTooSmall.Error(failure)
-              } else if (errors.StakeKeyNotRegistered.assert(failure)) {
-                return new errors.StakeKeyNotRegistered.Error(failure)
-              } else if (errors.RewardAccountNotExisting.assert(failure)) {
-                return new errors.RewardAccountNotExisting.Error(failure)
-              } else if (errors.RewardAccountNotEmpty.assert(failure)) {
-                return new errors.RewardAccountNotEmpty.Error(failure)
-              } else if (errors.WrongCertificateType.assert(failure)) {
-                return new errors.WrongCertificateType.Error(failure)
-              } else if (errors.UnknownGenesisKey.assert(failure)) {
-                return new errors.UnknownGenesisKey.Error(failure)
-              } else if (errors.AlreadyDelegating.assert(failure)) {
-                return new errors.AlreadyDelegating.Error(failure)
-              } else if (errors.InsufficientFundsForMir.assert(failure)) {
-                return new errors.InsufficientFundsForMir.Error(failure)
-              } else if (errors.TooLateForMir.assert(failure)) {
-                return new errors.TooLateForMir.Error(failure)
-              } else if (errors.MirTransferNotCurrentlyAllowed.assert(failure)) {
-                return new errors.MirTransferNotCurrentlyAllowed.Error(failure)
-              } else if (errors.MirNegativeTransferNotCurrentlyAllowed.assert(failure)) {
-                return new errors.MirNegativeTransferNotCurrentlyAllowed.Error(failure)
-              } else if (errors.MirProducesNegativeUpdate.assert(failure)) {
-                return new errors.MirProducesNegativeUpdate.Error(failure)
-              } else if (errors.DuplicateGenesisVrf.assert(failure)) {
-                return new errors.DuplicateGenesisVrf.Error(failure)
-              } else if (errors.NonGenesisVoters.assert(failure)) {
-                return new errors.NonGenesisVoters.Error(failure)
-              } else if (errors.UpdateWrongEpoch.assert(failure)) {
-                return new errors.UpdateWrongEpoch.Error(failure)
-              } else if (errors.ProtocolVersionCannotFollow.assert(failure)) {
-                return new errors.ProtocolVersionCannotFollow.Error(failure)
-              } else if (errors.OutsideOfValidityInterval.assert(failure)) {
-                return new errors.OutsideOfValidityInterval.Error(failure)
-              } else if (errors.TriesToForgeAda.assert(failure)) {
-                return new errors.TriesToForgeAda.Error(failure)
-              } else if (errors.TooManyAssetsInOutput.assert(failure)) {
-                return new errors.TooManyAssetsInOutput.Error(failure)
-              } else if (errors.MissingRequiredRedeemers.assert(failure)) {
-                return new errors.MissingRequiredRedeemers.Error(failure)
-              } else if (errors.ExtraDataMismatch.assert(failure)) {
-                return new errors.ExtraDataMismatch.Error(failure)
-              } else if (errors.MissingRequiredSignatures.assert(failure)) {
-                return new errors.MissingRequiredSignatures.Error(failure)
-              } else if (errors.MissingDatumHashesForInputs.assert(failure)) {
-                return new errors.MissingDatumHashesForInputs.Error(failure)
-              } else if (errors.MissingCollateralInputs.assert(failure)) {
-                return new errors.MissingCollateralInputs.Error(failure)
-              } else if (errors.CollateralTooSmall.assert(failure)) {
-                return new errors.CollateralTooSmall.Error(failure)
-              } else if (errors.CollateralIsScript.assert(failure)) {
-                return new errors.CollateralIsScript.Error(failure)
-              } else if (errors.CollateralHasNonAdaAssets.assert(failure)) {
-                return new errors.CollateralHasNonAdaAssets.Error(failure)
-              } else if (errors.TooManyCollateralInputs.assert(failure)) {
-                return new errors.TooManyCollateralInputs.Error(failure)
-              } else if (errors.ExecutionUnitsTooLarge.assert(failure)) {
-                return new errors.ExecutionUnitsTooLarge.Error(failure)
-              } else if (errors.OutsideForecast.assert(failure)) {
-                return new errors.OutsideForecast.Error(failure)
-              } else if (errors.ValidationTagMismatch.assert(failure)) {
-                return new errors.ValidationTagMismatch.Error(failure)
-              } else if (errors.CollectErrors.assert(failure)) {
-                return new errors.CollectErrors.Error(failure)
-              } else if (errors.PoolMetadataHashTooBig.assert(failure)) {
-                return new errors.PoolMetadataHashTooBig.Error(failure)
-              } else if (errors.MissingRequiredDatums.assert(failure)) {
-                return new errors.MissingRequiredDatums.Error(failure)
-              } else if (errors.UnspendableDatums.assert(failure)) {
-                return new errors.UnspendableDatums.Error(failure)
-              } else if (errors.UnspendableScriptInputs.assert(failure)) {
-                return new errors.UnspendableScriptInputs.Error(failure)
-              } else if (errors.ExtraRedeemers.assert(failure)) {
-                return new errors.ExtraRedeemers.Error(failure)
-              } else if (errors.ExtraScriptWitnesses.assert(failure)) {
-                return new errors.ExtraScriptWitnesses.Error(failure)
-              } else {
-                return new Error(failure)
-              }
-            }))
-          }
+        const result = handleSubmitTxResponse(response)
+        if (isTxId(result)) {
+          return resolve(result as TxId)
+        } else {
+          return reject(result as Error[])
         }
       } else {
-        return reject(new UnknownResultError(response))
+        return reject([new UnknownResultError(response)])
       }
     }
   }, context)
+
+/** @Internal */
+export const handleSubmitTxResponse = (response: Ogmios['SubmitTxResponse']) : (TxId | Error[]) => {
+  const { result } = response
+  if ('SubmitSuccess' in result) {
+    const { SubmitSuccess } = result
+    return SubmitSuccess.txId
+  } else if ('SubmitFail' in result) {
+    const { SubmitFail } = result
+    if (Array.isArray(SubmitFail)) {
+      return SubmitFail.map(failure => {
+        if (errors.EraMismatch.assert(failure)) {
+          return new errors.EraMismatch.Error(failure)
+        } else if (errors.InvalidWitnesses.assert(failure)) {
+          return new errors.InvalidWitnesses.Error(failure)
+        } else if (errors.MissingVkWitnesses.assert(failure)) {
+          return new errors.MissingVkWitnesses.Error(failure)
+        } else if (errors.MissingScriptWitnesses.assert(failure)) {
+          return new errors.MissingScriptWitnesses.Error(failure)
+        } else if (errors.ScriptWitnessNotValidating.assert(failure)) {
+          return new errors.ScriptWitnessNotValidating.Error(failure)
+        } else if (errors.InsufficientGenesisSignatures.assert(failure)) {
+          return new errors.InsufficientGenesisSignatures.Error(failure)
+        } else if (errors.MissingTxMetadata.assert(failure)) {
+          return new errors.MissingTxMetadata.Error(failure)
+        } else if (errors.MissingTxMetadataHash.assert(failure)) {
+          return new errors.MissingTxMetadataHash.Error(failure)
+        } else if (errors.TxMetadataHashMismatch.assert(failure)) {
+          return new errors.TxMetadataHashMismatch.Error(failure)
+        } else if (errors.BadInputs.assert(failure)) {
+          return new errors.BadInputs.Error(failure)
+        } else if (errors.ExpiredUtxo.assert(failure)) {
+          return new errors.ExpiredUtxo.Error(failure)
+        } else if (errors.TxTooLarge.assert(failure)) {
+          return new errors.TxTooLarge.Error(failure)
+        } else if (errors.MissingAtLeastOneInputUtxo.assert(failure)) {
+          return new errors.MissingAtLeastOneInputUtxo.Error(failure)
+        } else if (errors.InvalidMetadata.assert(failure)) {
+          return new errors.InvalidMetadata.Error(failure)
+        } else if (errors.FeeTooSmall.assert(failure)) {
+          return new errors.FeeTooSmall.Error(failure)
+        } else if (errors.ValueNotConserved.assert(failure)) {
+          return new errors.ValueNotConserved.Error(failure)
+        } else if (errors.NetworkMismatch.assert(failure)) {
+          return new errors.NetworkMismatch.Error(failure)
+        } else if (errors.OutputTooSmall.assert(failure)) {
+          return new errors.OutputTooSmall.Error(failure)
+        } else if (errors.AddressAttributesTooLarge.assert(failure)) {
+          return new errors.AddressAttributesTooLarge.Error(failure)
+        } else if (errors.DelegateNotRegistered.assert(failure)) {
+          return new errors.DelegateNotRegistered.Error(failure)
+        } else if (errors.UnknownOrIncompleteWithdrawals.assert(failure)) {
+          return new errors.UnknownOrIncompleteWithdrawals.Error(failure)
+        } else if (errors.StakePoolNotRegistered.assert(failure)) {
+          return new errors.StakePoolNotRegistered.Error(failure)
+        } else if (errors.WrongRetirementEpoch.assert(failure)) {
+          return new errors.WrongRetirementEpoch.Error(failure)
+        } else if (errors.WrongPoolCertificate.assert(failure)) {
+          return new errors.WrongPoolCertificate.Error(failure)
+        } else if (errors.StakeKeyAlreadyRegistered.assert(failure)) {
+          return new errors.StakeKeyAlreadyRegistered.Error(failure)
+        } else if (errors.PoolCostTooSmall.assert(failure)) {
+          return new errors.PoolCostTooSmall.Error(failure)
+        } else if (errors.StakeKeyNotRegistered.assert(failure)) {
+          return new errors.StakeKeyNotRegistered.Error(failure)
+        } else if (errors.RewardAccountNotExisting.assert(failure)) {
+          return new errors.RewardAccountNotExisting.Error(failure)
+        } else if (errors.RewardAccountNotEmpty.assert(failure)) {
+          return new errors.RewardAccountNotEmpty.Error(failure)
+        } else if (errors.WrongCertificateType.assert(failure)) {
+          return new errors.WrongCertificateType.Error(failure)
+        } else if (errors.UnknownGenesisKey.assert(failure)) {
+          return new errors.UnknownGenesisKey.Error(failure)
+        } else if (errors.AlreadyDelegating.assert(failure)) {
+          return new errors.AlreadyDelegating.Error(failure)
+        } else if (errors.InsufficientFundsForMir.assert(failure)) {
+          return new errors.InsufficientFundsForMir.Error(failure)
+        } else if (errors.TooLateForMir.assert(failure)) {
+          return new errors.TooLateForMir.Error(failure)
+        } else if (errors.MirTransferNotCurrentlyAllowed.assert(failure)) {
+          return new errors.MirTransferNotCurrentlyAllowed.Error(failure)
+        } else if (errors.MirNegativeTransferNotCurrentlyAllowed.assert(failure)) {
+          return new errors.MirNegativeTransferNotCurrentlyAllowed.Error(failure)
+        } else if (errors.MirProducesNegativeUpdate.assert(failure)) {
+          return new errors.MirProducesNegativeUpdate.Error(failure)
+        } else if (errors.DuplicateGenesisVrf.assert(failure)) {
+          return new errors.DuplicateGenesisVrf.Error(failure)
+        } else if (errors.NonGenesisVoters.assert(failure)) {
+          return new errors.NonGenesisVoters.Error(failure)
+        } else if (errors.UpdateWrongEpoch.assert(failure)) {
+          return new errors.UpdateWrongEpoch.Error(failure)
+        } else if (errors.ProtocolVersionCannotFollow.assert(failure)) {
+          return new errors.ProtocolVersionCannotFollow.Error(failure)
+        } else if (errors.OutsideOfValidityInterval.assert(failure)) {
+          return new errors.OutsideOfValidityInterval.Error(failure)
+        } else if (errors.TriesToForgeAda.assert(failure)) {
+          return new errors.TriesToForgeAda.Error(failure)
+        } else if (errors.TooManyAssetsInOutput.assert(failure)) {
+          return new errors.TooManyAssetsInOutput.Error(failure)
+        } else if (errors.MissingRequiredRedeemers.assert(failure)) {
+          return new errors.MissingRequiredRedeemers.Error(failure)
+        } else if (errors.ExtraDataMismatch.assert(failure)) {
+          return new errors.ExtraDataMismatch.Error(failure)
+        } else if (errors.MissingRequiredSignatures.assert(failure)) {
+          return new errors.MissingRequiredSignatures.Error(failure)
+        } else if (errors.MissingDatumHashesForInputs.assert(failure)) {
+          return new errors.MissingDatumHashesForInputs.Error(failure)
+        } else if (errors.MissingCollateralInputs.assert(failure)) {
+          return new errors.MissingCollateralInputs.Error(failure)
+        } else if (errors.CollateralTooSmall.assert(failure)) {
+          return new errors.CollateralTooSmall.Error(failure)
+        } else if (errors.CollateralIsScript.assert(failure)) {
+          return new errors.CollateralIsScript.Error(failure)
+        } else if (errors.CollateralHasNonAdaAssets.assert(failure)) {
+          return new errors.CollateralHasNonAdaAssets.Error(failure)
+        } else if (errors.TooManyCollateralInputs.assert(failure)) {
+          return new errors.TooManyCollateralInputs.Error(failure)
+        } else if (errors.ExecutionUnitsTooLarge.assert(failure)) {
+          return new errors.ExecutionUnitsTooLarge.Error(failure)
+        } else if (errors.OutsideForecast.assert(failure)) {
+          return new errors.OutsideForecast.Error(failure)
+        } else if (errors.ValidationTagMismatch.assert(failure)) {
+          return new errors.ValidationTagMismatch.Error(failure)
+        } else if (errors.CollectErrors.assert(failure)) {
+          return new errors.CollectErrors.Error(failure)
+        } else if (errors.PoolMetadataHashTooBig.assert(failure)) {
+          return new errors.PoolMetadataHashTooBig.Error(failure)
+        } else if (errors.MissingRequiredDatums.assert(failure)) {
+          return new errors.MissingRequiredDatums.Error(failure)
+        } else if (errors.UnspendableDatums.assert(failure)) {
+          return new errors.UnspendableDatums.Error(failure)
+        } else if (errors.UnspendableScriptInputs.assert(failure)) {
+          return new errors.UnspendableScriptInputs.Error(failure)
+        } else if (errors.ExtraRedeemers.assert(failure)) {
+          return new errors.ExtraRedeemers.Error(failure)
+        } else if (errors.ExtraScriptWitnesses.assert(failure)) {
+          return new errors.ExtraScriptWitnesses.Error(failure)
+        } else {
+          return new Error(failure)
+        }
+      })
+    }
+  } else {
+    return [new UnknownResultError(response)]
+  }
+}

--- a/clients/TypeScript/packages/client/test/TxSubmission/TxSubmission.test.ts
+++ b/clients/TypeScript/packages/client/test/TxSubmission/TxSubmission.test.ts
@@ -1,5 +1,5 @@
 import { TxIn, TxOut, Utxo } from '@cardano-ogmios/schema'
-import { InteractionContext, TxSubmission, UnknownResultError } from '../../src'
+import { createTxSubmissionClient, InteractionContext, TxSubmission, UnknownResultError } from '../../src'
 import { dummyInteractionContext } from '../util'
 
 describe('TxSubmission', () => {
@@ -30,18 +30,50 @@ describe('TxSubmission', () => {
     beforeAll(async () => { context = await dummyInteractionContext() })
     afterAll(() => context.socket.close())
 
-    it('rejects with an array of named errors', async () => {
+    const someTransaction =
+      '83a40081825820e1e86da6446c7f81da8d5e440bb0d4eed0f1530ba15bf77e49c33d' +
+      '6f050d8fb500018182581d60ff7b4521589238cfb9c26870edfa782541e615444744' +
+      '22d849ceb1031a001954ce021a000297d9031a05f5e100a10081825820cf14d1c834' +
+      'cecab8e1f5447bde551946804057332825e26e64ee43079dd408355840247c5e6092' +
+      '1130fa1df800d310f39788f4ae04837534ade6727875dbb87218f5b45e96ccd125a1' +
+      '4c4510e81694e7aad3ba8a24458aaf6b6f9c4f1a4801beba05f6'
+
+    // NOTE:
+    //
+    // Used this one to test https://github.com/CardanoSolutions/ogmios/issues/197
+    // The issue was only reproducible is the server took long-enough to submit transactions, so to test
+    // this, I've used an altered version of the server with an artificial delay added to the submission.
+    //
+    // Without this altered server, this test is relatively pointless, hence 'xit'.
+    xit('many transactions', async () => {
+      const client = await createTxSubmissionClient(context)
+      const requests = []
+      for (let i = 0; i < 20; i += 1) {
+        requests.push(client.submitTx(someTransaction).catch((e) => e))
+      }
+      await Promise.all(requests)
+    })
+
+    it('rejects with an array of named errors (submitTx)', async () => {
       try {
-        await TxSubmission.submitTx(
-          context,
-          ('83a40081825820e1e86da6446c7f81da8d5e440bb0d4eed0f1530ba15bf77e49c33d' +
-           '6f050d8fb500018182581d60ff7b4521589238cfb9c26870edfa782541e615444744' +
-           '22d849ceb1031a001954ce021a000297d9031a05f5e100a10081825820cf14d1c834' +
-           'cecab8e1f5447bde551946804057332825e26e64ee43079dd408355840247c5e6092' +
-           '1130fa1df800d310f39788f4ae04837534ade6727875dbb87218f5b45e96ccd125a1' +
-           '4c4510e81694e7aad3ba8a24458aaf6b6f9c4f1a4801beba05f6'
-          )
-        )
+        await TxSubmission.submitTx(context, someTransaction)
+      } catch (error) {
+        await expect(error).toHaveLength(2)
+        // NOTE: We can't predict in which order will the server return the errors.
+        try {
+          await expect(error[0]).toBeInstanceOf(TxSubmission.submissionErrors.errors.BadInputs.Error)
+          await expect(error[1]).toBeInstanceOf(TxSubmission.submissionErrors.errors.ValueNotConserved.Error)
+        } catch (e) {
+          await expect(error[1]).toBeInstanceOf(TxSubmission.submissionErrors.errors.BadInputs.Error)
+          await expect(error[0]).toBeInstanceOf(TxSubmission.submissionErrors.errors.ValueNotConserved.Error)
+        }
+      }
+    })
+
+    it('rejects with an array of named errors (TxSubmissionClient)', async () => {
+      const client = await createTxSubmissionClient(context)
+      try {
+        await client.submitTx(someTransaction)
       } catch (error) {
         await expect(error).toHaveLength(2)
         // NOTE: We can't predict in which order will the server return the errors.
@@ -55,6 +87,7 @@ describe('TxSubmission', () => {
       }
     })
   })
+
   describe('evaluateTx', () => {
     let context: InteractionContext
     beforeAll(async () => { context = await dummyInteractionContext() })

--- a/clients/TypeScript/packages/client/test/TxSubmission/TxSubmission.test.ts
+++ b/clients/TypeScript/packages/client/test/TxSubmission/TxSubmission.test.ts
@@ -30,61 +30,50 @@ describe('TxSubmission', () => {
     beforeAll(async () => { context = await dummyInteractionContext() })
     afterAll(() => context.socket.close())
 
-    const someTransaction =
-      '83a40081825820e1e86da6446c7f81da8d5e440bb0d4eed0f1530ba15bf77e49c33d' +
-      '6f050d8fb500018182581d60ff7b4521589238cfb9c26870edfa782541e615444744' +
-      '22d849ceb1031a001954ce021a000297d9031a05f5e100a10081825820cf14d1c834' +
-      'cecab8e1f5447bde551946804057332825e26e64ee43079dd408355840247c5e6092' +
-      '1130fa1df800d310f39788f4ae04837534ade6727875dbb87218f5b45e96ccd125a1' +
-      '4c4510e81694e7aad3ba8a24458aaf6b6f9c4f1a4801beba05f6'
-
-    // NOTE:
-    //
-    // Used this one to test https://github.com/CardanoSolutions/ogmios/issues/197
-    // The issue was only reproducible is the server took long-enough to submit transactions, so to test
-    // this, I've used an altered version of the server with an artificial delay added to the submission.
-    //
-    // Without this altered server, this test is relatively pointless, hence 'xit'.
-    xit('many transactions', async () => {
-      const client = await createTxSubmissionClient(context)
-      const requests = []
-      for (let i = 0; i < 20; i += 1) {
-        requests.push(client.submitTx(someTransaction).catch((e) => e))
+    const methods = [
+      async (payload: string) => await TxSubmission.submitTx(context, payload),
+      async (payload: string) => {
+        const client = await createTxSubmissionClient(context)
+        return await client.submitTx(payload)
       }
-      await Promise.all(requests)
-    })
+    ]
 
-    it('rejects with an array of named errors (submitTx)', async () => {
-      try {
-        await TxSubmission.submitTx(context, someTransaction)
-      } catch (error) {
-        await expect(error).toHaveLength(2)
-        // NOTE: We can't predict in which order will the server return the errors.
+    methods.forEach(submit => {
+      it('rejects with an array of named errors (submitTx)', async () => {
         try {
-          await expect(error[0]).toBeInstanceOf(TxSubmission.submissionErrors.errors.BadInputs.Error)
-          await expect(error[1]).toBeInstanceOf(TxSubmission.submissionErrors.errors.ValueNotConserved.Error)
-        } catch (e) {
-          await expect(error[1]).toBeInstanceOf(TxSubmission.submissionErrors.errors.BadInputs.Error)
-          await expect(error[0]).toBeInstanceOf(TxSubmission.submissionErrors.errors.ValueNotConserved.Error)
-        }
-      }
-    })
+          const someTransaction =
+            '83a40081825820e1e86da6446c7f81da8d5e440bb0d4eed0f1530ba15bf77e49c33d' +
+            '6f050d8fb500018182581d60ff7b4521589238cfb9c26870edfa782541e615444744' +
+            '22d849ceb1031a001954ce021a000297d9031a05f5e100a10081825820cf14d1c834' +
+            'cecab8e1f5447bde551946804057332825e26e64ee43079dd408355840247c5e6092' +
+            '1130fa1df800d310f39788f4ae04837534ade6727875dbb87218f5b45e96ccd125a1' +
+            '4c4510e81694e7aad3ba8a24458aaf6b6f9c4f1a4801beba05f6'
 
-    it('rejects with an array of named errors (TxSubmissionClient)', async () => {
-      const client = await createTxSubmissionClient(context)
-      try {
-        await client.submitTx(someTransaction)
-      } catch (error) {
-        await expect(error).toHaveLength(2)
-        // NOTE: We can't predict in which order will the server return the errors.
-        try {
-          await expect(error[0]).toBeInstanceOf(TxSubmission.submissionErrors.errors.BadInputs.Error)
-          await expect(error[1]).toBeInstanceOf(TxSubmission.submissionErrors.errors.ValueNotConserved.Error)
-        } catch (e) {
-          await expect(error[1]).toBeInstanceOf(TxSubmission.submissionErrors.errors.BadInputs.Error)
-          await expect(error[0]).toBeInstanceOf(TxSubmission.submissionErrors.errors.ValueNotConserved.Error)
+          await submit(someTransaction)
+        } catch (errors) {
+          await expect(errors).toHaveLength(2)
+          // NOTE: We can't predict in which order will the server return the errors.
+          try {
+            await expect(errors[0]).toBeInstanceOf(TxSubmission.submissionErrors.errors.BadInputs.Error)
+            await expect(errors[1]).toBeInstanceOf(TxSubmission.submissionErrors.errors.ValueNotConserved.Error)
+          } catch (e) {
+            await expect(errors[1]).toBeInstanceOf(TxSubmission.submissionErrors.errors.BadInputs.Error)
+            await expect(errors[0]).toBeInstanceOf(TxSubmission.submissionErrors.errors.ValueNotConserved.Error)
+          }
         }
-      }
+      })
+
+      it('fails (client fault) to submit on ill-formed tx', async () => {
+        try {
+          await submit(
+            ('80'
+            )
+          )
+        } catch (errors) {
+          expect(errors).toHaveLength(1)
+          expect(errors[0]).toBeInstanceOf(UnknownResultError)
+        }
+      })
     })
   })
 
@@ -93,116 +82,122 @@ describe('TxSubmission', () => {
     beforeAll(async () => { context = await dummyInteractionContext() })
     afterAll(() => context.socket.close())
 
-    it('successfully evaluates execution units of well-formed tx', async () => {
-      const result = await TxSubmission.evaluateTx(
-        context,
-        ('84A6008282582078E963207A3FA50F5DB363439A246D9C5631D398C7B7397435B6EC1' +
-         '33432A647018258207D67D80BC5B3BADCAF02375E428A39AEA398DD0438F26899A1B2' +
-         '65C6AC87EB6B000D81825820DB7DBF9EAA6094982ED4B9B735CE275345F348194A7E8' +
-         'E9200FEC7D1CAD008EB010181825839004A294F1EF53B30CDBF7CAF17798422A90227' +
-         '224F9FBF037FCF6C47A5BC2EC1952D1189886FE018214EED45F83AB04171C41F373D5' +
-         '30CA7A61A3BB94E8002000E800B58206DF8859EC92C3FF6BC0E2964793789E44E4C5A' +
-         'BBCC9FF6F2387B94F4C2020E6EA303814E4D010000332222200512001200110481800' +
-         '581840000182A820000F5F6'
+    const methods = [
+      async (payload: string, additionalUtxoSet?: Utxo) => await TxSubmission.evaluateTx(context, payload, additionalUtxoSet),
+      async (payload: string, additionalUtxoSet?: Utxo) => {
+        const client = await createTxSubmissionClient(context)
+        return await client.evaluateTx(payload, additionalUtxoSet)
+      }
+    ]
+
+    methods.forEach(evaluate => {
+      it('successfully evaluates execution units of well-formed tx', async () => {
+        const result = await evaluate(
+          ('84A6008282582078E963207A3FA50F5DB363439A246D9C5631D398C7B7397435B6EC1' +
+           '33432A647018258207D67D80BC5B3BADCAF02375E428A39AEA398DD0438F26899A1B2' +
+           '65C6AC87EB6B000D81825820DB7DBF9EAA6094982ED4B9B735CE275345F348194A7E8' +
+           'E9200FEC7D1CAD008EB010181825839004A294F1EF53B30CDBF7CAF17798422A90227' +
+           '224F9FBF037FCF6C47A5BC2EC1952D1189886FE018214EED45F83AB04171C41F373D5' +
+           '30CA7A61A3BB94E8002000E800B58206DF8859EC92C3FF6BC0E2964793789E44E4C5A' +
+           'BBCC9FF6F2387B94F4C2020E6EA303814E4D010000332222200512001200110481800' +
+           '581840000182A820000F5F6'
+          )
         )
-      )
-      expect(result).toEqual({
-        'spend:0': {
-          memory: 1700,
-          steps: 476468
+        expect(result).toEqual({
+          'spend:0': {
+            memory: 1700,
+            steps: 476468
+          }
+        })
+      })
+
+      it('fails to evaluate execution units when tx contains unknown inputs', async () => {
+        try {
+          await evaluate(
+            ('84a6008182582097b2af6dfc6a4825e934146f424cdd6ede43ff98c355' +
+             'd2ae3aa95b0f70b63949030d800182825839004a294f1ef53b30cdbf7c' +
+             'af17798422a90227224f9fbf037fcf6c47a5bc2ec1952d1189886fe018' +
+             '214eed45f83ab04171c41f373d530ca7a61a3b79acf783581d7067f331' +
+             '46617a5e61936081db3b2117cbf59bd2123748f58ac96786561a001e84' +
+             '80582045b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f' +
+             '9c0ab0e4c1c0021a000298890e800b582028aaa7a1cdf12d0070820ab5' +
+             'f5d8f1acba787535fed0729e4d11fbb3b068d17ea200818258209c3b28' +
+             '86f7b196ee20ce39c46abda9a76278534678b3e74288055f8b73f8ba3a' +
+             '58409ab3692df6560be6e4d831f69c6c6762b8892f905a37434b9b8aba' +
+             '6b355b761a12ea26289c9be6467fbd4a3a45c30131dc00ac836ecb1224' +
+             'b7e50d79d2e9c80c048180f5f6'
+            )
+          )
+        } catch (errors) {
+          expect(errors).toHaveLength(1)
+          expect(errors[0]).toBeInstanceOf(TxSubmission.evaluationErrors.errors.UnknownInputs.Error)
         }
       })
-    })
 
-    it('fails to evaluate execution units when tx contains unknown inputs', async () => {
-      try {
-        await TxSubmission.evaluateTx(
-          context,
-          ('84a6008182582097b2af6dfc6a4825e934146f424cdd6ede43ff98c355' +
-           'd2ae3aa95b0f70b63949030d800182825839004a294f1ef53b30cdbf7c' +
-           'af17798422a90227224f9fbf037fcf6c47a5bc2ec1952d1189886fe018' +
-           '214eed45f83ab04171c41f373d530ca7a61a3b79acf783581d7067f331' +
-           '46617a5e61936081db3b2117cbf59bd2123748f58ac96786561a001e84' +
-           '80582045b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f' +
-           '9c0ab0e4c1c0021a000298890e800b582028aaa7a1cdf12d0070820ab5' +
-           'f5d8f1acba787535fed0729e4d11fbb3b068d17ea200818258209c3b28' +
-           '86f7b196ee20ce39c46abda9a76278534678b3e74288055f8b73f8ba3a' +
-           '58409ab3692df6560be6e4d831f69c6c6762b8892f905a37434b9b8aba' +
-           '6b355b761a12ea26289c9be6467fbd4a3a45c30131dc00ac836ecb1224' +
-           'b7e50d79d2e9c80c048180f5f6'
-          )
+      it('successfully evaluate execution units when unknown inputs are provided as additional utxo', async () => {
+        const additionalUtxoSet = [
+          [{
+            txId: '97b2af6dfc6a4825e934146f424cdd6ede43ff98c355d2ae3aa95b0f70b63949',
+            index: 3
+          } as TxIn,
+           {
+             address: 'addr_test1qp9zjnc775anpndl0jh3w7vyy25syfezf70m7qmleaky0fdu9mqe2tg33xyxlcqcy98w630c82cyzuwyrumn65cv57nqwxm2yd',
+             value: { coins: BigInt(10000000) }
+           } as TxOut
+          ]
+        ] as Utxo
+
+        const result = await evaluate(
+          ('84A6008282582078E963207A3FA50F5DB363439A246D9C5631D398C7B7397435B6EC1' +
+           '33432A647018258207D67D80BC5B3BADCAF02375E428A39AEA398DD0438F26899A1B2' +
+           '65C6AC87EB6B000D81825820DB7DBF9EAA6094982ED4B9B735CE275345F348194A7E8' +
+           'E9200FEC7D1CAD008EB010181825839004A294F1EF53B30CDBF7CAF17798422A90227' +
+           '224F9FBF037FCF6C47A5BC2EC1952D1189886FE018214EED45F83AB04171C41F373D5' +
+           '30CA7A61A3BB94E8002000E800B58206DF8859EC92C3FF6BC0E2964793789E44E4C5A' +
+           'BBCC9FF6F2387B94F4C2020E6EA303814E4D010000332222200512001200110481800' +
+           '581840000182A820000F5F6'
+          ),
+          additionalUtxoSet
         )
-      } catch (error) {
-        expect(error).toHaveLength(1)
-        expect(error[0]).toBeInstanceOf(TxSubmission.evaluationErrors.errors.UnknownInputs.Error)
-      }
-    })
+        expect(result).toEqual({
+          'spend:0': {
+            memory: 1700,
+            steps: 476468
+          }
+        })
+      })
 
-    it('successfully evaluate execution units when unknown inputs are provided as additional utxo', async () => {
-      const additionalUtxoSet = [
-        [{
-          txId: '97b2af6dfc6a4825e934146f424cdd6ede43ff98c355d2ae3aa95b0f70b63949',
-          index: 3
-        } as TxIn,
-         {
-           address: 'addr_test1qp9zjnc775anpndl0jh3w7vyy25syfezf70m7qmleaky0fdu9mqe2tg33xyxlcqcy98w630c82cyzuwyrumn65cv57nqwxm2yd',
-           value: { coins: BigInt(10000000) }
-         } as TxOut
-        ]
-      ] as Utxo
-
-      const result = await TxSubmission.evaluateTx(
-        context,
-        ('84A6008282582078E963207A3FA50F5DB363439A246D9C5631D398C7B7397435B6EC1' +
-         '33432A647018258207D67D80BC5B3BADCAF02375E428A39AEA398DD0438F26899A1B2' +
-         '65C6AC87EB6B000D81825820DB7DBF9EAA6094982ED4B9B735CE275345F348194A7E8' +
-         'E9200FEC7D1CAD008EB010181825839004A294F1EF53B30CDBF7CAF17798422A90227' +
-         '224F9FBF037FCF6C47A5BC2EC1952D1189886FE018214EED45F83AB04171C41F373D5' +
-         '30CA7A61A3BB94E8002000E800B58206DF8859EC92C3FF6BC0E2964793789E44E4C5A' +
-         'BBCC9FF6F2387B94F4C2020E6EA303814E4D010000332222200512001200110481800' +
-         '581840000182A820000F5F6'
-        ),
-        additionalUtxoSet
-      )
-      expect(result).toEqual({
-        'spend:0': {
-          memory: 1700,
-          steps: 476468
+      it('fails to evaluate execution units of non-Alonzo tx', async () => {
+        try {
+          await evaluate(
+            ('83a4008182582039786f186d94d8dd0b4fcf05d1458b18cd5fd8c68233' +
+              '64612f4a3c11b77e7cc700018282581d60f8a68cd18e59a6ace848155a' +
+              '0e967af64f4d00cf8acee8adc95a6b0d1a05f5e10082581d60f8a68cd1' +
+              '8e59a6ace848155a0e967af64f4d00cf8acee8adc95a6b0d1b000000d1' +
+              '8635a3cf021a0002a331031878a10081825820eb94e8236e2099357fa4' +
+              '99bfbc415968691573f25ec77435b7949f5fdfaa5da05840c8c0c016b7' +
+              '14adb318a9495849c8ec647bc9742ef2b4cd03b9bc8694b65a42dbe3a2' +
+              '275ebcfe482c246fc8fbc34aa8dcebf18a4c3836b3ce8473e990d61c15' +
+              '06f6'
+            )
+          )
+        } catch (errors) {
+          expect(errors).toHaveLength(1)
+          expect(errors[0]).toBeInstanceOf(TxSubmission.evaluationErrors.errors.IncompatibleEra.Error)
         }
       })
-    })
 
-    it('fails to evaluate execution units of non-Alonzo tx', async () => {
-      try {
-        await TxSubmission.evaluateTx(
-          context,
-          ('83a4008182582039786f186d94d8dd0b4fcf05d1458b18cd5fd8c68233' +
-            '64612f4a3c11b77e7cc700018282581d60f8a68cd18e59a6ace848155a' +
-            '0e967af64f4d00cf8acee8adc95a6b0d1a05f5e10082581d60f8a68cd1' +
-            '8e59a6ace848155a0e967af64f4d00cf8acee8adc95a6b0d1b000000d1' +
-            '8635a3cf021a0002a331031878a10081825820eb94e8236e2099357fa4' +
-            '99bfbc415968691573f25ec77435b7949f5fdfaa5da05840c8c0c016b7' +
-            '14adb318a9495849c8ec647bc9742ef2b4cd03b9bc8694b65a42dbe3a2' +
-            '275ebcfe482c246fc8fbc34aa8dcebf18a4c3836b3ce8473e990d61c15' +
-            '06f6'
+      it('fails (client fault) to evaluate execution units on ill-formed tx', async () => {
+        try {
+          await evaluate(
+            ('80'
+            )
           )
-        )
-      } catch (error) {
-        expect(error).toHaveLength(1)
-        expect(error[0]).toBeInstanceOf(TxSubmission.evaluationErrors.errors.IncompatibleEra.Error)
-      }
-    })
-
-    it('fails (client fault) to evaluate execution units on ill-formed tx', async () => {
-      try {
-        await TxSubmission.evaluateTx(
-          context,
-          ('80'
-          )
-        )
-      } catch (error) {
-        expect(error).toBeInstanceOf(UnknownResultError)
-      }
+        } catch (errors) {
+          expect(errors).toHaveLength(1)
+          expect(errors[0]).toBeInstanceOf(UnknownResultError)
+        }
+      })
     })
   })
 })

--- a/clients/TypeScript/packages/client/test/util.test.ts
+++ b/clients/TypeScript/packages/client/test/util.test.ts
@@ -4,9 +4,29 @@ import {
   Metadata,
   TxOut
 } from '@cardano-ogmios/schema'
-import { safeJSON } from '../src'
+import { EventEmitter } from 'events'
+import { safeJSON, eventEmitterToGenerator } from '../src'
 
 describe('util', () => {
+  describe('eventToGenerator', () => {
+    it('can yield immediate and deferred matched events', async () => {
+      const eventEmitter = new EventEmitter()
+      const matchOdd = (x: string) => Number(x) % 2 !== 0 ? Number(x) : null
+      const generator = eventEmitterToGenerator(eventEmitter, 'myEvent', matchOdd)() as AsyncGenerator<number>
+
+      eventEmitter.emit('myEvent', 1)
+      eventEmitter.emit('myEvent', 2)
+      eventEmitter.emit('myEvent', 3)
+      setTimeout(() => eventEmitter.emit('myEvent', 4), 50)
+      setTimeout(() => eventEmitter.emit('myEvent', 5), 100)
+      setTimeout(() => eventEmitter.emit('myEvent', 6), 150)
+
+      expect((await generator.next()).value).toEqual(1)
+      expect((await generator.next()).value).toEqual(3)
+      expect((await generator.next()).value).toEqual(5)
+    })
+  })
+
   describe('safeJSON', () => {
     it('parse asset quantities as bigint, always', () => {
       const json = `

--- a/clients/TypeScript/yarn.lock
+++ b/clients/TypeScript/yarn.lock
@@ -683,6 +683,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/events@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
+  integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
+
 "@types/expect-puppeteer@^4.4.5":
   version "4.4.7"
   resolved "https://registry.yarnpkg.com/@types/expect-puppeteer/-/expect-puppeteer-4.4.7.tgz#fc5651b3a982dad7ddf8db1c5ac3b7b15db2b79a"


### PR DESCRIPTION
Fix #197 

---

- :round_pushpin: **Add TypeScript util to convert an event emitter into an asynchronous generator.**
    In cases where (a) we expect only one event in response to some other effect and (b) events to come in the same order as the requests, then it becomes useful to simply treat some event source as a stream of values yielded by a generator. Not only it is useful, but it allows to make the consuming code relatively simple as we can now fire some event and wait synchronously on the response.

- :round_pushpin: **Rework submitTx to use the new util for waiting on server responses.**
    Now, we only need to have a single event listener for the whole submission client. Many requests can be fired asynchronously and handled in due time; behind the scene the server still process them one at the time though.

- :round_pushpin: **Test both submitTx and the submission client in the TypeScript specs.**
  
- :round_pushpin: **Also rework evaluateTx to avoid setting handlers on each call.**
  
- :round_pushpin: **Test both evaluateTx standalone and through the TxSubmissionClient.**
  
- :round_pushpin: **Update yarn.lock**
