### PR TITLE
fix: cardano-node version in Docker and CI

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -185,7 +185,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         network: [testnet]
-        cardanoNodeVersion: [1.35.0-rc1]
+        cardanoNodeVersion: [1.35.0-rc3]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ ENTRYPOINT ["/bin/ogmios"]
 # --------------------- RUN (cardano-node & ogmios) -------------------------- #
 #                                                                              #
 
-FROM inputoutput/cardano-node:1.35.0-rc1 as cardano-node-ogmios
+FROM inputoutput/cardano-node:1.35.0-rc3 as cardano-node-ogmios
 
 ARG NETWORK=mainnet
 ENV TINI_VERSION v0.19.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:1.35.0-rc1
+    image: inputoutput/cardano-node:1.35.0-rc3
     command: [
       "run",
       "--config", "/config/config.json",


### PR DESCRIPTION
The `cardano-node` version bump was missed in a few places