### PR TITLE
Add a missing source-repository-package hash

### DIFF
--- a/server/cabal.project
+++ b/server/cabal.project
@@ -67,6 +67,7 @@ source-repository-package
     ouroboros-consensus
     ouroboros-consensus-cardano
     ouroboros-consensus-diffusion
+  --sha256: 05114zbhlwswi7r1wvhsajiwn2an4lz7b4659j0yp4lslhd79424
 
 source-repository-package
   type: git


### PR DESCRIPTION
Hey :wave: Can we add this hash after the recent dependency changes? :pray: Otherwise our Hydra rejects the build in pure mode. Thank you!

Related to #341 