### PR TITLE
Add SanchoNet variant to Dockerhub builds

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -382,7 +382,7 @@ jobs:
       matrix:
         os: [ linux ]
         target: [ ogmios, cardano-node-ogmios ]
-        network: [ mainnet, preprod, preview ]
+        network: [ mainnet, preprod, preview, sanchonet ]
         cardano-node: [ 8.5.0-pre ]
         cardano-node-latest: [ 8.5.0-pre ]
         arch: [ x86_64 ]


### PR DESCRIPTION
SanchoNet is a public network that will be supported for some time. It would be great to have pre-built images while this network is live