### PR TITLE
Fix/docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,10 +24,6 @@ services:
 
   ogmios:
     image: cardanosolutions/ogmios:latest
-    build:
-      context: .
-      target: ogmios
-      cache_from: [cardanosolutions/ogmios:latest]
     restart: on-failure
     command: [
       "--host", "0.0.0.0",

--- a/docs/content/getting-started/docker.md
+++ b/docs/content/getting-started/docker.md
@@ -127,7 +127,7 @@ Configuration files are available from within the image under `/config` in folde
 Alternatively, you may use Docker's [compose](https://docs.docker.com/compose/) to run either Ogmios standalone, or an orchestration of cardano-node and Ogmios talking to each other. Compose is a handy tool to orchestrate multiple services packaged as containers. It works from a compose file which is available in the project repository, get it via:
 
 ```console
-$ git clone --depth 1 git@github.com:cardanosolutions/ogmios.git
+$ git clone --depth 1 --recursive --shallow-submodules git@github.com:cardanosolutions/ogmios.git
 $ cd ogmios
 ```
 


### PR DESCRIPTION
- remove the old build instructions (as discussed in discord)
- update the documentation to also download the submodules fully when cloning the repository -> the config submodule is also needed for running the `docker-compose up` command