### PR TITLE
Docs: Update links to new intersectMBO repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -628,7 +628,7 @@ N/A
 
 #### Added
 
-- Integrated with the Cardano eco-system corresponding to [cardano-node@1.29.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.29.0) (Alonzo!) & latest testnet(s).
+- Integrated with the Cardano eco-system corresponding to [cardano-node@1.29.0](https://github.com/intersectMBO/cardano-node/releases/tag/1.29.0) (Alonzo!) & latest testnet(s).
 >
 - New `alonzo` block type, with various additions related to Alonzo.
 >

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   </picture>
 </p>
 
-**Ogmios** is a lightweight bridge interface for [cardano-node](https://github.com/input-output-hk/cardano-node/). It provides an **HTTP / WebSocket** API that enables applications to interact with a local cardano-node via **JSON+RPC-2.0**.
+**Ogmios** is a lightweight bridge interface for [cardano-node](https://github.com/intersectMBO/cardano-node/). It provides an **HTTP / WebSocket** API that enables applications to interact with a local cardano-node via **JSON+RPC-2.0**.
 
 ## Compatibility
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -5,7 +5,7 @@ chapter = true
 
 # Ogmios
 
-**Ogmios** is a lightweight bridge interface for [cardano-node](https://github.com/input-output-hk/cardano-node/). It offers a WebSockets API that enables local clients to speak [Ouroboros' mini-protocols](https://input-output-hk.github.io/ouroboros-network/pdfs/network-spec/network-spec.pdf#chapter.3) via JSON/RPC.
+**Ogmios** is a lightweight bridge interface for [cardano-node](https://github.com/intersectMBO/cardano-node/). It offers a WebSockets API that enables local clients to speak [Ouroboros' mini-protocols](https://ouroboros-network.cardano.intersectmbo.org/pdfs/network-spec/network-spec.pdf#chapter.3) via JSON/RPC.
 
 ---
 

--- a/docs/content/faq/_index.md
+++ b/docs/content/faq/_index.md
@@ -8,7 +8,7 @@ pre = "<b>6. </b>"
 #### Can you explain Ogmios in ~~one~~ three sentences?
 
 
-Ogmios is a lightweight bridge interface for [cardano-node](https://github.com/input-output-hk/cardano-node/). It offers a WebSockets API that enables local clients to speak [Ouroboros' mini-protocols](https://input-output-hk.github.io/ouroboros-network/pdfs/network-spec/network-spec.pdf#chapter.3) via JSON/RPC. Ogmios is a fast and lightweight solution that can be deployed alongside relays to create entry points on the Cardano network for various types of applications (e.g. wallets, explorers, chatbots, dashboards…)
+Ogmios is a lightweight bridge interface for [cardano-node](https://github.com/intersectMBO/cardano-node/). It offers a WebSockets API that enables local clients to speak [Ouroboros' mini-protocols](https://ouroboros-network.cardano.intersectmbo.org/pdfs/network-spec/network-spec.pdf#chapter.3) via JSON/RPC. Ogmios is a fast and lightweight solution that can be deployed alongside relays to create entry points on the Cardano network for various types of applications (e.g. wallets, explorers, chatbots, dashboards…)
 
 #### Can you explain Ogmios to me like I'm five?
 

--- a/docs/content/getting-started/docker.md
+++ b/docs/content/getting-started/docker.md
@@ -139,7 +139,7 @@ $ docker-compose up
 
 👆This will run and connect:
 
-- A [Cardano node](https://github.com/input-output-hk/cardano-node/), connected to mainnet.
+- A [Cardano node](https://github.com/intersectMBO/cardano-node/), connected to mainnet.
 - An Ogmios server using the [latest Dockerhub build](https://hub.docker.com/r/cardanosolutions/ogmios), listening to localhost on port: 1337.
 
 Once finish, tear the stack down using:

--- a/docs/content/mini-protocols/_index.md
+++ b/docs/content/mini-protocols/_index.md
@@ -7,4 +7,4 @@ pre = "<b>2. </b>"
 
 # Mini-Protocols
 
-In this section, we'll give practical insights about interacting with the [Ouroboros mini-protocols](https://input-output-hk.github.io/ouroboros-network/pdfs/network-spec/network-spec.pdf#chapter.3). Each sub-section will focus on one particular protocol, give an overview and give examples in JavaScript using Ogmios.
+In this section, we'll give practical insights about interacting with the [Ouroboros mini-protocols](https://ouroboros-network.cardano.intersectmbo.org/pdfs/network-spec/network-spec.pdf#chapter.3). Each sub-section will focus on one particular protocol, give an overview and give examples in JavaScript using Ogmios.

--- a/docs/content/mini-protocols/local-tx-submission.md
+++ b/docs/content/mini-protocols/local-tx-submission.md
@@ -36,7 +36,7 @@ This guide doesn't cover the creation and serialization of Cardano transactions.
 
 - [Mesh.js](https://meshjs.dev/), a JavaScript library providing numerous tools to easily build powerful dApps on the Cardano blockchain.
 
-- [cardano-cli](https://github.com/input-output-hk/cardano-node/tree/master/cardano-cli) which offers another command-line interface for constructing and signing transactions.
+- [cardano-cli](https://github.com/intersectMBO/cardano-cli/tree/main/cardano-cli) which offers another command-line interface for constructing and signing transactions.
 
 In any case, one can always refer to the source [CDDL specifications](https://github.com/input-output-hk/cardano-ledger/blob/5af4f68486680bf73ba21a9620a14e128e9fe5f7/eras/babbage/test-suite/cddl-files/babbage.cddl) to know how to construct and serialize Cardano transactions.
 


### PR DESCRIPTION
* Update docs to point to new intersectMBO links.
* Update cardano-node repo to cardano-cli repo.

Fixes #369 