### PR TITLE
Remove superfluous string concatenation in TS client UnknownResultError

### DIFF
--- a/clients/TypeScript/packages/client/src/errors/UnknownResultError.ts
+++ b/clients/TypeScript/packages/client/src/errors/UnknownResultError.ts
@@ -10,6 +10,6 @@ import { safeJSON } from '../util'
 export class UnknownResultError extends CustomError {
   public constructor (result: object | string) {
     super()
-    this.message = `${safeJSON.stringify(result)} is an unknown result`
+    this.message = safeJSON.stringify(result)
   }
 }


### PR DESCRIPTION
Submitting an invalidly encoded tx payload throws this error, which currently requires string manipulation prior to JSON parsing.

```
{"type":"jsonwsp/fault","version":"1.0","servicename":"ogmios","fault":{"code":"client","string":"Invalid request: failed to decode payload from base64 or base16."},"reflection":null} is an unknown result
```

The concatenated description is superfluous given the error name already sets the context 