### PR TITLE
chore: bump cardano-node

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -185,7 +185,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         network: [testnet]
-        cardanoNodeVersion: [1.35.1]
+        cardanoNodeVersion: [1.35.2]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ ENTRYPOINT ["/bin/ogmios"]
 # --------------------- RUN (cardano-node & ogmios) -------------------------- #
 #                                                                              #
 
-FROM inputoutput/cardano-node:1.35.1 as cardano-node-ogmios
+FROM inputoutput/cardano-node:1.35.2 as cardano-node-ogmios
 
 ARG NETWORK=mainnet
 ENV TINI_VERSION v0.19.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:1.35.1
+    image: inputoutput/cardano-node:1.35.2
     command: [
       "run",
       "--config", "/config/config.json",


### PR DESCRIPTION
This PR updates the `cardano-node-ogmios` Dockerfile target, TypeScript client CI, and dev Docker Compose config to the minimum version of `cardano-node` suitable for running in the Babbage era. It should only be merged once the release is **published**.

https://github.com/input-output-hk/cardano-node/tree/1.35.2

_It would be ideal to make a point release of Ogmios afterwards to allow consumers, depending on the git repository as a submodule, the ability to build without switching to an unusual reference such as the master branch or pinning a specific commit._