### PR TITLE
Add stakePools parameter to stakePools query

### DIFF
--- a/clients/TypeScript/packages/client/src/LedgerStateQuery/Client.ts
+++ b/clients/TypeScript/packages/client/src/LedgerStateQuery/Client.ts
@@ -29,6 +29,7 @@ import {
   GenesisShelley,
   Origin,
   Point,
+  StakePoolId,
   UtxoByAddresses,
   UtxoByOutputReferences,
   ValueAdaOnly
@@ -70,7 +71,7 @@ export interface LedgerStateQueryClient {
     keys?: AnyStakeCredential[],
   }): ReturnType<typeof rewardAccountSummaries>
   rewardsProvenance(): ReturnType<typeof rewardsProvenance>
-  stakePools(): ReturnType<typeof stakePools>
+  stakePools(stakePools?: { id: StakePoolId }[]): ReturnType<typeof stakePools>
   utxo(filter?: UtxoByOutputReferences | UtxoByAddresses): ReturnType<typeof utxo>
 }
 
@@ -184,8 +185,8 @@ export async function createLedgerStateQueryClient (
     rewardsProvenance () {
       return rewardsProvenance(context)
     },
-    stakePools () {
-      return stakePools(context)
+    stakePools (stakePools) {
+      return stakePools(context, stakePools)
     },
     utxo (filter) {
       return utxo(context, filter)


### PR DESCRIPTION
The parameter was introduced here: https://github.com/CardanoSolutions/ogmios/commit/37af3a8a138a20f2f2fed7cdbe87d2836de461bb#diff-b15b783a10f9fc2b73f782b921d2d3a0d702d8c677e2dbdfa8377d136291f8a9L12

But it was not properly propagated in the interface, so it could not be used from outside ogmios-client