### PR TITLE
Evaluate with mempool

### DIFF
--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -166,6 +166,7 @@ library
     , containers
     , contra-tracer
     , contra-tracers
+    , deepseq
     , directory
     , ekg-core
     , fast-bech32

--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -166,7 +166,6 @@ library
     , containers
     , contra-tracer
     , contra-tracers
-    , deepseq
     , directory
     , ekg-core
     , fast-bech32

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -67,6 +67,7 @@ library:
     - containers
     - contra-tracer
     - contra-tracers
+    - deepseq
     - directory
     - ekg-core
     - fast-bech32

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -67,7 +67,6 @@ library:
     - containers
     - contra-tracer
     - contra-tracers
-    - deepseq
     - directory
     - ekg-core
     - fast-bech32

--- a/server/src/Ogmios/App/Server/WebSocket.hs
+++ b/server/src/Ogmios/App/Server/WebSocket.hs
@@ -61,7 +61,7 @@ import Ogmios.App.Protocol.TxMonitor
     ( mkTxMonitorClient
     )
 import Ogmios.App.Protocol.TxSubmission
-    ( ExecutionUnitsEvaluator
+    ( ExecutionUnitsEvaluator (..)
     , mkTxSubmissionClient
     , newExecutionUnitsEvaluator
     )
@@ -241,9 +241,9 @@ newWebSocketApp tr unliftIO = do
                     let clientB = mkClient unliftIO (natTracer liftIO trClient) slotsPerEpoch exUnitsClients
                     let vData  = NodeToClientVersionData networkMagic False
                     concurrently_
-                        (connectClient trClient clientA vData nodeSocket)
-                        (connectClient trClient clientB vData nodeSocket)
-                        & handle (onIOException conn)
+                       (connectClient trClient clientA vData nodeSocket)
+                       (connectClient trClient clientB vData nodeSocket)
+                       & handle (onIOException conn)
         logWith tr (WebSocketConnectionEnded $ userAgent pending)
   where
     userAgent :: PendingConnection -> Text
@@ -291,6 +291,7 @@ withExecutionUnitsEvaluator
     :: forall m a.
         ( MonadClock m
         , MonadSTM m
+        , MonadIO m
         )
     => (ExecutionUnitsEvaluator m Block -> Clients m Block -> m a)
     -> m a
@@ -314,6 +315,7 @@ withOuroborosClients
         , MonadLog m
         , MonadMetrics m
         , MonadWebSocket m
+        , MonadIO m
         )
     => Logger TraceWebSocket
     -> Rpc.Options

--- a/server/src/Ogmios/App/Server/WebSocket.hs
+++ b/server/src/Ogmios/App/Server/WebSocket.hs
@@ -156,9 +156,6 @@ import Ouroboros.Network.NodeToClient.Version
 import Ouroboros.Network.Protocol.ChainSync.ClientPipelined
     ( ChainSyncClientPipelined (..)
     )
-import Ouroboros.Network.Protocol.LocalTxMonitor.Client
-    ( LocalTxMonitorClient (..)
-    )
 import Ouroboros.Network.Protocol.LocalTxSubmission.Client
     ( LocalTxSubmissionClient (..)
     )
@@ -298,7 +295,7 @@ withExecutionUnitsEvaluator
     => (ExecutionUnitsEvaluator m Block -> Clients m Block -> m a)
     -> m a
 withExecutionUnitsEvaluator action = do
-    ( exUnitsEvaluator, stateQueryClient ) <- newExecutionUnitsEvaluator
+    ( exUnitsEvaluator, stateQueryClient, txMonitorClient ) <- newExecutionUnitsEvaluator
     action exUnitsEvaluator $ Clients
          { chainSyncClient =
             ChainSyncClientPipelined idle
@@ -307,7 +304,7 @@ withExecutionUnitsEvaluator action = do
          , txSubmissionClient =
             LocalTxSubmissionClient idle
          , txMonitorClient =
-            LocalTxMonitorClient idle
+            txMonitorClient
          }
 
 withOuroborosClients


### PR DESCRIPTION
Closes #375.

- :round_pushpin: **Augment ExecutionUnitsEvaluator with mempool info**
    This shall make the mempool available to the evaluator. The background
  mempool client running here is very simple, it drains all the
  transaction from the mempool and store them in a TMVar, then wait for
  a new snapshot.

  We use a TMVar and not a TVar here to ensure that the full list is
  only available when we have drained all transactions (so that a
  concurrent reader cannot access a partially fetched mempool).

  We also provide a way to invalidate the mempool, which is potentially
  hazardous if used recklessly. But, the intent is to invalidate the
  mempool after every transaction submission so that there's no race
  condition for clients that would be evaluating then submitting many
  transactions. This will cause the evaluation step to always _wait_ on
  the mempool to be refreshed -- which should be relatively fast.

  Another approach could be to simply insert the latest submitted
  transaction on top of the mempool. Yet, this technically break the
  boundary of a "snapshot", since we may return a completely incoherent
  state of the mempool (some snapshot's transactions which may no longer
  even be in the mempool + one fresh transaction that isn't even part of
  the snapshot).

  So while the latter sounds more efficient, it comes with data
  integrity issues.

- :round_pushpin: **Use UTxO available from the mempool during transaction evaluation.**
    This is a bit tricky because we evaluation and the submission now play
  concurrently against each other. When a new transaction is submitted,
  we must clear the mempool to make sure we evaluate on top of the most
  recent informations.

  This needs more proper logging. For the sake of moving foward with
  this, I shoved a 'MonadIO' and some 'putStrLn' as breadcrumbs, but
  this screams for more meaningful logging.

  The code around evaluation has also proven quite fragile. Especially
  the bits regarding the era translations. Many parts can fail in async
  thread causing Ogmios to either become unresponsive or fail with very
  little detail. This happens even if the culprit parts aren't even in
  async threads, but due to laziness, only blow up later in the stack.

  Hence, some of those errors can be made to surface earlier by forcing
  evaluation of critical elements, but I am not fully convinced that
  this doesn't blow up if someone submits a Conway transaction while
  still in the Babbage era.

- :round_pushpin: **Update configuration files.**
  