### PR TITLE
chore: remove unused cardano-configurations submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "modules/hjsonschema"]
 	path = server/modules/hjsonschema
 	url = https://github.com/KtorZ/hjsonschema.git
-[submodule "server/config"]
-	path = server/config
-	url = https://github.com/input-output-hk/cardano-configurations.git
 [submodule "clients/Go"]
 	path = clients/Go
 	url = https://github.com/savaki/ogmigo.git


### PR DESCRIPTION
This was previously used to load configuration into the `cardano-node-ogmios`
Docker image, but the config is now being [cloned as part of the build definition.](https://github.com/CardanoSolutions/ogmios/blob/8b08ce856c5dda12f7918cd21718a8da5fc4904f/Dockerfile#L15)