### PR TITLE
Update protocol parameter helpers in TypeScript client

### DIFF
--- a/clients/TypeScript/packages/client/src/util.ts
+++ b/clients/TypeScript/packages/client/src/util.ts
@@ -11,6 +11,7 @@ import {
   EpochBoundaryBlock,
   Point,
   ProtocolParametersAlonzo,
+  ProtocolParametersBabbage,
   ProtocolParametersShelley,
   StandardBlock
 } from '@cardano-ogmios/schema'
@@ -159,9 +160,19 @@ export const isEmptyObject = (obj: Object): boolean =>
   obj !== undefined && Object.keys(obj).length === 0 && (obj.constructor === Object || obj.constructor === undefined)
 
 /** @category Helper */
-export const isAlonzoProtocolParameters = (params: ProtocolParametersShelley | ProtocolParametersAlonzo): params is ProtocolParametersAlonzo =>
+export const isShelleyProtocolParameters = (
+  params: ProtocolParametersShelley | ProtocolParametersAlonzo | ProtocolParametersBabbage
+): params is ProtocolParametersShelley =>
+  (params as ProtocolParametersShelley).minUtxoValue !== undefined
+
+/** @category Helper */
+export const isAlonzoProtocolParameters = (
+  params: ProtocolParametersShelley | ProtocolParametersAlonzo | ProtocolParametersBabbage
+): params is ProtocolParametersAlonzo =>
   (params as ProtocolParametersAlonzo).coinsPerUtxoWord !== undefined
 
 /** @category Helper */
-export const isShelleyProtocolParameters = (params: ProtocolParametersShelley | ProtocolParametersAlonzo): params is ProtocolParametersShelley =>
-  (params as ProtocolParametersShelley).minUtxoValue !== undefined
+export const isBabbageProtocolParameters = (
+  params: ProtocolParametersShelley | ProtocolParametersAlonzo | ProtocolParametersBabbage
+): params is ProtocolParametersBabbage =>
+  (params as ProtocolParametersBabbage).coinsPerUtxoByte !== undefined


### PR DESCRIPTION
The helpers to determine what era the protocol parameters belong to were "out-dated".
1. Existing ones (`isShelleyProtocolParameters` and `isAlonzoProtocolParameters`) were hard-to-use, as they didn't accept the new `ProtocolParametersBabbage` type
2. And the function `isBabbageProtocolParameters` was missing.

This PR should fix both of these issues.