### PR TITLE
Fix extracting method from response

### DIFF
--- a/clients/TypeScript/packages/client/src/TransactionSubmission/Client.ts
+++ b/clients/TypeScript/packages/client/src/TransactionSubmission/Client.ts
@@ -40,8 +40,8 @@ const matchSubmitTransaction = (data: string) => {
     return null
   }
 
-  if ('method' in json.id) {
-    if (json.id.method !== METHODS.SUBMIT) {
+  if ('method' in json) {
+    if (json.method !== METHODS.SUBMIT) {
       return null
     }
   }
@@ -57,8 +57,8 @@ const matchEvaluateTransaction = (data: string) => {
     return null
   }
 
-  if ('method' in json.id) {
-    if (json.id.method !== METHODS.EVALUATE) {
+  if ('method' in json) {
+    if (json.method !== METHODS.EVALUATE) {
       return null
     }
   }


### PR DESCRIPTION
When sending two requests to ogmios, e.g. `protocolParameters` and `evaluateTransaction`, response for `protocolParameters` is matched in `matchEvaluateTransaction` because `'method' in json.id` is false.

There is a top-level `method` field as defined in https://ogmios.dev/api/#operation-publish-/?EvaluateTransaction