### PR TITLE
Add a missing `sha256` for Haskell.nix compatibility

### DIFF
--- a/server/cabal.project
+++ b/server/cabal.project
@@ -105,3 +105,4 @@ source-repository-package
     eras/alonzo/impl
     eras/babbage/impl
     eras/conway/impl
+  --sha256: 0vrjfhffs5m01qkhjr2vyilwk18x96x2xg3w4r9kdil3kxj3wla3


### PR DESCRIPTION
I do patch it in our tree, so it's not a blocker, but it might be useful to contribute back. :)