### PR TITLE
Convert raw to string

### DIFF
--- a/clients/TypeScript/packages/client/src/util.ts
+++ b/clients/TypeScript/packages/client/src/util.ts
@@ -102,7 +102,7 @@ export const safeJSON = {
       return this.sanitize(this.$.parse(raw))
     } catch (e) {
       if (e.name === 'SyntaxError' && typeof e.message === 'string' && e.message.includes('forbidden constructor')) {
-        const escaped = raw.replace(/"constructor"/g, '"constr"')
+        const escaped = raw.toString().replace(/"constructor"/g, '"constr"')
         return this.sanitize(this.$.parse(escaped))
       }
       throw e


### PR DESCRIPTION
Resolves the issue `raw.replace is not a function` that seems to randomly occur during indexing. In some cases, `raw` is a buffer, which needs converted to a string before calling the `.replace(...)`