### PR TITLE
Fix 'sanitize' to support Value without 'assets'

### DIFF
--- a/clients/TypeScript/packages/client/src/util.ts
+++ b/clients/TypeScript/packages/client/src/util.ts
@@ -33,12 +33,16 @@ export const safeJSON = {
     if (typeof json === 'object' && json !== null) {
       const len = Object.getOwnPropertyNames(json).length
 
-      // AssetQuantity
-      if (len === 2 && json.coins !== undefined && json.assets !== undefined) {
+      // Lovelace & AssetQuantity
+      if (json.coins !== undefined) {
         const coins = json.coins
         json.coins = typeof coins === 'number' ? BigInt(coins) : coins
 
-        return this.sanitizeAdditionalFields(json.assets)
+        if (json.assets !== undefined) {
+          return this.sanitizeAdditionalFields(json.assets)
+        }
+
+        return json
       }
 
       // Transaction

--- a/clients/TypeScript/packages/client/test/util.test.ts
+++ b/clients/TypeScript/packages/client/test/util.test.ts
@@ -238,6 +238,19 @@ describe('util', () => {
         expect(typeof result.pools[poolId].poolParameters.cost).toEqual('bigint')
         expect(typeof result.pools[poolId].poolParameters.pledge).toEqual('bigint')
       })
+
+      it('value without assets', () => {
+        const json = `
+          {
+            "value": {
+              "coins": 42
+            }
+          }
+        `
+
+        const result = safeJSON.parse(json) as Pick<TxOut, 'value'>
+        expect(typeof result.value.coins).toEqual('bigint')
+      })
     })
   })
 })


### PR DESCRIPTION
`Value` without assets comes as `{coins:n}` instead of `{coins:n, assets:{}}` from the server, which results in `Lovelace` not being sanitized.