### PR TITLE
 Health over Prometheus metrics

### DIFF
--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -39,6 +39,7 @@ library
       Ogmios.App.Configuration
       Ogmios.App.Health
       Ogmios.App.Metrics
+      Ogmios.App.Metrics.Prometheus
       Ogmios.App.Protocol
       Ogmios.App.Protocol.ChainSync
       Ogmios.App.Protocol.StateQuery
@@ -174,6 +175,7 @@ library
     , plutus-ledger-api
     , prettyprinter
     , profunctors
+    , prometheus
     , relude
     , safe
     , safe-exceptions

--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.6.
 --
 -- see: https://github.com/sol/hpack
 
@@ -78,6 +78,8 @@ library
       Ogmios.Prelude
       Ogmios.Version
   other-modules:
+      Paths_ogmios
+  autogen-modules:
       Paths_ogmios
   hs-source-dirs:
       src
@@ -206,6 +208,8 @@ executable ogmios
   main-is: Main.hs
   other-modules:
       Paths_ogmios
+  autogen-modules:
+      Paths_ogmios
   hs-source-dirs:
       app
   default-extensions:
@@ -268,6 +272,8 @@ test-suite unit
       Test.Generators.Orphans
       Test.Instances.Util
       Test.Path.Util
+      Paths_ogmios
+  autogen-modules:
       Paths_ogmios
   hs-source-dirs:
       test/unit

--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -39,7 +39,6 @@ library
       Ogmios.App.Configuration
       Ogmios.App.Health
       Ogmios.App.Metrics
-      Ogmios.App.Metrics.Prometheus
       Ogmios.App.Protocol
       Ogmios.App.Protocol.ChainSync
       Ogmios.App.Protocol.StateQuery
@@ -69,6 +68,7 @@ library
       Ogmios.Data.Json.Query
       Ogmios.Data.Json.Shelley
       Ogmios.Data.Metrics
+      Ogmios.Data.Metrics.Prometheus
       Ogmios.Data.Protocol
       Ogmios.Data.Protocol.ChainSync
       Ogmios.Data.Protocol.StateQuery

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -90,6 +90,7 @@ library:
     - plutus-ledger-api
     - prettyprinter
     - profunctors
+    - prometheus
     - relude
     - safe
     - safe-exceptions

