### PR TITLE
Only return the OverlappingAdditionalUtxo error if the provided UTXO actually differs from the one in the ledger

### DIFF
--- a/server/src/Ogmios/App/Protocol/TxSubmission.hs
+++ b/server/src/Ogmios/App/Protocol/TxSubmission.hs
@@ -600,9 +600,9 @@ mkEvaluateTransactionResponse callback (UTxO networkUtxo) args =
                   \to convince the compiler of this."
         Just (UTxO userProvidedUtxo, tx) ->
             let
-                intersection = Map.intersection userProvidedUtxo networkUtxo
+                intersection = Map.intersectionWith (==) userProvidedUtxo networkUtxo
             in
-                if null intersection
+                if all intersection
                 then
                     callback (UTxO $ userProvidedUtxo <> networkUtxo) tx
                 else


### PR DESCRIPTION
This simplifies downstream logic, since we can just provide the UTXOs we have, and not worry about whether they've been included in the ledger by now or not.

(Disclaimer: I'm terrified of getting a haskell dev environment up, so this hasn't been tested, and might need imports tweaked)