### PR TITLE
Apply #378 to v6.2

### DIFF
--- a/server/cabal.project
+++ b/server/cabal.project
@@ -107,3 +107,4 @@ source-repository-package
     eras/alonzo/impl
     eras/babbage/impl
     eras/conway/impl
+  --sha256: 0vrjfhffs5m01qkhjr2vyilwk18x96x2xg3w4r9kdil3kxj3wla3


### PR DESCRIPTION
v6.2 branch is still incompatible with haskell.nix because it lacks this fix.