--- a/server/src/Ogmios/App/Metrics/Prometheus.hs
+++ b/server/src/Ogmios/App/Metrics/Prometheus.hs
@@ -1,0 +1,81 @@
+--  This Source Code Form is subject to the terms of the Mozilla Public
+--  License, v. 2.0. If a copy of the MPL was not distributed with this
+--  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+{-# LANGUAGE RecordWildCards #-}
+
+module Ogmios.App.Metrics.Prometheus where
+
+import Ogmios.Prelude
+
+import Ogmios.App.Metrics
+    ( RuntimeStats(..), Metrics(..) )
+import Ogmios.Data.Health
+    ( ConnectionStatus (..), Health (..), Tip (..), SlotInEpoch (..), NetworkSynchronization (..), EpochNo (..) )
+
+import qualified Ogmios.Data.Metrics as Metrics
+
+import Cardano.Slotting.Block (BlockNo(..))
+import Cardano.Slotting.Slot (SlotNo(..))
+
+import Data.ByteString.Builder (Builder)
+
+import System.Metrics.Prometheus.Metric (MetricSample(..))
+import System.Metrics.Prometheus.Metric.Counter (CounterSample(..))
+import System.Metrics.Prometheus.Metric.Gauge (GaugeSample(..))
+import System.Metrics.Prometheus.MetricId (Labels(..), MetricId(..), makeName)
+import System.Metrics.Prometheus.Registry (RegistrySample (..))
+import System.Metrics.Prometheus.Encode.Text (encodeMetrics)
+
+import qualified Data.Map
+import qualified Data.Scientific
+
+-- | Convert `Health` status and metrics into
+-- Prometheus format builder
+asPrometheusMetrics :: Health block -> Builder
+asPrometheusMetrics Health{..} =
+  let Metrics{..} = metrics
+      RuntimeStats{..} = runtimeStats
+
+      gaugeSample :: Double -> MetricSample
+      gaugeSample = GaugeMetricSample . GaugeSample
+
+      counterSample :: Int -> MetricSample
+      counterSample = CounterMetricSample . CounterSample
+
+      converted :: [(Text, MetricSample)]
+      converted =
+        [ ("connected", if connectionStatus == Connected then gaugeSample 1 else gaugeSample 0) ]
+        <> (maybe mempty (\(NetworkSynchronization ns) -> pure ("network_synchronization", gaugeSample $ Data.Scientific.toRealFloat ns)) networkSynchronization)
+        <> (maybe mempty (\e -> pure ("current_epoch", counterSample $ fromEnum $ unEpochNo e)) currentEpoch)
+        <> (maybe mempty (\s -> pure ("slot_in_epoch", counterSample $ fromEnum $ getSlotInEpoch s)) slotInEpoch)
+        <>
+        [ -- Metrics
+          ("active_connections", gaugeSample $ fromInteger activeConnections)
+        , ("total_connections", counterSample $ fromInteger totalConnections)
+        , ("total_messages", counterSample $ fromInteger totalMessages)
+        , ("total_unrouted", counterSample $ fromInteger totalUnrouted)
+          -- Runtime stats
+        , ("max_heap_size", gaugeSample $ fromInteger maxHeapSize)
+        , ("current_heap_size", gaugeSample $ fromInteger currentHeapSize)
+        , ("cpu_time", counterSample $ fromInteger cpuTime)
+        , ("gc_cpu_time", counterSample $ fromInteger gcCpuTime)
+          -- Session durations
+        , ("session_duration_mean", gaugeSample $ Metrics.mean sessionDurations)
+        , ("session_duration_mix", gaugeSample $ Metrics.min sessionDurations)
+        , ("session_duration_max", gaugeSample $ Metrics.max sessionDurations)
+        ]
+        ++
+        case lastKnownTip of
+          TipGenesis -> pure ("tip_at_genesis", gaugeSample 1)
+          Tip slot _hash block -> [
+              ("tip_block", counterSample $ fromEnum $ unBlockNo block)
+            , ("tip_slot", counterSample $ fromEnum $ unSlotNo slot)
+            ]
+
+  in encodeMetrics
+   $ RegistrySample
+   $ Data.Map.mapKeys
+      (\k -> (MetricId (makeName $ "ogmios_" <> k) (Labels mempty)))
+   $ Data.Map.fromList
+     converted

--- a/server/src/Ogmios/App/Server/Http.hs
+++ b/server/src/Ogmios/App/Server/Http.hs
@@ -28,9 +28,10 @@ import Ogmios.Control.MonadSTM
     ( MonadSTM (..), TVar )
 import Ogmios.Data.Health
     ( ConnectionStatus (..), Health (..), Tip (..), modifyHealth )
+import Ogmios.Data.Metrics.Prometheus
+    ( mkPrometheusMetrics )
 
 import qualified Ogmios.App.Metrics as Metrics
-import qualified Ogmios.App.Metrics.Prometheus as PrometheusMetrics
 
 import Data.Aeson
     ( ToJSON (..) )
@@ -117,8 +118,9 @@ getHealthR = runHandlerM $ do
 getMetricsR :: Handler Server
 getMetricsR = runHandlerM $ do
     header "Access-Control-Allow-Origin" "*"
+    header "Content-Type" "text/plain; charset=utf-8"
     Server unliftIO EnvServer{health,sensors,sampler} <- sub
-    (rawBuilder . PrometheusMetrics.asPrometheusMetrics) =<< liftIO (unliftIO (do
+    (rawBuilder . mkPrometheusMetrics) =<< liftIO (unliftIO (do
         metrics <- Metrics.sample sampler sensors
         modifyHealth health (\h -> h { metrics })))
 

--- a/server/src/Ogmios/App/Server/Http.hs
+++ b/server/src/Ogmios/App/Server/Http.hs
@@ -19,7 +19,7 @@ module Ogmios.App.Server.Http
 import Ogmios.Prelude
 
 import Ogmios.App.Metrics
-    ( RuntimeStats(..), Sampler, Sensors )
+    ( RuntimeStats (..), Sampler, Sensors )
 import Ogmios.Control.MonadClock
     ( MonadClock )
 import Ogmios.Control.MonadMetrics

--- a/server/src/Ogmios/Data/Metrics/Prometheus.hs
+++ b/server/src/Ogmios/Data/Metrics/Prometheus.hs
@@ -4,7 +4,7 @@
 
 {-# LANGUAGE RecordWildCards #-}
 
-module Ogmios.App.Metrics.Prometheus where
+module Ogmios.Data.Metrics.Prometheus where
 
 import Ogmios.Prelude
 
@@ -42,8 +42,8 @@ import qualified Data.Scientific as Scientific
 import qualified Ogmios.Data.Metrics as Metrics
 
 -- | Convert `Health` status and metrics into Prometheus format builder
-asPrometheusMetrics :: Health block -> Builder
-asPrometheusMetrics Health{..} =
+mkPrometheusMetrics :: Health block -> Builder
+mkPrometheusMetrics Health{..} =
     prometheusMetrics
     & Map.fromList
     & Map.mapKeys (\k -> (MetricId (makeName $ "ogmios_" <> k) (Labels mempty)))


### PR DESCRIPTION
This patch adds `/metrics` route which exports metrics in Prometheus format (using encoding from `prometheus` library).

Sample output:

```bash
$ curl localhost:1337/metrics
# TYPE active_connections gauge
active_connections  0.0
# TYPE connected gauge
connected  1.0
# TYPE cpu_time counter
cpu_time  3841629783
# TYPE current_epoch counter
current_epoch  363
# TYPE current_heap_size gauge
current_heap_size  390.0
# TYPE gc_cpu_time counter
gc_cpu_time  3142668337
# TYPE max_heap_size gauge
max_heap_size  433.0
# TYPE network_synchronization gauge
network_synchronization  0.99999
# TYPE session_duration_max gauge
session_duration_max  0.0
# TYPE session_duration_mean gauge
session_duration_mean  0.0
# TYPE session_duration_mix gauge
session_duration_mix  0.0
# TYPE slot_in_epoch counter
slot_in_epoch  150361
# TYPE tip_block counter
tip_block  7756720
# TYPE tip_slot counter
tip_slot  71603161
# TYPE total_connections counter
total_connections  0
# TYPE total_messages counter
total_messages  0
# TYPE total_unrouted counter
total_unrouted  0
```

Note that connection status of `Connected` is encoded as `connected 1` and `Disconnected` as `connected 0`.

For a special case when tip is at genesis there is a `tip_at_genesis 1` metric reported until tip updates and `tip_block` and `tip_slot` metrics are reported instead.