### PR TITLE
Typescript client: isomorphic websocket browser detection

### DIFF
--- a/clients/TypeScript/packages/client/src/IsomorphicWebSocket.ts
+++ b/clients/TypeScript/packages/client/src/IsomorphicWebSocket.ts
@@ -82,4 +82,4 @@ const browserPolyfill = (target : EventTarget) : IsoWebSocket => {
 /**
  * @Internal
  */
-const isBrowser = typeof process === 'undefined'
+const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined'


### PR DESCRIPTION
`process` gets injected by several tooling applications (e.g. create-react-app). Using it for detection causes the websocket connection to always use the node version. 

The modified version comes from [browser-or-node](https://github.com/flexdinesh/browser-or-node/blob/master/src/index.js) npm package.