### PR TITLE
WIP: Dijkstra integration — bump deps to cardano-node 11.0.1 (stubbed)

### DIFF
--- a/server/cabal.project
+++ b/server/cabal.project
@@ -10,27 +10,31 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 index-state:
-  , hackage.haskell.org 2025-09-11T07:59:00Z
-  , cardano-haskell-packages 2025-09-11T08:36:14Z
+  , hackage.haskell.org 2026-05-08T22:40:19Z
+  , cardano-haskell-packages 2026-05-08T13:26:45Z
 
 constraints:
-  , any.cardano-node == 10.5.1
+  , any.cardano-node == 11.0.1
 
-  , any.cardano-ledger-core == 1.17.0.0
-  , any.cardano-ledger-shelley == 1.16.0.0
-  , any.cardano-ledger-conway == 1.19.0.0
+  , any.cardano-ledger-conway >= 1.22.1.0
 
-  , any.ouroboros-consensus == 0.27.0.0
-  , any.ouroboros-consensus-cardano == 0.25.1.0
-  , any.ouroboros-network == 0.21.3.0
+  , any.ouroboros-consensus ^>= 3.0.1
+  , any.ouroboros-network ^>= 1.1
 
-  , any.io-classes == 1.5.0.0
-  , any.io-classes-mtl == 0.1.2.0
+  , any.io-classes ^>= 1.8
   , any.formatting == 7.2.0
+  , any.validation < 1.2
   , any.text source
+
+  -- ogmios doesn't exercise io_uring code paths, so build `blockio` with the
+  -- serial backend to drop the `liburing` system dependency.
+  , any.blockio +serialblockio
 
 allow-newer:
   *:formatting
+  , katip:Win32
+  , io-sim:time
+  , io-classes:time
 
 packages:
   ./
@@ -87,28 +91,7 @@ package text
 package formatting
   flags: +no-double-conversion
 
--- cardano-ledger with queryDRepDelegations backported on top of conway-1.19.0.0 (instead of 1.20.0.0).
-source-repository-package
-  type: git
-  location: https://github.com/CardanoSolutions/cardano-ledger.git
-  tag: 5cca15a1f0629c11e8d4d4daeb73428684f9c34f
-  subdir:
-    libs/cardano-ledger-core
-    libs/cardano-ledger-api
-
--- ouroboros-network patched with NodeToClientV_21 declared for GetDRepsDelegations query.
-source-repository-package
-  type: git
-  location: https://github.com/CardanoSolutions/ouroboros-network.git
-  tag: d3477c4e6b3243f89afb974914ea423a75873fa0
-  subdir:
-    ouroboros-network-api
-
--- ouroboros-consensus patched with GetDRepsDelegations query & associated client versions
-source-repository-package
-  type: git
-  location: https://github.com/CardanoSolutions/ouroboros-consensus.git
-  tag: 5bbbf9c8b4cd3dc3e3a80d13ef54b3a2ee43a585
-  subdir:
-    ouroboros-consensus
-    ouroboros-consensus-cardano
+-- NOTE: GetDRepDelegations query and associated patches are now upstream
+-- in cardano-node 11.0.1 (ouroboros-consensus 3.0.1, cardano-ledger-conway >= 1.22.1).
+-- The previous source-repository-package patches for cardano-ledger,
+-- ouroboros-network, and ouroboros-consensus have been removed.

--- a/server/modules/ouroboros-network-ogmios/ouroboros-network-ogmios.cabal
+++ b/server/modules/ouroboros-network-ogmios/ouroboros-network-ogmios.cabal
@@ -1,6 +1,6 @@
-cabal-version: 1.12
+cabal-version: 3.0
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.3.
 --
 -- see: https://github.com/sol/hpack
 
@@ -31,6 +31,8 @@ library
       Cardano.Network.Protocol.NodeToClient
       Cardano.Network.Protocol.NodeToClient.Trace
   other-modules:
+      Paths_ouroboros_network_ogmios
+  autogen-modules:
       Paths_ouroboros_network_ogmios
   hs-source-dirs:
       src
@@ -78,22 +80,23 @@ library
       aeson
     , base >=4.7 && <5
     , bytestring
+    , cardano-diffusion
     , cardano-ledger-byron
     , cardano-slotting
     , cborg
     , containers
     , contra-tracer
+    , deepseq
     , io-classes
     , iohk-monitoring
     , network-mux
     , ouroboros-consensus
-    , ouroboros-consensus-cardano
-    , ouroboros-consensus-diffusion
-    , ouroboros-network
-    , ouroboros-network-api
-    , ouroboros-network-framework
-    , ouroboros-network-protocols
+    , ouroboros-consensus:cardano
+    , ouroboros-consensus:diffusion
+    , ouroboros-network:api
+    , ouroboros-network:framework
+    , ouroboros-network:protocols
     , typed-protocols
-    , typed-protocols-cborg
-    , typed-protocols-stateful
+    , typed-protocols:cborg
+    , typed-protocols:stateful
   default-language: Haskell2010

--- a/server/modules/ouroboros-network-ogmios/package.yaml
+++ b/server/modules/ouroboros-network-ogmios/package.yaml
@@ -35,15 +35,16 @@ library:
     - io-classes
     - iohk-monitoring
     - network-mux
+    - cardano-diffusion
+    - deepseq
     - ouroboros-consensus
-    - ouroboros-consensus-diffusion
-    - ouroboros-consensus-cardano
-    - ouroboros-network
-    - ouroboros-network-api
-    - ouroboros-network-framework
-    - ouroboros-network-protocols
+    - ouroboros-consensus:diffusion
+    - ouroboros-consensus:cardano
+    - ouroboros-network:api
+    - ouroboros-network:framework
+    - ouroboros-network:protocols
     - typed-protocols
-    - typed-protocols-stateful
-    - typed-protocols-cborg
+    - typed-protocols:stateful
+    - typed-protocols:cborg
   build-tools:
   - hspec-discover

--- a/server/modules/ouroboros-network-ogmios/src/Cardano/Network/Protocol/NodeToClient.hs
+++ b/server/modules/ouroboros-network-ogmios/src/Cardano/Network/Protocol/NodeToClient.hs
@@ -43,6 +43,7 @@ module Cardano.Network.Protocol.NodeToClient
     , Error (..)
     , HandshakeProtocolError (..)
     , NodeToClientVersion
+    , NodeToClientVersionData (..)
     , GenTx
     , GenTxId
 
@@ -66,6 +67,9 @@ import Cardano.Network.Protocol.NodeToClient.Trace
 import Cardano.Slotting.Slot
     ( SlotNo
     )
+import Control.DeepSeq
+    ( NFData
+    )
 import Control.Monad.Class.MonadAsync
     ( MonadAsync
     )
@@ -73,7 +77,8 @@ import Control.Monad.Class.MonadST
     ( MonadST
     )
 import Control.Monad.Class.MonadThrow
-    ( MonadMask
+    ( MonadEvaluate
+    , MonadMask
     , MonadThrow (..)
     )
 import Control.Monad.IO.Class
@@ -163,7 +168,7 @@ import Ouroboros.Network.Mux
     , OuroborosApplication (..)
     , RunMiniProtocol (..)
     )
-import Ouroboros.Network.NodeToClient
+import Cardano.Network.NodeToClient
     ( LocalAddress
     , MinimalInitiatorContext
     , NetworkConnectTracers (..)
@@ -256,6 +261,7 @@ instance ConvertRawTxId (GenTx (CardanoBlock StandardCrypto)) where
         GenTxIdAlonzo x -> toRawTxIdHash x
         GenTxIdBabbage x -> toRawTxIdHash x
         GenTxIdConway x -> toRawTxIdHash x
+        _ -> error "TODO(dijkstra): toRawTxIdHash Dijkstra arm (GenTxIdDijkstra)"
 
 -- | A handy type to pass clients around
 data Clients m block = Clients
@@ -286,9 +292,8 @@ connectClient tr client vData addr = liftIO $ withIOManager $ \iocp -> do
         | v <- [ nodeToClientV_Min .. nodeToClientV_Latest ]
         ]
 
-    tracers :: NetworkConnectTracers LocalAddress NodeToClientVersion
     tracers = NetworkConnectTracers
-        { nctMuxTracer = nullTracer
+        { nctMuxTracers = undefined -- TODO(dijkstra): nctMuxTracer was renamed to nctMuxTracers and retyped from Tracer to Mx.TracersWithBearer in ouroboros-network 1.1 -- needs proper construction (was `nullTracer`)
         , nctHandshakeTracer = contramap TrHandshake tr
         }
 
@@ -305,6 +310,7 @@ mkClient
         , MonadIO m
         , MonadMask m
         , MonadST m
+        , MonadEvaluate m
         )
     => (forall a. m a -> IO a)
         -- ^ A natural transformation to unlift a particular 'm' into 'IO'.
@@ -367,6 +373,7 @@ localChainSync
         ( protocol ~ ChainSync Block (Point Block) (Tip Block)
         , MonadThrow m
         , MonadAsync m
+        , MonadEvaluate m
         )
     => (forall a. m a -> IO a)
         -- ^ A natural transformation to unlift a particular 'm' into 'IO'.
@@ -389,6 +396,7 @@ localTxSubmission
     :: forall m protocol.
         ( protocol ~ LocalTxSubmission (SerializedTransaction Block) (SubmitTransactionError Block)
         , MonadThrow m
+        , MonadEvaluate m
         )
     => (forall a. m a -> IO a)
         -- ^ A natural transformation to unlift a particular 'm' into 'IO'.
@@ -411,6 +419,8 @@ localTxMonitor
     :: forall m protocol a.
         ( protocol ~ LocalTxMonitor (GenTxId Block) (GenTx Block) SlotNo
         , MonadThrow m
+        , MonadEvaluate m
+        , NFData a
         )
     => (forall x. m x -> IO x)
         -- ^ A natural transformation to unlift a particular 'm' into 'IO'.
@@ -433,6 +443,7 @@ localStateQuery
     :: forall m.
         ( MonadAsync m
         , MonadMask m
+        , MonadEvaluate m
         )
     => (forall x. m x -> IO x)
         -- ^ A natural transformation to unlift a particular 'm' into 'IO'.
@@ -461,10 +472,11 @@ codecs epochSlots nodeToClientV =
   where
     supportedVersions = supportedNodeToClientVersions (Proxy @Block)
     cfg = CardanoCodecConfig
-        (let byron   = ByronCodecConfig epochSlots in byron)
-        (let shelley = ShelleyCodecConfig in shelley)
-        (let allegra = ShelleyCodecConfig in allegra)
-        (let mary    = ShelleyCodecConfig in mary)
-        (let alonzo  = ShelleyCodecConfig in alonzo)
-        (let babbage = ShelleyCodecConfig in babbage)
-        (let conway  = ShelleyCodecConfig in conway)
+        (let byron    = ByronCodecConfig epochSlots in byron)
+        (let shelley  = ShelleyCodecConfig in shelley)
+        (let allegra  = ShelleyCodecConfig in allegra)
+        (let mary     = ShelleyCodecConfig in mary)
+        (let alonzo   = ShelleyCodecConfig in alonzo)
+        (let babbage  = ShelleyCodecConfig in babbage)
+        (let conway   = ShelleyCodecConfig in conway)
+        (let dijkstra = undefined in dijkstra) -- TODO(dijkstra): new era slot in CardanoCodecConfig (ouroboros-consensus 3.0.1)

--- a/server/modules/ouroboros-network-ogmios/src/Cardano/Network/Protocol/NodeToClient/Trace.hs
+++ b/server/modules/ouroboros-network-ogmios/src/Cardano/Network/Protocol/NodeToClient/Trace.hs
@@ -34,7 +34,7 @@ import Network.TypedProtocol.Codec
 import Ouroboros.Network.Driver.Simple
     ( TraceSendRecv (..)
     )
-import Ouroboros.Network.NodeToClient
+import Cardano.Network.NodeToClient
     ( ConnectionId (..)
     , LocalAddress
     , NodeToClientVersion

--- a/server/ogmios.cabal
+++ b/server/ogmios.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 
--- This file has been generated from package.yaml by hpack version 0.38.2.
+-- This file has been generated from package.yaml by hpack version 0.38.3.
 --
 -- see: https://github.com/sol/hpack
 
@@ -188,13 +188,12 @@ library
     , mtl
     , optparse-applicative
     , ouroboros-consensus
-    , ouroboros-consensus-cardano
-    , ouroboros-consensus-protocol
-    , ouroboros-network
-    , ouroboros-network-api
-    , ouroboros-network-framework
+    , ouroboros-consensus:cardano
+    , ouroboros-consensus:protocol
     , ouroboros-network-ogmios
-    , ouroboros-network-protocols
+    , ouroboros-network:api
+    , ouroboros-network:framework
+    , ouroboros-network:protocols
     , plutus-core
     , plutus-ledger-api
     , prettyprinter
@@ -370,12 +369,12 @@ test-suite unit
     , lens-aeson
     , ogmios
     , ouroboros-consensus
-    , ouroboros-consensus-cardano
-    , ouroboros-consensus-cardano:unstable-cardano-testlib
-    , ouroboros-network-api
-    , ouroboros-network-framework
+    , ouroboros-consensus:cardano
+    , ouroboros-consensus:unstable-cardano-testlib
     , ouroboros-network-ogmios
-    , ouroboros-network-protocols
+    , ouroboros-network:api
+    , ouroboros-network:framework
+    , ouroboros-network:protocols
     , random
     , strict-sop-core
     , template-haskell

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -88,13 +88,12 @@ library:
     - mtl
     - optparse-applicative
     - ouroboros-consensus
-    - ouroboros-consensus-cardano
-    - ouroboros-consensus-protocol
-    - ouroboros-network
-    - ouroboros-network-api
-    - ouroboros-network-framework
+    - ouroboros-consensus:cardano
+    - ouroboros-consensus:protocol
+    - ouroboros-network:api
+    - ouroboros-network:framework
     - ouroboros-network-ogmios
-    - ouroboros-network-protocols
+    - ouroboros-network:protocols
     - plutus-core
     - plutus-ledger-api
     - prettyprinter
@@ -169,12 +168,12 @@ tests:
     - lens-aeson
     - ogmios
     - ouroboros-consensus
-    - ouroboros-consensus-cardano
-    - ouroboros-consensus-cardano:unstable-cardano-testlib
-    - ouroboros-network-api
-    - ouroboros-network-framework
+    - ouroboros-consensus:cardano
+    - ouroboros-consensus:unstable-cardano-testlib
+    - ouroboros-network:api
+    - ouroboros-network:framework
     - ouroboros-network-ogmios
-    - ouroboros-network-protocols
+    - ouroboros-network:protocols
     - QuickCheck
     - random
     - strict-sop-core

--- a/server/src/Ogmios/App/Configuration.hs
+++ b/server/src/Ogmios/App/Configuration.hs
@@ -8,6 +8,9 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
+-- TODO(dijkstra): warnings suppressed during dep migration.
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-incomplete-patterns -Wno-unused-matches -Wno-unused-top-binds -Wno-redundant-constraints -Wno-deprecations -Wno-orphans #-}
+
 module Ogmios.App.Configuration
     (
     -- * Configuration
@@ -186,21 +189,9 @@ readAlonzoGenesis configFile = do
     allV1ParamNames = Ledger.costModelParamNames Ledger.PlutusV1
 
     withoutFutureParameters :: Set Text -> GenesisConfig AlonzoEra -> GenesisConfig AlonzoEra
-    withoutFutureParameters sourceParamNames config =
-        let
-            inner = Ledger.unAlonzoGenesisWrapper config
-            costModels = Ledger.uappCostModels inner
-            costModelsPruned = Map.adjust
-                (either (error . show) identity
-                    . Ledger.mkCostModel Ledger.PlutusV1
-                    . Map.elems
-                    . (`Map.restrictKeys` sourceParamNames)
-                    . Ledger.costModelToMap
-                )
-                Ledger.PlutusV1
-                (Ledger.costModelsValid costModels)
-         in
-            Ledger.AlonzoGenesisWrapper (inner { Ledger.uappCostModels = Ledger.mkCostModels costModelsPruned })
+    withoutFutureParameters _ _ =
+        -- TODO(dijkstra): UpgradeAlonzoPParams vs AlonzoExtraConfig + Maybe CostModels in cardano-ledger-alonzo 1.15.0; needs rewrite.
+        error "TODO(dijkstra): withoutFutureParameters needs new AlonzoExtraConfig / UpgradeAlonzoPParams API"
 
 
 readConwayGenesis :: MonadIO m => FilePath -> m (Either Text (GenesisConfig ConwayEra))

--- a/server/src/Ogmios/App/Health.hs
+++ b/server/src/Ogmios/App/Health.hs
@@ -129,7 +129,7 @@ import Ouroboros.Network.Block
     , genesisPoint
     , getTipPoint
     )
-import Ouroboros.Network.NodeToClient
+import Cardano.Network.Protocol.NodeToClient
     ( NodeToClientVersionData (NodeToClientVersionData)
     )
 import Ouroboros.Network.Protocol.ChainSync.ClientPipelined
@@ -155,7 +155,8 @@ import Ouroboros.Network.Protocol.LocalTxSubmission.Client
     )
 
 import Control.Monad.Class.MonadThrow
-    ( MonadMask
+    ( MonadEvaluate
+    , MonadMask
     )
 import qualified Data.Aeson as Json
 import qualified Data.Text as T
@@ -231,6 +232,7 @@ connectHealthCheckClient
         , MonadClock m
         , MonadLog m
         , MonadMask m
+        , MonadEvaluate m
         , MonadOuroboros m
         , MonadReader env m
         , HasType NetworkParameters env

--- a/server/src/Ogmios/App/Protocol/TxMonitor.hs
+++ b/server/src/Ogmios/App/Protocol/TxMonitor.hs
@@ -37,6 +37,9 @@
 --                    │      Busy     │
 --                    └───────────────┘
 -- @
+-- TODO(dijkstra): warnings suppressed during dep migration.
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-incomplete-patterns -Wno-unused-matches -Wno-unused-top-binds -Wno-redundant-constraints -Wno-deprecations -Wno-orphans #-}
+
 module Ogmios.App.Protocol.TxMonitor
     ( mkTxMonitorClient
     ) where
@@ -201,16 +204,13 @@ mkTxMonitorClient defaultWithInternalError TxMonitorCodecs{..} queue yield nodeT
                     clientStIdle
 
 inMultipleEras
-    :: forall crypto constraint.
-        ( constraint ~ (MostRecentEra (CardanoBlock crypto) ~ ConwayEra)
-        )
+    :: forall crypto.
+        ()
     => NodeToClientVersion
     -> Ledger.TxId
     -> [GenTxId (CardanoBlock crypto)]
 inMultipleEras nodeToClientV id =
-    -- The list is ordered from the "most probable era", down to the least
-    -- probable. This hopefully ensures that we do a minimum number of loops
-    -- for the happy path.
+    -- TODO(dijkstra): era guard (keepRedundantConstraint) disabled — needs `Cardano.Ledger.Dijkstra.Era` import + Dijkstra entry in this list.
     GenTxIdBabbage (ShelleyTxId id) :
         if nodeToClientV >= NodeToClientV_16 then
             [ GenTxIdConway (ShelleyTxId id)
@@ -221,8 +221,3 @@ inMultipleEras nodeToClientV id =
             [ GenTxIdAlonzo (ShelleyTxId id)
             , GenTxIdMary (ShelleyTxId id)
             ]
-  where
-    -- This line exists as a reminder. It will generate a compiler error
-    -- when a new era becomes available. From there, one should update
-    -- the list above to contain that latest era.
-    _compilerWarning = keepRedundantConstraint (Proxy @constraint)

--- a/server/src/Ogmios/App/Protocol/TxSubmission.hs
+++ b/server/src/Ogmios/App/Protocol/TxSubmission.hs
@@ -28,6 +28,9 @@
 --                                                  │          │⇦ START
 --                                                  └──────────┘
 -- @
+-- TODO(dijkstra): warnings suppressed during dep migration.
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-incomplete-patterns -Wno-unused-matches -Wno-unused-top-binds -Wno-redundant-constraints -Wno-deprecations -Wno-orphans #-}
+
 module Ogmios.App.Protocol.TxSubmission
     ( ExecutionUnitsEvaluator(..)
     , mkTxSubmissionClient
@@ -53,6 +56,7 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Core
     ( EraTx (..)
     , EraTxBody (..)
+    , TopTx
     , eraName
     )
 import Control.Monad.Trans.Except
@@ -358,9 +362,10 @@ newExecutionUnitsEvaluator tr = do
                     logWith tr $ TxSubmissionEvaluateArguments { utxoEra = "babbage", transactionEra = "conway" }
                     return $ Right (SomeEvaluationInAnyEra (upgrade utxo) tx)
 
-                (UTxOInConwayEra utxo, GenTxBabbage (ShelleyTx _id tx)) -> do
+                (UTxOInConwayEra utxo, GenTxBabbage (ShelleyTx _id _tx)) -> do
                     logWith tr $ TxSubmissionEvaluateArguments { utxoEra = "conway", transactionEra = "babbage" }
-                    return $ Right (SomeEvaluationInAnyEra utxo (upgrade tx))
+                    -- TODO(dijkstra): Tx TopTx Upgrade instance commented out in EraTranslation.hs.
+                    return $ Right (SomeEvaluationInAnyEra utxo (error "TODO(dijkstra): Babbage→Conway tx upgrade"))
 
                 (UTxOInConwayEra utxo, GenTxConway (ShelleyTx _id tx)) -> do
                     logWith tr $ TxSubmissionEvaluateArguments { utxoEra = "conway", transactionEra = "conway" }
@@ -482,7 +487,7 @@ newExecutionUnitsEvaluator tr = do
                -> SystemStart
                -> EpochInfo (Except PastHorizonException)
                -> UTxO era
-               -> Tx era
+               -> Tx TopTx era
                -> EvaluateTransactionResponse block
                )
             -> HoistQuery proto era
@@ -503,7 +508,7 @@ newExecutionUnitsEvaluator tr = do
             -> (  SystemStart
                -> EpochInfo (Except PastHorizonException)
                -> UTxO era
-               -> Tx era
+               -> Tx TopTx era
                -> EvaluateTransactionResponse block
                )
             -> HoistQuery proto era
@@ -520,7 +525,7 @@ newExecutionUnitsEvaluator tr = do
             => SomeEvaluationInAnyEra
             -> (  EpochInfo (Except PastHorizonException)
                -> UTxO era
-               -> Tx era
+               -> Tx TopTx era
                -> EvaluateTransactionResponse block
                )
             -> HoistQuery proto era
@@ -536,7 +541,7 @@ newExecutionUnitsEvaluator tr = do
             :: forall proto era. (CanEvaluateScriptsInEra era)
             => SomeEvaluationInAnyEra
             -> (  UTxO era
-               -> Tx era
+               -> Tx TopTx era
                -> EvaluateTransactionResponse block
                )
             -> HoistQuery proto era
@@ -601,7 +606,7 @@ data SomeEvaluationInAnyEra where
     SomeEvaluationInAnyEra
         :: forall era. (CanEvaluateScriptsInEra era)
         => !(UTxO era)
-        -> !(Tx era)
+        -> !(Tx TopTx era)
         -> SomeEvaluationInAnyEra
 
 -- | Return all unspent transaction outputs needed for evaluation. This includes
@@ -620,7 +625,7 @@ newEvaluateTransactionResponse
     :: forall era result.
         ( CanEvaluateScriptsInEra era
         )
-    => (UTxO era -> Tx era -> result)
+    => (UTxO era -> Tx TopTx era -> result)
     -> (EvaluateTransactionError -> result)
     -> UTxO era -- ^ Utxo fetched from the network
     -> SomeEvaluationInAnyEra -- ^ Tx & additional utxo
@@ -666,7 +671,7 @@ translateToNetworkEra
         ( CanEvaluateScriptsInEra eraNetwork
         )
     => SomeEvaluationInAnyEra
-    -> Maybe (UTxO eraNetwork, Tx eraNetwork)
+    -> Maybe (UTxO eraNetwork, Tx TopTx eraNetwork)
 translateToNetworkEra (SomeEvaluationInAnyEra utxoOrig txOrig) =
     translate utxoOrig txOrig
   where
@@ -675,8 +680,8 @@ translateToNetworkEra (SomeEvaluationInAnyEra utxoOrig txOrig) =
             ( CanEvaluateScriptsInEra eraArgs
             )
         => UTxO eraArgs
-        -> Tx eraArgs
-        -> Maybe (UTxO eraNetwork, Tx eraNetwork)
+        -> Tx TopTx eraArgs
+        -> Maybe (UTxO eraNetwork, Tx TopTx eraNetwork)
     translate utxo tx =
         let
             eraNetwork = typeRep @eraNetwork
@@ -694,7 +699,8 @@ translateToNetworkEra (SomeEvaluationInAnyEra utxoOrig txOrig) =
             babbageToConway =
                 case (testEquality eraNetwork eraConway, testEquality eraArgs eraBabbage) of
                     (Just Refl, Just Refl) -> do
-                        Just (upgrade utxo, upgrade tx)
+                        -- TODO(dijkstra): Tx TopTx Upgrade instance commented out in EraTranslation.hs; tx upgrade stubbed.
+                        Just (upgrade utxo, error "TODO(dijkstra): Babbage→Conway Tx upgrade")
                     _ ->
                         Nothing
           in

--- a/server/src/Ogmios/App/Server/WebSocket.hs
+++ b/server/src/Ogmios/App/Server/WebSocket.hs
@@ -27,6 +27,9 @@ import Cardano.Network.Protocol.NodeToClient
     , connectClient
     , mkClient
     )
+import Control.Monad.Class.MonadThrow
+    ( MonadEvaluate
+    )
 import Cardano.Network.Protocol.NodeToClient.Trace
     ( TraceClient
     )
@@ -157,7 +160,7 @@ import Ogmios.Data.Protocol.TxSubmission
     , TxSubmissionMessage (..)
     , mkTxSubmissionCodecs
     )
-import Ouroboros.Network.NodeToClient.Version
+import Cardano.Network.Protocol.NodeToClient
     ( NodeToClientVersionData (NodeToClientVersionData)
     )
 import Ouroboros.Network.Protocol.ChainSync.ClientPipelined
@@ -184,6 +187,7 @@ newWebSocketApp
         , MonadClock m
         , MonadLink m
         , MonadMetrics m
+        , MonadEvaluate m
         , MonadOuroboros m
         , MonadWebSocket m
         , MonadReader env m

--- a/server/src/Ogmios/Control.hs
+++ b/server/src/Ogmios/Control.hs
@@ -19,6 +19,9 @@ import Ogmios.Control.Exception
     , MonadMask
     , MonadThrow
     )
+import Control.Monad.Class.MonadThrow
+    ( MonadEvaluate
+    )
 import Ogmios.Control.MonadAsync
     ( MonadAsync (..)
     , MonadFork
@@ -77,7 +80,7 @@ newtype App a = App
         , MonadClock
         , MonadST
         , MonadThread, MonadFork
-        , MonadThrow, MonadCatch, MonadMask
+        , MonadThrow, MonadCatch, MonadMask, MonadEvaluate
         , MonadDisk
         )
 

--- a/server/src/Ogmios/Data/EraTranslation.hs
+++ b/server/src/Ogmios/Data/EraTranslation.hs
@@ -4,6 +4,10 @@
 
 {-# LANGUAGE UndecidableInstances #-}
 
+-- TODO(dijkstra): warnings disabled while the AlonzoTx Upgrade instance is stubbed
+-- (AlonzoTx now has kind `TxLevel -> Type -> Type` in cardano-ledger 1.20).
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-unused-top-binds -Wno-incomplete-patterns #-}
+
 -- | Provides translation of types across the current era and the latest era.
 module Ogmios.Data.EraTranslation
     ( -- * Type Families
@@ -27,10 +31,12 @@ import Cardano.Ledger.Babbage.Tx
 import Cardano.Ledger.Babbage.TxOut
     ( BabbageTxOut (..)
     )
+import Cardano.Ledger.Api.Tx.Body
+    ( upgradeTxBody
+    )
 import Cardano.Ledger.Core
     ( PreviousEra
     , translateEraThroughCBOR
-    , upgradeTxBody
     )
 import Cardano.Ledger.Shelley.UTxO
     ( UTxO (..)
@@ -88,17 +94,23 @@ instance Upgrade UTxO ConwayEra where
 -- Tx
 ----------
 
+-- TODO(dijkstra): AlonzoTx now has kind `TxLevel -> Type -> Type` in cardano-ledger 1.20;
+-- the Upgrade instance head needs to apply a TxLevel (e.g. TopTx).
+-- PR #461 replaces this with `instance Upgrade (Tx TopTx) ConwayEra` using the generic
+-- ledger `Tx` type instead of `AlonzoTx`. Stubbed out until that refactor lands.
+{-
 instance Upgrade AlonzoTx ConwayEra where
     type Upgraded AlonzoTx = AlonzoTx
     upgrade tx = force $ unsafeFromRight $ do
-        body <- left show $ upgradeTxBody (Alonzo.body tx)
+        body <- left show $ upgradeTxBody (Alonzo.atBody tx)
         left show $ runExcept $ do
-            wits <- translateEraThroughCBOR "witness" $ Alonzo.wits tx
-            auxiliaryData <- case Alonzo.auxiliaryData tx of
+            wits <- translateEraThroughCBOR "witness" $ Alonzo.atWits tx
+            auxiliaryData <- case Alonzo.atAuxData tx of
               SNothing -> pure SNothing
               SJust auxData -> SJust <$> translateEraThroughCBOR "auxiliaryData" auxData
-            let isValid = Alonzo.isValid tx
-            pure $ AlonzoTx{body,wits,auxiliaryData,isValid}
+            let isValid = Alonzo.atIsValid tx
+            pure $ AlonzoTx { atBody = body, atWits = wits, atAuxData = auxiliaryData, atIsValid = isValid }
+-}
 
 ----------
 -- GenTx

--- a/server/src/Ogmios/Data/Health.hs
+++ b/server/src/Ogmios/Data/Health.hs
@@ -245,10 +245,11 @@ eraIndexToCardanoEra
     => EraIndex (CardanoEras crypto)
     -> CardanoEra
 eraIndexToCardanoEra = \case
-    EraIndex                   Z{}       -> Byron
-    EraIndex                (S Z{})      -> Shelley
-    EraIndex             (S (S Z{}))     -> Allegra
-    EraIndex          (S (S (S Z{})))    -> Mary
-    EraIndex       (S (S (S (S Z{}))))   -> Alonzo
-    EraIndex    (S (S (S (S (S Z{})))))  -> Babbage
-    EraIndex (S (S (S (S (S (S Z{})))))) -> Conway
+    EraIndex                      Z{}        -> Byron
+    EraIndex                   (S Z{})       -> Shelley
+    EraIndex                (S (S Z{}))      -> Allegra
+    EraIndex             (S (S (S Z{})))     -> Mary
+    EraIndex          (S (S (S (S Z{}))))    -> Alonzo
+    EraIndex       (S (S (S (S (S Z{})))))   -> Babbage
+    EraIndex    (S (S (S (S (S (S Z{}))))))  -> Conway
+    EraIndex (S (S (S (S (S (S (S Z{}))))))) -> error "TODO(dijkstra): eraIndexToCardanoEra Dijkstra arm; needs Dijkstra added to CardanoEra type"

--- a/server/src/Ogmios/Data/Json.hs
+++ b/server/src/Ogmios/Data/Json.hs
@@ -4,6 +4,9 @@
 
 {-# LANGUAGE AllowAmbiguousTypes #-}
 
+-- TODO(dijkstra): warnings disabled while encodeTx era arms and ApplyTxError patterns are stubbed.
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-incomplete-patterns -Wno-unused-matches -Wno-unused-top-binds -Wno-redundant-constraints -Wno-deprecations #-}
+
 module Ogmios.Data.Json
     ( Json
     , ViaEncoding (..)
@@ -175,33 +178,9 @@ encodeSubmitTransactionError
     :: (Rpc.FaultCode -> String -> Maybe Json -> Json)
     -> SubmitTransactionError (CardanoBlock crypto)
     -> Json
-encodeSubmitTransactionError reject = \case
-    ApplyTxErrWrongEra e ->
-        reject (Rpc.FaultCustom 3005)
-            "Failed to submit the transaction in the current era. This may happen when trying to \
-            \submit a transaction near an era boundary (i.e. at the moment of a hard-fork). \
-            \Retrying should help."
-            (pure $ encodeEraMismatch e)
-    ApplyTxErrConway (ApplyTxError xs) ->
-        (encodePredicateFailure reject . pickPredicateFailure)
-            (Conway.encodeLedgerFailure <$> xs)
-    ApplyTxErrBabbage (ApplyTxError xs) ->
-        (encodePredicateFailure reject . pickPredicateFailure)
-            (Babbage.encodeLedgerFailure <$> xs)
-    ApplyTxErrAlonzo (ApplyTxError xs) ->
-        (encodePredicateFailure reject . pickPredicateFailure)
-            (Alonzo.encodeLedgerFailure <$> xs)
-    ApplyTxErrMary (ApplyTxError xs) ->
-        (encodePredicateFailure reject . pickPredicateFailure)
-            (Mary.encodeLedgerFailure <$> xs)
-    ApplyTxErrAllegra (ApplyTxError xs) ->
-        (encodePredicateFailure reject . pickPredicateFailure)
-            (Allegra.encodeLedgerFailure <$> xs)
-    ApplyTxErrShelley (ApplyTxError xs) ->
-        (encodePredicateFailure reject . pickPredicateFailure)
-            (Shelley.encodeLedgerFailure <$> xs)
-    ApplyTxErrByron{} ->
-        error "encodeSubmitTransactionError: unsupported Byron transaction."
+encodeSubmitTransactionError _ _ =
+    -- TODO(dijkstra): `ApplyTxError` is now a type, not a pattern, in cardano-ledger-shelley 1.18; needs new accessor (e.g. `applyTxErrorL` lens or `unApplyTxError`).
+    error "TODO(dijkstra): encodeSubmitTransactionError"
 
 encodeSerializedTransaction
     :: (PraosCrypto crypto, TPraos.PraosCrypto crypto)
@@ -243,21 +222,9 @@ encodeTx
     :: (MetadataFormat, IncludeCbor)
     -> GenTx (CardanoBlock crypto)
     -> Json
-encodeTx opts = \case
-    GenTxConway (ShelleyTx _ x) ->
-        Conway.encodeTx opts x
-    GenTxBabbage (ShelleyTx _ x) ->
-        Babbage.encodeTx opts x
-    GenTxAlonzo (ShelleyTx _ x) ->
-        Alonzo.encodeTx opts x
-    GenTxMary (ShelleyTx _ x) ->
-        Mary.encodeTx opts x
-    GenTxAllegra (ShelleyTx _ x) ->
-        Allegra.encodeTx opts x
-    GenTxShelley (ShelleyTx _ x) ->
-        Shelley.encodeTx opts x
-    GenTxByron _ ->
-        error "encodeTx: unsupported Byron transaction."
+encodeTx _ _ =
+    -- TODO(dijkstra): per-era encodeTx now expects AlonzoTx but receives generic Tx — needs MkShelleyTx/MkAlonzoTx unwrap or lens.
+    error "TODO(dijkstra): encodeTx dispatcher"
 
 encodeGenTxId
     :: GenTxId (CardanoBlock crypto)

--- a/server/src/Ogmios/Data/Json/Allegra.hs
+++ b/server/src/Ogmios/Data/Json/Allegra.hs
@@ -2,6 +2,9 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+-- TODO(dijkstra): warnings disabled while encodeTx is stubbed (needs lens rewrite).
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-unused-matches -Wno-unused-top-binds -Wno-incomplete-patterns #-}
+
 module Ogmios.Data.Json.Allegra where
 
 import Ogmios.Data.Json.Prelude
@@ -20,7 +23,7 @@ import qualified Cardano.Ledger.Address as Ledger
 import qualified Cardano.Ledger.Block as Ledger
 import qualified Cardano.Ledger.Core as Ledger
 
-import qualified Cardano.Ledger.Shelley.BlockChain as Sh
+import qualified Cardano.Ledger.Shelley.BlockBody as Sh
 import qualified Cardano.Ledger.Shelley.Scripts as Sh
 import qualified Cardano.Ledger.Shelley.Tx as Sh
 import qualified Cardano.Ledger.Shelley.TxWits as Sh
@@ -66,7 +69,7 @@ encodeBlock opts (ShelleyBlock (Ledger.Block blkHeader txs) headerHash) =
         <>
           "size" .= encodeSingleton "bytes" (encodeWord32 (TPraos.bsize hBody))
         <>
-          "transactions" .= encodeFoldable (encodeTx opts) (Sh.txSeqTxns' txs)
+          "transactions" .= encodeFoldable (encodeTx opts) (Sh.shelleyBlockBodyTxs txs)
         )
   where
     TPraos.BHeader hBody _ = blkHeader
@@ -119,36 +122,14 @@ encodeTimelock = encodeObject . \case
 
 encodeTx
     :: (MetadataFormat, IncludeCbor)
-    -> Sh.ShelleyTx AllegraEra
+    -> Sh.Tx Ledger.TopTx AllegraEra
     -> Json
-encodeTx (fmt, opts) x =
-    encodeObject
-        ( Shelley.encodeTxId (Ledger.txIdTxBody @AllegraEra (Sh.body x))
-       <>
-        "spends" .= encodeText "inputs"
-       <>
-        encodeTxBody (Sh.body x) (strictMaybe mempty (Map.keys . snd) auxiliary)
-       <>
-        "metadata" .=? OmitWhenNothing fst auxiliary
-       <>
-        encodeWitnessSet opts (snd <$> auxiliary) (Sh.wits x)
-       <>
-        if includeTransactionCbor opts then
-           "cbor" .= encodeByteStringBase16 (encodeCbor @AllegraEra x)
-        else
-           mempty
-       )
-  where
-    auxiliary = do
-        hash <- Shelley.encodeAuxiliaryDataHash <$> Al.atbAuxDataHash (Sh.body x)
-        (labels, scripts) <- encodeAuxiliaryData (fmt, opts) <$> Sh.auxiliaryData x
-        pure
-            ( encodeObject ("hash" .= hash <> "labels" .= labels)
-            , scripts
-            )
+encodeTx _ _ =
+    -- TODO(dijkstra): rewrite using lenses (bodyTxL/witsTxL/auxDataTxL) instead of Sh.MkShelleyTx pattern. The `Sh.MkShelleyTx` syn doesn't unify with non-Shelley eras in cardano-ledger 1.20. PR #461 uses `x ^. Ledger.bodyTxL` etc.
+    error "TODO(dijkstra): encodeTx Allegra"
 
 encodeTxBody
-    :: Al.AllegraTxBody AllegraEra
+    :: Ledger.TxBody Ledger.TopTx AllegraEra
     -> [Ledger.ScriptHash]
     -> Series
 encodeTxBody (Al.AllegraTxBody inps outs dCerts wdrls fee validity updates _) requiredScripts =

--- a/server/src/Ogmios/Data/Json/Alonzo.hs
+++ b/server/src/Ogmios/Data/Json/Alonzo.hs
@@ -2,6 +2,9 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+-- TODO(dijkstra): warnings disabled while accessor and constructor renames are stubbed.
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-incomplete-patterns -Wno-unused-matches -Wno-unused-top-binds -Wno-deprecations -Wno-redundant-constraints #-}
+
 module Ogmios.Data.Json.Alonzo where
 
 import Ogmios.Data.Json.Prelude
@@ -46,7 +49,7 @@ import qualified Cardano.Ledger.Alonzo.Scripts as Al
 import qualified Cardano.Ledger.Alonzo.Tx as Al
 import qualified Cardano.Ledger.Alonzo.TxAuxData as Al
 import qualified Cardano.Ledger.Alonzo.TxBody as Al
-import qualified Cardano.Ledger.Alonzo.TxSeq as Al
+import qualified Cardano.Ledger.Alonzo.BlockBody as Al
 import qualified Cardano.Ledger.Alonzo.TxWits as Al
 
 import qualified Ogmios.Data.Json.Allegra as Allegra
@@ -71,25 +74,9 @@ encodeAuxiliaryData
     => (MetadataFormat, IncludeCbor)
     -> Al.AlonzoTxAuxData era
     -> (Json, AuxiliaryScripts era)
-encodeAuxiliaryData opts (Al.AlonzoTxAuxData blob timelocks plutus) =
-    ( Shelley.encodeMetadataBlob @era opts blob
-    , foldr
-        (\(Al.TimelockScript -> script) -> Map.insert (Ledger.hashScript @era script) script)
-        (Map.foldrWithKey
-            (\lang ->
-                flip $ foldr (\bytes ->
-                    let script = maybe
-                            (error ("mkBinaryPlutusScript: incompatible language and script: " <> show lang <> " for " <> show bytes))
-                            Al.PlutusScript
-                            (Al.mkBinaryPlutusScript @era lang bytes)
-                     in Map.insert (Ledger.hashScript @era script) script
-                )
-            )
-            mempty
-            plutus
-        )
-        timelocks
-    )
+encodeAuxiliaryData _ _ =
+    -- TODO(dijkstra): Al.TimelockScript constructor removed in cardano-ledger-alonzo 1.15.0 (Script type refactored).
+    error "TODO(dijkstra): encodeAuxiliaryData Alonzo"
 
 encodeBinaryData
     :: Ledger.BinaryData era
@@ -101,22 +88,9 @@ encodeBlock
     :: (MetadataFormat, IncludeCbor)
     -> ShelleyBlock (TPraos StandardCrypto) AlonzoEra
     -> Json
-encodeBlock opts (ShelleyBlock (Ledger.Block blkHeader txs) headerHash) =
-    encodeObject
-        ( "type" .= encodeText "praos"
-        <>
-          "era" .= encodeText "alonzo"
-        <>
-          "id" .= Shelley.encodeShelleyHash headerHash
-        <>
-          Shelley.encodeBHeader blkHeader
-        <>
-          "size" .= encodeSingleton "bytes" (encodeWord32 (TPraos.bsize hBody))
-        <>
-          "transactions" .= encodeFoldable (encodeTx opts) (Al.txSeqTxns txs)
-        )
-  where
-    TPraos.BHeader hBody _ = blkHeader
+encodeBlock _ _ =
+    -- TODO(dijkstra): alonzoBlockBodyTxs now yields generic Al.Tx, not Al.AlonzoTx — need different encoder shape.
+    error "TODO(dijkstra): encodeBlock Alonzo"
 
 encodeContextError
     :: Al.AlonzoContextError era
@@ -181,28 +155,9 @@ encodeExBudget budget =
 encodeGenesis
     :: Al.AlonzoGenesis
     -> Json
-encodeGenesis x =
-    encodeObject
-        ( "era" .= encodeText "alonzo"
-       <> "updatableParameters" .= encodeObject
-            ( "minUtxoDepositCoefficient" .=
-                (encodeInteger . (`div` 8) . unCoin . Al.unCoinPerWord) (Al.agCoinsPerUTxOWord x) <>
-              "plutusCostModels" .=
-                  encodeCostModels (Al.agCostModels x) <>
-              "scriptExecutionPrices" .=
-                  encodePrices (Al.agPrices x) <>
-              "maxExecutionUnitsPerTransaction" .=
-                  encodeExUnits (Al.agMaxTxExUnits x) <>
-              "maxExecutionUnitsPerBlock" .=
-                  encodeExUnits (Al.agMaxBlockExUnits x) <>
-              "maxValueSize" .=
-                  (encodeSingleton "bytes" . encodeNatural) (Al.agMaxValSize x) <>
-              "collateralPercentage" .=
-                  encodeNatural (Al.agCollateralPercentage x) <>
-              "maxCollateralInputs" .=
-                    encodeNatural (Al.agMaxCollateralInputs x)
-            )
-        )
+encodeGenesis _ =
+    -- TODO(dijkstra): AlonzoGenesis field types changed (Maybe CostModels, Word32 vs Natural, separate AlonzoExtraConfig); needs rewrite.
+    error "TODO(dijkstra): encodeGenesis Alonzo"
 
 encodeIsValid
     :: Al.IsValid
@@ -295,58 +250,9 @@ encodePParamsHKD
     -> (Integer -> Sh.HKD f Integer)
     -> Al.AlonzoPParams f era
     -> Json
-encodePParamsHKD encode pure_ x =
-    encode "minFeeCoefficient"
-        (encodeInteger . unCoin) (Al.appMinFeeA x) <>
-    encode "minFeeConstant"
-        encodeCoin (Al.appMinFeeB x) <>
-    encode "maxBlockBodySize"
-        (encodeSingleton "bytes" . encodeWord32) (Al.appMaxBBSize x) <>
-    encode "maxBlockHeaderSize"
-        (encodeSingleton "bytes" . encodeWord16) (Al.appMaxBHSize x) <>
-    encode "maxTransactionSize"
-        (encodeSingleton "bytes" . encodeWord32) (Al.appMaxTxSize x) <>
-    encode "stakeCredentialDeposit"
-        encodeCoin (Al.appKeyDeposit x) <>
-    encode "stakePoolDeposit"
-        encodeCoin (Al.appPoolDeposit x) <>
-    encode "stakePoolRetirementEpochBound"
-        encodeEpochInterval (Al.appEMax x) <>
-    encode "desiredNumberOfStakePools"
-        encodeWord16 (Al.appNOpt x) <>
-    encode "stakePoolPledgeInfluence"
-        encodeNonNegativeInterval (Al.appA0 x) <>
-    encode "monetaryExpansion"
-        encodeUnitInterval (Al.appRho x) <>
-    encode "treasuryExpansion"
-        encodeUnitInterval (Al.appTau x) <>
-    encode "federatedBlockProductionRatio"
-        encodeUnitInterval (Al.appD x) <>
-    encode "extraEntropy"
-        Shelley.encodeNonce (Al.appExtraEntropy x) <>
-    encode "minStakePoolCost"
-        encodeCoin (Al.appMinPoolCost x) <>
-    encode "minUtxoDepositConstant"
-        (encodeCoin . Coin) (pure_ 0) <>
-    encode "minUtxoDepositCoefficient"
-        (encodeInteger . (`div` 8) . unCoin . Al.unCoinPerWord) (Al.appCoinsPerUTxOWord x) <>
-    encode "plutusCostModels"
-        encodeCostModels (Al.appCostModels x) <>
-    encode "scriptExecutionPrices"
-        encodePrices (Al.appPrices x) <>
-    encode "maxExecutionUnitsPerTransaction"
-        (encodeExUnits . Al.unOrdExUnits) (Al.appMaxTxExUnits x) <>
-    encode "maxExecutionUnitsPerBlock"
-        (encodeExUnits . Al.unOrdExUnits) (Al.appMaxBlockExUnits x) <>
-    encode "maxValueSize"
-        (encodeSingleton "bytes" . encodeNatural) (Al.appMaxValSize x) <>
-    encode "collateralPercentage"
-        encodeNatural (Al.appCollateralPercentage x) <>
-    encode "maxCollateralInputs"
-        encodeNatural (Al.appMaxCollateralInputs x) <>
-    encode "version"
-        Shelley.encodeProtVer (Al.appProtocolVersion x)
-    & encodeObject
+encodePParamsHKD _ _ _ =
+    -- TODO(dijkstra): AlonzoPParams HKD layout changed in cardano-ledger-alonzo 1.15.0 — Compact Coin fields, Word32/Word16 vs Natural mismatches.
+    error "TODO(dijkstra): encodePParamsHKD Alonzo"
 
 encodePrices
     :: Al.Prices
@@ -389,22 +295,9 @@ encodeScript
     => IncludeCbor
     -> Al.Script era
     -> Json
-encodeScript opts = encodeObject . \case
-    Al.TimelockScript nativeScript ->
-        "language" .=
-            encodeText "native" <>
-        "json" .=
-            Allegra.encodeTimelock nativeScript <>
-        if includeScriptCbor opts then
-            "cbor" .=
-                encodeByteStringBase16 (Ledger.originalBytes nativeScript)
-        else
-            mempty
-    Al.PlutusScript script ->
-        "language" .=
-            encodeText (stringifyLanguage (Al.plutusScriptLanguage script)) <>
-        "cbor" .=
-            encodeByteStringBase16 (Ledger.originalBytes (Al.plutusScriptBinary script))
+encodeScript _opts _ =
+    -- TODO(dijkstra): Al.TimelockScript constructor removed in cardano-ledger-alonzo 1.15.0.
+    encodeObject (error "TODO(dijkstra): encodeScript Alonzo")
 
 encodeScriptPurposeIndex
     :: Al.AlonzoPlutusPurpose Ledger.AsIx era
@@ -463,19 +356,19 @@ encodeScriptPurposeItem = fmap encodeObject . \case
 
 encodeTx
     :: (MetadataFormat, IncludeCbor)
-    -> Al.AlonzoTx AlonzoEra
+    -> Al.AlonzoTx Ledger.TopTx AlonzoEra
     -> Json
 encodeTx (fmt, opts) x =
     encodeObject
-        ( Shelley.encodeTxId (Ledger.txIdTxBody @AlonzoEra (Al.body x))
+        ( Shelley.encodeTxId (Ledger.txIdTxBody @AlonzoEra (Al.atBody x))
        <>
-        "spends" .= encodeIsValid (Al.isValid x)
+        "spends" .= encodeIsValid (Al.atIsValid x)
        <>
-        encodeTxBody (Al.body x) (strictMaybe mempty (Map.keys . snd) auxiliary)
+        encodeTxBody (Al.atBody x) (strictMaybe mempty (Map.keys . snd) auxiliary)
        <>
         "metadata" .=? OmitWhenNothing fst auxiliary
        <>
-        encodeWitnessSet opts (snd <$> auxiliary) encodeScriptPurposeIndex (Al.wits x)
+        encodeWitnessSet opts (snd <$> auxiliary) encodeScriptPurposeIndex (Al.atWits x)
        <>
         if includeTransactionCbor opts then
            "cbor" .= encodeByteStringBase16 (encodeCbor @AlonzoEra x)
@@ -484,15 +377,15 @@ encodeTx (fmt, opts) x =
        )
   where
     auxiliary = do
-        hash <- Shelley.encodeAuxiliaryDataHash <$> Al.atbAuxDataHash (Al.body x)
-        (labels, scripts) <- encodeAuxiliaryData (fmt, opts) <$> Al.auxiliaryData x
+        hash <- Shelley.encodeAuxiliaryDataHash <$> Al.atbAuxDataHash (Al.atBody x)
+        (labels, scripts) <- encodeAuxiliaryData (fmt, opts) <$> Al.atAuxData x
         pure
             ( encodeObject ("hash" .= hash <> "labels" .= labels)
             , scripts
             )
 
 encodeTxBody
-    :: Al.AlonzoTxBody AlonzoEra
+    :: Ledger.TxBody Ledger.TopTx AlonzoEra
     -> [Ledger.ScriptHash]
     -> Series
 encodeTxBody x scripts =

--- a/server/src/Ogmios/Data/Json/Babbage.hs
+++ b/server/src/Ogmios/Data/Json/Babbage.hs
@@ -2,6 +2,9 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+-- TODO(dijkstra): warnings disabled while encoders are stubbed.
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-incomplete-patterns -Wno-unused-matches -Wno-unused-top-binds -Wno-redundant-constraints -Wno-deprecations #-}
+
 module Ogmios.Data.Json.Babbage where
 
 import Ogmios.Data.Json.Prelude
@@ -40,7 +43,7 @@ import qualified Cardano.Ledger.Mary.Value as Ma
 
 import qualified Cardano.Ledger.Alonzo.PParams as Al
 import qualified Cardano.Ledger.Alonzo.Scripts as Al
-import qualified Cardano.Ledger.Alonzo.TxSeq as Al
+import qualified Cardano.Ledger.Alonzo.BlockBody as Al
 
 import qualified Cardano.Ledger.Babbage.Core as Ba
 import qualified Cardano.Ledger.Babbage.PParams as Ba
@@ -59,18 +62,9 @@ encodeBlock
     :: (MetadataFormat, IncludeCbor)
     -> ShelleyBlock (Praos StandardCrypto) BabbageEra
     -> Json
-encodeBlock opts (ShelleyBlock (Ledger.Block blkHeader txs) headerHash) =
-    encodeObject
-        ( "type" .= encodeText "praos"
-        <>
-          "era" .= encodeText "babbage"
-        <>
-          "id" .= Shelley.encodeShelleyHash headerHash
-        <>
-          encodeHeader blkHeader
-        <>
-          "transactions" .= encodeFoldable (encodeTx opts) (Al.txSeqTxns txs)
-        )
+encodeBlock _ _ =
+    -- TODO(dijkstra): alonzoBlockBodyTxs yields generic Tx, not AlonzoTx — needs lens-based shape.
+    error "TODO(dijkstra): encodeBlock Babbage"
 
 encodeContextError
     :: ( Ba.PlutusPurpose AsIx era ~ Al.AlonzoPlutusPurpose AsIx era
@@ -204,70 +198,25 @@ encodePParamsHKD
     -> (Integer -> Sh.HKD f Integer)
     -> Ba.BabbagePParams f era
     -> Json
-encodePParamsHKD encode pure_ x =
-    encode "minFeeCoefficient"
-        (encodeInteger . unCoin) (Ba.bppMinFeeA x) <>
-    encode "minFeeConstant"
-        encodeCoin (Ba.bppMinFeeB x) <>
-    encode "maxBlockBodySize"
-        (encodeSingleton "bytes" . encodeWord32) (Ba.bppMaxBBSize x) <>
-    encode "maxBlockHeaderSize"
-        (encodeSingleton "bytes" . encodeWord16) (Ba.bppMaxBHSize x) <>
-    encode "maxTransactionSize"
-        (encodeSingleton "bytes" . encodeWord32) (Ba.bppMaxTxSize x) <>
-    encode "stakeCredentialDeposit"
-        encodeCoin (Ba.bppKeyDeposit x) <>
-    encode "stakePoolDeposit"
-        encodeCoin (Ba.bppPoolDeposit x) <>
-    encode "stakePoolRetirementEpochBound"
-        encodeEpochInterval (Ba.bppEMax x) <>
-    encode "desiredNumberOfStakePools"
-        encodeWord16 (Ba.bppNOpt x) <>
-    encode "stakePoolPledgeInfluence"
-        encodeNonNegativeInterval (Ba.bppA0 x) <>
-    encode "monetaryExpansion"
-        encodeUnitInterval (Ba.bppRho x) <>
-    encode "treasuryExpansion"
-        encodeUnitInterval (Ba.bppTau x) <>
-    encode "minStakePoolCost"
-        encodeCoin (Ba.bppMinPoolCost x) <>
-    encode "minUtxoDepositConstant"
-        (encodeCoin . Coin) (pure_ 0) <>
-    encode "minUtxoDepositCoefficient"
-        (encodeInteger . unCoin . Ba.unCoinPerByte) (Ba.bppCoinsPerUTxOByte x) <>
-    encode "plutusCostModels"
-        Alonzo.encodeCostModels (Ba.bppCostModels x) <>
-    encode "scriptExecutionPrices"
-        Alonzo.encodePrices (Ba.bppPrices x) <>
-    encode "maxExecutionUnitsPerTransaction"
-        (Alonzo.encodeExUnits . Al.unOrdExUnits) (Ba.bppMaxTxExUnits x) <>
-    encode "maxExecutionUnitsPerBlock"
-        (Alonzo.encodeExUnits . Al.unOrdExUnits) (Ba.bppMaxBlockExUnits x) <>
-    encode "maxValueSize"
-        (encodeSingleton "bytes" . encodeNatural) (Ba.bppMaxValSize x) <>
-    encode "collateralPercentage"
-        encodeNatural (Ba.bppCollateralPercentage x) <>
-    encode "maxCollateralInputs"
-        encodeNatural (Ba.bppMaxCollateralInputs x) <>
-    encode "version"
-        Shelley.encodeProtVer (Ba.bppProtocolVersion x)
-    & encodeObject
+encodePParamsHKD _ _ _ =
+    -- TODO(dijkstra): BabbagePParams HKD layout changed (Compact Coin / Word32 vs Natural mismatches).
+    error "TODO(dijkstra): encodePParamsHKD Babbage"
 
 encodeTx
     :: (MetadataFormat, IncludeCbor)
-    -> Ba.AlonzoTx BabbageEra
+    -> Ba.AlonzoTx Ledger.TopTx BabbageEra
     -> Json
 encodeTx (fmt, opts) x =
     encodeObject
-        ( Shelley.encodeTxId (Ledger.txIdTxBody @BabbageEra (Ba.body x))
+        ( Shelley.encodeTxId (Ledger.txIdTxBody @BabbageEra (Ba.atBody x))
        <>
-        "spends" .= Alonzo.encodeIsValid (Ba.isValid x)
+        "spends" .= Alonzo.encodeIsValid (Ba.atIsValid x)
        <>
-        encodeTxBody opts (Ba.body x) (strictMaybe mempty (Map.keys . snd) auxiliary)
+        encodeTxBody opts (Ba.atBody x) (strictMaybe mempty (Map.keys . snd) auxiliary)
        <>
         "metadata" .=? OmitWhenNothing fst auxiliary
        <>
-        Alonzo.encodeWitnessSet opts (snd <$> auxiliary) Alonzo.encodeScriptPurposeIndex (Ba.wits x)
+        Alonzo.encodeWitnessSet opts (snd <$> auxiliary) Alonzo.encodeScriptPurposeIndex (Ba.atWits x)
        <>
         if includeTransactionCbor opts then
            "cbor" .= encodeByteStringBase16 (encodeCbor @BabbageEra x)
@@ -276,8 +225,8 @@ encodeTx (fmt, opts) x =
        )
   where
     auxiliary = do
-        hash <- Shelley.encodeAuxiliaryDataHash <$> Ba.btbAuxDataHash (Ba.body x)
-        (labels, scripts) <- Alonzo.encodeAuxiliaryData (fmt, opts) <$> Ba.auxiliaryData x
+        hash <- Shelley.encodeAuxiliaryDataHash <$> Ba.btbAuxDataHash (Ba.atBody x)
+        (labels, scripts) <- Alonzo.encodeAuxiliaryData (fmt, opts) <$> Ba.atAuxData x
         pure
             ( encodeObject ("hash" .= hash <> "labels" .= labels)
             , scripts
@@ -285,7 +234,7 @@ encodeTx (fmt, opts) x =
 
 encodeTxBody
     :: IncludeCbor
-    -> Ba.BabbageTxBody BabbageEra
+    -> Ledger.TxBody Ledger.TopTx BabbageEra
     -> [Ledger.ScriptHash]
     -> Series
 encodeTxBody opts x scripts =

--- a/server/src/Ogmios/Data/Json/Conway.hs
+++ b/server/src/Ogmios/Data/Json/Conway.hs
@@ -3,6 +3,9 @@
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 {-# LANGUAGE TypeOperators #-}
 
+-- TODO(dijkstra): warnings disabled while encoders are stubbed.
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-incomplete-patterns -Wno-unused-matches -Wno-unused-top-binds -Wno-redundant-constraints -Wno-deprecations #-}
+
 module Ogmios.Data.Json.Conway where
 
 import Ogmios.Data.Json.Prelude
@@ -51,7 +54,7 @@ import qualified Cardano.Ledger.HKD as Ledger
 import qualified Cardano.Ledger.Shelley.PParams as Sh
 
 import qualified Cardano.Ledger.Alonzo.PParams as Al
-import qualified Cardano.Ledger.Alonzo.TxSeq as Al
+import qualified Cardano.Ledger.Alonzo.BlockBody as Al
 
 import qualified Cardano.Ledger.Babbage.Core as Ba
 import qualified Cardano.Ledger.Babbage.Tx as Ba
@@ -92,18 +95,9 @@ encodeBlock
     :: (MetadataFormat, IncludeCbor)
     -> ShelleyBlock (Praos StandardCrypto) ConwayEra
     -> Json
-encodeBlock opts (ShelleyBlock (Ledger.Block blkHeader txs) headerHash) =
-    encodeObject
-        ( "type" .= encodeText "praos"
-        <>
-          "era" .= encodeText "conway"
-        <>
-          "id" .= Shelley.encodeShelleyHash headerHash
-        <>
-          Babbage.encodeHeader blkHeader
-        <>
-          "transactions" .= encodeFoldable (encodeTx opts) (Al.txSeqTxns txs)
-        )
+encodeBlock _ _ =
+    -- TODO(dijkstra): alonzoBlockBodyTxs yields generic Tx, not AlonzoTx.
+    error "TODO(dijkstra): encodeBlock Conway"
 
 encodeCommittee
     :: Cn.Committee ConwayEra
@@ -126,7 +120,7 @@ encodeCommitteeMembersState x = encodeObject
     )
 
 encodeConstitutionalCommitteeMemberState
-    :: Ledger.Credential 'ColdCommitteeRole
+    :: Ledger.Credential ColdCommitteeRole
     -> Cn.CommitteeMemberState
     -> Json
 encodeConstitutionalCommitteeMemberState memberId st = encodeObject
@@ -247,10 +241,11 @@ encodeConstitution x =
     "guardrails" .=
         encodeStrictMaybe
             (\s -> encodeObject ("hash" .= Shelley.encodeScriptHash s))
-            (Cn.constitutionScript x)
+            -- TODO(dijkstra): constitutionScript → constitutionScriptL lens
+            (error "TODO(dijkstra): constitutionScript renamed to constitutionScriptL lens in cardano-ledger-conway 1.22.1")
 
 encodeConstitutionalCommitteeMember
-    :: Ledger.Credential 'ColdCommitteeRole
+    :: Ledger.Credential ColdCommitteeRole
     -> StrictMaybe EpochNo
     -> Json
 encodeConstitutionalCommitteeMember memberId mandate =
@@ -536,94 +531,9 @@ encodePParamsHKD
     -> (forall a. a -> Ledger.HKD f a)
     -> Cn.ConwayPParams f era
     -> Json
-encodePParamsHKD encode pure_ x =
-    encode "minFeeCoefficient"
-        (encodeInteger . unCoin) (unTHKD (Cn.cppMinFeeA x)) <>
-    encode "minFeeConstant"
-        encodeCoin (unTHKD (Cn.cppMinFeeB x)) <>
-    encode "minFeeReferenceScripts"
-        (\(base :: NonNegativeInterval) -> encodeObject
-            -- NOTE: This will very likely always be an integer. The ledger
-            -- represent this as a 'NonNegativeInterval', which technically
-            -- allow any _Rational_ value between 0 and +INFINITY, but it is
-            -- highly impractical to manipulate a Rationale here from an API
-            -- standpoint.
-            --
-            -- So this is a debatable choice, but I believe it's better for
-            -- users to convert to a Double so that it is directly a number in
-            -- JSON, and we can still accomodate decimal representation so long
-            -- as they don't get _too precise_ (which should be a fair
-            -- assumption in this context).
-            ( "base" .= encodeDouble (fromRational (unboundRational base))
-            <>
-              "range" .= encodeWord32 25600
-            <>
-              "multiplier" .= encodeDouble 1.2
-            )
-        )
-        (unTHKD (Cn.cppMinFeeRefScriptCostPerByte x))
-        <>
-    encode "maxBlockBodySize"
-        (encodeSingleton "bytes" . encodeWord32) (unTHKD (Cn.cppMaxBBSize x)) <>
-    encode "maxBlockHeaderSize"
-        (encodeSingleton "bytes" . encodeWord16) (unTHKD (Cn.cppMaxBHSize x)) <>
-    encode "maxTransactionSize"
-        (encodeSingleton "bytes" . encodeWord32) (unTHKD (Cn.cppMaxTxSize x)) <>
-    encode "maxReferenceScriptsSize"
-        (encodeSingleton "bytes" . encodeWord32) (pure_ @Word32 204800) <> -- NOTE: Hard-coded in Conway.
-    encode "stakeCredentialDeposit"
-        encodeCoin (unTHKD (Cn.cppKeyDeposit x)) <>
-    encode "stakePoolDeposit"
-        encodeCoin (unTHKD (Cn.cppPoolDeposit x)) <>
-    encode "stakePoolRetirementEpochBound"
-        encodeEpochInterval (unTHKD (Cn.cppEMax x)) <>
-    encode "desiredNumberOfStakePools"
-        encodeWord16 (unTHKD (Cn.cppNOpt x)) <>
-    encode "stakePoolPledgeInfluence"
-        encodeNonNegativeInterval (unTHKD (Cn.cppA0 x)) <>
-    encode "monetaryExpansion"
-        encodeUnitInterval (unTHKD (Cn.cppRho x)) <>
-    encode "treasuryExpansion"
-        encodeUnitInterval (unTHKD (Cn.cppTau x)) <>
-    encode "minStakePoolCost"
-        encodeCoin (unTHKD (Cn.cppMinPoolCost x)) <>
-    encode "minUtxoDepositConstant"
-        encodeCoin (pure_ (Coin 0)) <>
-    encode "minUtxoDepositCoefficient"
-        (encodeInteger . unCoin . Ba.unCoinPerByte) (unTHKD (Cn.cppCoinsPerUTxOByte x)) <>
-    encode "plutusCostModels"
-        Alonzo.encodeCostModels (unTHKD (Cn.cppCostModels x)) <>
-    encode "scriptExecutionPrices"
-        Alonzo.encodePrices (unTHKD (Cn.cppPrices x)) <>
-    encode "maxExecutionUnitsPerTransaction"
-        (Alonzo.encodeExUnits . Al.unOrdExUnits) (unTHKD (Cn.cppMaxTxExUnits x)) <>
-    encode "maxExecutionUnitsPerBlock"
-        (Alonzo.encodeExUnits . Al.unOrdExUnits) (unTHKD (Cn.cppMaxBlockExUnits x)) <>
-    encode "maxValueSize"
-        (encodeSingleton "bytes" . encodeWord32) (unTHKD (Cn.cppMaxValSize x)) <>
-    encode "collateralPercentage"
-        encodeWord16 (unTHKD (Cn.cppCollateralPercentage x)) <>
-    encode "maxCollateralInputs"
-        encodeWord16 (unTHKD (Cn.cppMaxCollateralInputs x)) <>
-    encode "version"
-        Shelley.encodeProtVer (fromNoUpdate @f @ProtVer (Cn.cppProtocolVersion x)) <>
-    encode "stakePoolVotingThresholds"
-        encodePoolVotingThresholds (unTHKD (Cn.cppPoolVotingThresholds x)) <>
-    encode "delegateRepresentativeVotingThresholds"
-        encodeDRepVotingThresholds (unTHKD (Cn.cppDRepVotingThresholds x)) <>
-    encode "constitutionalCommitteeMinSize"
-        encodeWord16 (unTHKD (Cn.cppCommitteeMinSize x)) <>
-    encode "constitutionalCommitteeMaxTermLength"
-        encodeEpochInterval (unTHKD (Cn.cppCommitteeMaxTermLength x)) <>
-    encode "governanceActionLifetime"
-        encodeEpochInterval (unTHKD (Cn.cppGovActionLifetime x)) <>
-    encode "governanceActionDeposit"
-        encodeCoin (unTHKD (Cn.cppGovActionDeposit x)) <>
-    encode "delegateRepresentativeDeposit"
-        encodeCoin (unTHKD (Cn.cppDRepDeposit x)) <>
-    encode "delegateRepresentativeMaxIdleTime"
-        encodeEpochInterval (unTHKD (Cn.cppDRepActivity x))
-    & encodeObject
+encodePParamsHKD _ _ _ =
+    -- TODO(dijkstra): ConwayPParams HKD field types changed in cardano-ledger-conway 1.22.1 (CompactForm Coin etc.).
+    error "TODO(dijkstra): encodePParamsHKD Conway"
 
 encodeDRepVotingThresholds :: Cn.DRepVotingThresholds -> Json
 encodeDRepVotingThresholds x =
@@ -734,19 +644,19 @@ encodeScriptPurposeItem = encodeObject . \case
 
 encodeTx
     :: (MetadataFormat, IncludeCbor)
-    -> Ba.AlonzoTx ConwayEra
+    -> Ba.AlonzoTx Ledger.TopTx ConwayEra
     -> Json
 encodeTx (fmt, opts) x =
     encodeObject
-        ( Shelley.encodeTxId (Ledger.txIdTxBody @ConwayEra (Cn.body x))
+        ( Shelley.encodeTxId (Ledger.txIdTxBody @ConwayEra (Cn.atBody x))
        <>
-        "spends" .= Alonzo.encodeIsValid (Cn.isValid x)
+        "spends" .= Alonzo.encodeIsValid (Cn.atIsValid x)
        <>
-        encodeTxBody opts (Cn.body x) (strictMaybe mempty (Map.keys . snd) auxiliary)
+        encodeTxBody opts (Cn.atBody x) (strictMaybe mempty (Map.keys . snd) auxiliary)
        <>
         "metadata" .=? OmitWhenNothing fst auxiliary
        <>
-        Alonzo.encodeWitnessSet opts (snd <$> auxiliary) encodeScriptPurposeIndex (Cn.wits x)
+        Alonzo.encodeWitnessSet opts (snd <$> auxiliary) encodeScriptPurposeIndex (Cn.atWits x)
        <>
         if includeTransactionCbor opts then
            "cbor" .= encodeByteStringBase16 (encodeCbor @ConwayEra x)
@@ -755,8 +665,8 @@ encodeTx (fmt, opts) x =
         )
   where
     auxiliary = do
-        hash <- Shelley.encodeAuxiliaryDataHash <$> Cn.ctbAdHash (Cn.body x)
-        (labels, scripts) <- Alonzo.encodeAuxiliaryData (fmt, opts) <$> Ba.auxiliaryData x
+        hash <- Shelley.encodeAuxiliaryDataHash <$> Cn.ctbAdHash (Cn.atBody x)
+        (labels, scripts) <- Alonzo.encodeAuxiliaryData (fmt, opts) <$> Ba.atAuxData x
         pure
             ( encodeObject ("hash" .= hash <> "labels" .= labels)
             , scripts
@@ -764,7 +674,7 @@ encodeTx (fmt, opts) x =
 
 encodeTxBody
     :: IncludeCbor
-    -> Cn.ConwayTxBody ConwayEra
+    -> Ledger.TxBody Ledger.TopTx ConwayEra
     -> [Ledger.ScriptHash]
     -> Series
 encodeTxBody opts x scripts =

--- a/server/src/Ogmios/Data/Json/Mary.hs
+++ b/server/src/Ogmios/Data/Json/Mary.hs
@@ -2,6 +2,9 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+-- TODO(dijkstra): warnings disabled while encodeTx is stubbed.
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-unused-matches -Wno-unused-top-binds #-}
+
 module Ogmios.Data.Json.Mary where
 
 import Ogmios.Data.Json.Prelude
@@ -23,7 +26,7 @@ import qualified Cardano.Ledger.Address as Ledger
 import qualified Cardano.Ledger.Block as Ledger
 import qualified Cardano.Ledger.Core as Ledger
 
-import qualified Cardano.Ledger.Shelley.BlockChain as Sh
+import qualified Cardano.Ledger.Shelley.BlockBody as Sh
 import qualified Cardano.Ledger.Shelley.Tx as Sh
 import qualified Cardano.Ledger.Shelley.TxOut as Sh
 import qualified Cardano.Ledger.Shelley.TxWits as Sh
@@ -69,7 +72,7 @@ encodeBlock opts (ShelleyBlock (Ledger.Block blkHeader txs) headerHash) =
         <>
           "size" .= encodeSingleton "bytes" (encodeWord32 (TPraos.bsize hBody))
         <>
-          "transactions" .= encodeFoldable (encodeTx opts) (Sh.txSeqTxns' txs)
+          "transactions" .= encodeFoldable (encodeTx opts) (Sh.shelleyBlockBodyTxs txs)
         )
   where
     TPraos.BHeader hBody _ = blkHeader
@@ -91,36 +94,14 @@ encodePolicyId (Ma.PolicyID hash) =
 
 encodeTx
     :: (MetadataFormat, IncludeCbor)
-    -> Sh.ShelleyTx MaryEra
+    -> Sh.Tx Ledger.TopTx MaryEra
     -> Json
-encodeTx (fmt, opts) x =
-    encodeObject
-        ( Shelley.encodeTxId (Ledger.txIdTxBody @MaryEra (Sh.body x))
-       <>
-        "spends" .= encodeText "inputs"
-       <>
-        encodeTxBody (Sh.body x) (strictMaybe mempty (Map.keys . snd) auxiliary)
-       <>
-        "metadata" .=? OmitWhenNothing fst auxiliary
-       <>
-        encodeWitnessSet opts (snd <$> auxiliary) (Sh.wits x)
-       <>
-        if includeTransactionCbor opts then
-           "cbor" .= encodeByteStringBase16 (encodeCbor @MaryEra x)
-        else
-           mempty
-       )
-  where
-    auxiliary = do
-        hash <- Shelley.encodeAuxiliaryDataHash <$> Ma.mtbAuxDataHash (Sh.body x)
-        (labels, scripts) <- encodeAuxiliaryData (fmt, opts) <$> Sh.auxiliaryData x
-        pure
-            ( encodeObject ("hash" .= hash <> "labels" .= labels)
-            , scripts
-            )
+encodeTx _ _ =
+    -- TODO(dijkstra): same as Allegra — rewrite using lenses; Sh.MkShelleyTx pattern doesn't unify with MaryEra in cardano-ledger 1.20.
+    error "TODO(dijkstra): encodeTx Mary"
 
 encodeTxBody
-    :: Ma.MaryTxBody MaryEra
+    :: Ledger.TxBody Ledger.TopTx MaryEra
     -> [Ledger.ScriptHash]
     -> Series
 encodeTxBody (Ma.MaryTxBody inps outs dCerts wdrls fee validity updates _ mint) scripts =

--- a/server/src/Ogmios/Data/Json/Orphans.hs
+++ b/server/src/Ogmios/Data/Json/Orphans.hs
@@ -8,6 +8,9 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
+-- TODO(dijkstra): warnings suppressed during dep migration.
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-incomplete-patterns -Wno-unused-matches -Wno-unused-top-binds -Wno-redundant-constraints -Wno-deprecations -Wno-orphans #-}
+
 module Ogmios.Data.Json.Orphans () where
 
 import Ogmios.Data.Json.Prelude
@@ -76,7 +79,7 @@ instance ToJSON (Tip (CardanoBlock crypto)) where
     toEncoding = encodeTip
 
 -- Only used for logging & health
-instance ToJSON (Point (CardanoBlock crypto)) where
+instance {-# OVERLAPPING #-} ToJSON (Point (CardanoBlock crypto)) where
     toJSON = inefficientEncodingToValue . encodePoint
     toEncoding = encodePoint
 
@@ -91,7 +94,7 @@ instance FromJSON (MultiEraDecoder (GenTx (CardanoBlock StandardCrypto))) where
 instance FromJSON (MultiEraUTxO (CardanoBlock crypto)) where
     parseJSON = decodeUtxo
 
-instance FromJSON (Point (CardanoBlock crypto)) where
+instance {-# OVERLAPPING #-} FromJSON (Point (CardanoBlock crypto)) where
     parseJSON = decodePoint
 
 instance FromJSON (Tip (CardanoBlock crypto)) where

--- a/server/src/Ogmios/Data/Json/Query.hs
+++ b/server/src/Ogmios/Data/Json/Query.hs
@@ -6,6 +6,9 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE QuasiQuotes #-}
 
+-- TODO(dijkstra): warnings disabled while assorted accessor/constructor renames cascade through Query.hs.
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-incomplete-patterns -Wno-unused-matches -Wno-unused-top-binds -Wno-redundant-constraints -Wno-deprecations -Wno-dodgy-imports -Wno-dodgy-exports #-}
+
 module Ogmios.Data.Json.Query
     ( -- * Types
       Query (..)
@@ -23,7 +26,7 @@ module Ogmios.Data.Json.Query
     , Deposits
     , GenesisConfig
     , Interpreter
-    , Ledger.PoolParams
+    , Ledger.StakePoolParams
     , PoolRewardsInfo (..)
     , RewardAccountSummaries
     , RewardAccountSummary (..)
@@ -309,7 +312,7 @@ import qualified Cardano.Ledger.Hashes as Ledger
 import qualified Cardano.Ledger.Mary.Value as Ledger.Mary
 import qualified Cardano.Ledger.Plutus.Data as Ledger.Plutus
 import qualified Cardano.Ledger.Plutus.Language as Ledger.Plutus
-import qualified Cardano.Ledger.PoolParams as Ledger
+import qualified Cardano.Ledger.State as Ledger
 import qualified Cardano.Ledger.Shelley.Scripts as Ledger.Shelley
 import qualified Cardano.Ledger.State as Ledger
 import qualified Cardano.Ledger.TxIn as Ledger
@@ -498,35 +501,35 @@ type GenResult crypto f t =
     Proxy (QueryResult crypto t) -> f (QueryResult crypto t)
 
 type Delegations =
-    Map (Ledger.Credential 'Staking) (Ledger.KeyHash 'StakePool)
+    Map (Ledger.Credential Staking) (Ledger.KeyHash StakePool)
 
 type Deposits =
-    Map (Ledger.Credential 'Staking ) Coin
+    Map (Ledger.Credential Staking ) Coin
 
 type VoteDelegatees =
-    Map (Ledger.Credential 'Staking) Ledger.DRep
+    Map (Ledger.Credential Staking) Ledger.DRep
 
 type RewardAccounts =
-    Map (Ledger.Credential 'Staking) Coin
+    Map (Ledger.Credential Staking) Coin
 
 type RewardAccountSummaries =
-    Map (Ledger.Credential 'Staking) RewardAccountSummary
+    Map (Ledger.Credential Staking) RewardAccountSummary
 
 type StakePoolsPerformances =
     ( Sh.Api.RewardParams
-    , Map (Ledger.KeyHash 'StakePool) Sh.Api.RewardInfoPool
+    , Map (Ledger.KeyHash StakePool) Sh.Api.RewardInfoPool
     )
 
 data RewardAccountSummary = RewardAccountSummary
-    { poolDelegate :: !(StrictMaybe (Ledger.KeyHash 'StakePool))
+    { poolDelegate :: !(StrictMaybe (Ledger.KeyHash StakePool))
     , drepDelegate :: !(StrictMaybe Ledger.DRep)
     , rewards :: !Coin
     , deposit :: !Coin
     } deriving (Eq, Show, Generic)
 
 data DRepSummary
-    = AlwaysAbstain Coin (Set (Ledger.Credential 'Staking))
-    | AlwaysNoConfidence Coin (Set (Ledger.Credential 'Staking))
+    = AlwaysAbstain Coin (Set (Ledger.Credential Staking))
+    | AlwaysNoConfidence Coin (Set (Ledger.Credential Staking))
     | Registered Coin Ledger.DRepState
     deriving (Eq, Show, Generic)
 
@@ -535,13 +538,13 @@ data DRepSummary
 --
 
 encodeAccountState
-    :: AccountState
+    :: Ledger.ChainAccountState
     -> Json
 encodeAccountState st =
     "treasury" .=
-        encodeCoin (asTreasury st) <>
+        encodeCoin (Ledger.casTreasury st) <>
     "reserves" .=
-        encodeCoin (asReserves st)
+        encodeCoin (Ledger.casReserves st)
     & encodeObject
 
 encodeBound
@@ -698,7 +701,7 @@ encodePoolDistr =
         & encodeObject
 
 encodeRewardInfoPool
-    :: Ledger.KeyHash 'StakePool
+    :: Ledger.KeyHash StakePool
     -> Sh.Api.RewardInfoPool
     -> Json
 encodeRewardInfoPool poolId info =
@@ -815,8 +818,8 @@ deserialisePartialNewEpochState (Serialised bytes) =
     decodePartialLedgerState
         :: forall s. ()
         => StateT
-            ( Binary.Interns (Ledger.Credential 'Staking)
-            , Binary.Interns (Ledger.KeyHash 'StakePool)
+            ( Binary.Interns (Ledger.Credential Staking)
+            , Binary.Interns (Ledger.KeyHash StakePool)
             , Binary.Interns (Ledger.Credential DRepRole)
             , Binary.Interns (Ledger.Credential HotCommitteeRole)
             )
@@ -847,7 +850,7 @@ encodeSafeZone = \case
         encodeNull
 
 encodeStakePools
-    :: Map (Ledger.KeyHash 'StakePool) (Maybe Ledger.PoolParams, StrictMaybe Coin)
+    :: Map (Ledger.KeyHash StakePool) (Maybe Ledger.StakePoolParams, StrictMaybe Coin)
     -> Json
 encodeStakePools =
     encodeObject . encodeMapSeries Shelley.stringifyPoolId (\k (params, stake) ->
@@ -980,7 +983,7 @@ parseQueryLedgerDelegateRepresentatives genResult =
         . Map.alter (<|> Just (AlwaysNoConfidence mempty Set.empty)) Ledger.DRepAlwaysNoConfidence
 
     mergeAll
-        :: Map Ledger.DRep (Set (Ledger.Credential 'Staking))
+        :: Map Ledger.DRep (Set (Ledger.Credential Staking))
         -> Map Ledger.DRep Ledger.DRepState
         -> Map Ledger.DRep Coin
         -> Map Ledger.DRep DRepSummary
@@ -1041,7 +1044,8 @@ parseQueryLedgerDelegateRepresentatives genResult =
               "mandate" .=
                 (encodeSingleton "epoch" . encodeEpochNo) (Ledger.drepExpiry summary)
            <> "deposit" .=
-                encodeCoin (Ledger.drepDeposit summary)
+                -- TODO(dijkstra): drepDeposit now returns CompactForm Coin in cardano-ledger-conway 1.22.1.
+                encodeCoin (error "TODO(dijkstra): drepDeposit CompactForm" :: Coin)
            <> "stake" .=
                 encodeCoin stake
            <> "metadata" .=? OmitWhenNothing
@@ -1165,7 +1169,7 @@ parseQueryLedgerTip genResultInEraTPraos genResultInEraPraos =
 
 parseQueryLedgerTreasuryAndReserves
     :: forall crypto f. ()
-    => GenResult crypto f AccountState
+    => GenResult crypto f Ledger.ChainAccountState
     -> Json.Value
     -> Json.Parser (QueryInEra f (CardanoBlock crypto))
 parseQueryLedgerTreasuryAndReserves genResult =
@@ -1955,8 +1959,8 @@ parseQueryLedgerRewardsProvenance genResult =
 
 parseQueryLedgerStakePools
     :: forall crypto f. ()
-    => GenResult crypto f (Map (Ledger.KeyHash 'StakePool) Ledger.PoolParams)
-    -> GenResult crypto f (Map (Ledger.KeyHash 'StakePool) (Maybe Ledger.PoolParams, StrictMaybe Coin))
+    => GenResult crypto f (Map (Ledger.KeyHash StakePool) Ledger.StakePoolParams)
+    -> GenResult crypto f (Map (Ledger.KeyHash StakePool) (Maybe Ledger.StakePoolParams, StrictMaybe Coin))
     -> Json.Value
     -> Json.Parser (QueryInEra f (CardanoBlock crypto))
 parseQueryLedgerStakePools genResultNoStake genResult =
@@ -1971,9 +1975,9 @@ parseQueryLedgerStakePools genResultNoStake genResult =
     encodeStakePoolsWithoutStake = encodeStakePools . Map.map (\params -> (Just params,SNothing))
 
     mergeDistrAndParams
-        :: Map (Ledger.KeyHash 'StakePool) Coin
-        -> Map (Ledger.KeyHash 'StakePool) Ledger.PoolParams
-        -> Map (Ledger.KeyHash 'StakePool) (Maybe Ledger.PoolParams, StrictMaybe Coin)
+        :: Map (Ledger.KeyHash StakePool) Coin
+        -> Map (Ledger.KeyHash StakePool) Ledger.StakePoolParams
+        -> Map (Ledger.KeyHash StakePool) (Maybe Ledger.StakePoolParams, StrictMaybe Coin)
     mergeDistrAndParams =
         Map.merge
            (Map.mapMissing $ \_ distr -> (Nothing, SJust distr))
@@ -2209,9 +2213,9 @@ decodeCoin = Json.withObject "Lovelace" $ \o -> do
     pure $ Ledger.word64ToCoin lovelace
 
 decodeStakingCredential
-    :: (ByteString -> Json.Parser (Ledger.Credential 'Staking))
+    :: (ByteString -> Json.Parser (Ledger.Credential Staking))
     -> Json.Value
-    -> Json.Parser (Ledger.Credential 'Staking)
+    -> Json.Parser (Ledger.Credential Staking)
 decodeStakingCredential decodeAsKeyOrScript =
     Json.withText "StakingCredential" $ \(encodeUtf8 -> str) -> asum
         [ decodeBase16 str >>=
@@ -2234,7 +2238,7 @@ decodeStakingCredential decodeAsKeyOrScript =
   where
     decodeAsStakeAddress
         :: ByteString
-        -> Json.Parser (Ledger.Credential 'Staking)
+        -> Json.Parser (Ledger.Credential Staking)
     decodeAsStakeAddress =
         fmap Ledger.raCredential
             . maybe invalidStakeAddress pure
@@ -2244,9 +2248,9 @@ decodeStakingCredential decodeAsKeyOrScript =
             fail "invalid stake address"
 
 decodeDRepCredential
-    :: (ByteString -> Json.Parser (Ledger.Credential 'DRepRole))
+    :: (ByteString -> Json.Parser (Ledger.Credential DRepRole))
     -> Json.Value
-    -> Json.Parser (Ledger.Credential 'DRepRole)
+    -> Json.Parser (Ledger.Credential DRepRole)
 decodeDRepCredential decodeAsKeyOrScript =
     Json.withText "DRepCredential" $ \(encodeUtf8 -> str) -> asum
         [ decodeBase16 str >>=
@@ -2350,7 +2354,7 @@ decodePolicyId =
 
 decodePoolId
     :: Json.Value
-    -> Json.Parser (Ledger.KeyHash 'StakePool)
+    -> Json.Parser (Ledger.KeyHash StakePool)
 decodePoolId = Json.withObject "StakePoolId" $ \obj -> do
     txt <- obj .: "id"
     poolIdFromBytes fromBech32 txt <|> poolIdFromBytes fromBase16 txt
@@ -2394,19 +2398,8 @@ decodeScript v =
     decodeFromWrappedJson o = do
         o .:? "language" >>= \case
             Just "native" -> do
-                cbor <- o .:? "cbor" >>= traverse (decodeBase16 . encodeUtf8 @Text)
-                json <- o .:? "json"
-                case (cbor, json) of
-                    (Just bytes, _) -> do
-                        case decodeCborAnn @era "Script<Native>" Binary.decCBOR (toLazy bytes) of
-                            Right script ->
-                                pure (Ledger.Alonzo.TimelockScript script)
-                            Left (_ :: Text) ->
-                                fail "couldn't decode native script"
-                    (_, Just script) ->
-                        Ledger.Alonzo.TimelockScript <$> decodeTimeLock script
-                    (_, _) ->
-                        fail "missing field 'cbor' or 'json' to decode native script"
+                -- TODO(dijkstra): native script decoding needs the replacement for the removed Ledger.Alonzo.TimelockScript constructor in cardano-ledger-alonzo 1.15.0.
+                fail "TODO(dijkstra): native script decoder stubbed"
             Just lang@"plutus:v1" -> do
                 bytes <- o .: "cbor"
                 plutus <- Ledger.Alonzo.mkBinaryPlutusScript Ledger.Plutus.PlutusV1 <$> decodePlutusScript Plutus.PlutusV1 lang bytes
@@ -2475,10 +2468,9 @@ decodeScript v =
         Cbor.decodeBytes
 
 decodeSerializedTransaction
-    :: forall crypto constraint.
+    :: forall crypto.
         ( PraosCrypto crypto
         , TPraos.PraosCrypto crypto
-        , constraint ~ (MostRecentEra (CardanoBlock crypto) ~ ConwayEra)
         , crypto ~ StandardCrypto
         )
     => Json.Value
@@ -2513,7 +2505,8 @@ decodeSerializedTransaction = Json.withText "Transaction" $ \(encodeUtf8 -> utf8
     -- available, this will generate a compiler error looking like:
     --
     --    • Couldn't match type ‘BabbageEra crypto’ with ‘AlonzoEra crypto’ arising from a use of ‘deserialiseCBOR’
-    _compilerWarning = keepRedundantConstraint (Proxy @constraint)
+    -- TODO(dijkstra): era guard removed; restore once Cardano.Ledger.Dijkstra.Era is wired into Ogmios.
+    _compilerWarning = ()
 
     invalidEncodingError :: Json.Parser a
     invalidEncodingError =

--- a/server/src/Ogmios/Data/Json/Shelley.hs
+++ b/server/src/Ogmios/Data/Json/Shelley.hs
@@ -7,6 +7,8 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -fno-warn-unticked-promoted-constructors #-}
+-- TODO(dijkstra): warnings disabled while encodePParamsHKD / encodeTx metadata / encodePoolMetadata hash are stubbed.
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 module Ogmios.Data.Json.Shelley where
 
@@ -45,10 +47,11 @@ import qualified Cardano.Ledger.Coin as Ledger
 import qualified Cardano.Ledger.Core as Ledger
 import qualified Cardano.Ledger.Credential as Ledger
 import qualified Cardano.Ledger.Keys as Ledger
-import qualified Cardano.Ledger.PoolParams as Ledger
+import qualified Cardano.Ledger.Keys.WitVKey as Sh
+import qualified Cardano.Ledger.State as Ledger
 import qualified Cardano.Ledger.TxIn as Ledger
 
-import qualified Cardano.Ledger.Shelley.BlockChain as Sh
+import qualified Cardano.Ledger.Shelley.BlockBody as Sh
 import qualified Cardano.Ledger.Shelley.Genesis as Sh
 import qualified Cardano.Ledger.Shelley.PParams as Sh
 import qualified Cardano.Ledger.Shelley.Rules as Sh
@@ -130,7 +133,7 @@ encodeBlock opts (ShelleyBlock (Ledger.Block blkHeader txs) headerHash) =
         <>
           "size" .= encodeSingleton "bytes" (encodeWord32 (TPraos.bsize hBody))
         <>
-          "transactions" .= encodeFoldable (encodeTx opts) (Sh.txSeqTxns' txs)
+          "transactions" .= encodeFoldable (encodeTx opts) (Sh.shelleyBlockBodyTxs txs)
         )
   where
     TPraos.BHeader hBody _ = blkHeader
@@ -169,7 +172,7 @@ encodeConstitutionalDelegCert (Sh.GenesisDelegCert key delegate vrf) =
         )
 
 encodeCredential
-    :: forall any. (any :\: 'StakePool)
+    :: forall any. (any :\: StakePool)
     => Text
     -> Ledger.Credential any
     -> Series
@@ -180,7 +183,7 @@ encodeCredential k x = case x of
         "from" .= "script" <> k .= encodeScriptHash h
 
 encodeCredentialRaw
-    :: forall any. (any :\: 'StakePool)
+    :: forall any. (any :\: StakePool)
     => Ledger.Credential any
     -> Json
 encodeCredentialRaw x = case x of
@@ -326,7 +329,7 @@ encodeGenDelegPair x =
     & encodeObject
 
 encodeGenesisVote
-    :: Ledger.KeyHash 'Genesis
+    :: Ledger.KeyHash GenesisRole
     -> Json
 encodeGenesisVote credential =
     encodeObject
@@ -351,7 +354,7 @@ encodeHashHeader =
     encodeByteStringBase16 . CC.hashToBytes . TPraos.unHashHeader
 
 encodeInitialDelegates
-    :: Map (Ledger.KeyHash 'Genesis) GenDelegPair
+    :: Map (Ledger.KeyHash GenesisRole) GenDelegPair
     -> Json
 encodeInitialDelegates =
     encodeMapAsList
@@ -543,7 +546,7 @@ encodePoolCert = \case
         "type" .= encodeText "stakePoolRegistration"
         <>
         "stakePool" .= encodeObject
-            ( "id" .= encodePoolId (Ledger.ppId params)
+            ( "id" .= encodePoolId (Ledger.sppId params)
            <> encodePoolParams params
             )
     Sh.RetirePool keyHash epochNo ->
@@ -567,29 +570,31 @@ encodePoolMetadata x =
     "url" .=
         encodeUrl (Ledger.pmUrl x) <>
     "hash" .=
-        encodeByteStringBase16 (Ledger.pmHash x)
+        encodeByteStringBase16
+            -- TODO(dijkstra): Ledger.pmHash now returns Data.Array.Byte.ByteArray instead of ByteString in cardano-ledger 1.20; needs conversion.
+            (error "TODO(dijkstra): Ledger.pmHash now ByteArray" :: ByteString)
     & encodeObject
 
 encodePoolParams
-    :: Ledger.PoolParams
+    :: Ledger.StakePoolParams
     -> Series
 encodePoolParams x =
     "vrfVerificationKeyHash" .=
-        encodeHash (Ledger.unVRFVerKeyHash $ Ledger.ppVrf x) <>
+        encodeHash (Ledger.unVRFVerKeyHash $ Ledger.sppVrf x) <>
     "pledge" .=
-        encodeCoin (Ledger.ppPledge x) <>
+        encodeCoin (Ledger.sppPledge x) <>
     "cost" .=
-        encodeCoin (Ledger.ppCost x) <>
+        encodeCoin (Ledger.sppCost x) <>
     "margin" .=
-        encodeUnitInterval (Ledger.ppMargin x) <>
+        encodeUnitInterval (Ledger.sppMargin x) <>
     "rewardAccount" .=
-        encodeRewardAcnt (Ledger.ppRewardAccount x) <>
+        encodeRewardAcnt (Ledger.sppAccountAddress x) <>
     "owners" .=
-        encodeFoldable encodeKeyHash (Ledger.ppOwners x) <>
+        encodeFoldable encodeKeyHash (Ledger.sppOwners x) <>
     "relays" .=
-        encodeFoldable encodeStakePoolRelay (Ledger.ppRelays x) <>
+        encodeFoldable encodeStakePoolRelay (Ledger.sppRelays x) <>
     "metadata" .=? OmitWhenNothing
-        encodePoolMetadata (Ledger.ppMetadata x)
+        encodePoolMetadata (Ledger.sppMetadata x)
 
 encodePParams
     :: (Ledger.PParamsHKD Identity era ~ Sh.ShelleyPParams Identity era)
@@ -674,44 +679,9 @@ encodePParamsHKD
     -> (Integer -> Sh.HKD f Integer)
     -> Ledger.PParamsHKD f era
     -> Json
-encodePParamsHKD encode pure_ x =
-    encode "minFeeCoefficient"
-        (encodeInteger . unCoin) (Sh.sppMinFeeA x) <>
-    encode "minFeeConstant"
-        encodeCoin (Sh.sppMinFeeB x) <>
-    encode "maxBlockBodySize"
-        (encodeSingleton "bytes" . encodeWord32) (Sh.sppMaxBBSize x) <>
-    encode "maxBlockHeaderSize"
-        (encodeSingleton "bytes" . encodeWord16) (Sh.sppMaxBHSize x) <>
-    encode "maxTransactionSize"
-        (encodeSingleton "bytes" . encodeWord32) (Sh.sppMaxTxSize x) <>
-    encode "stakeCredentialDeposit"
-        encodeCoin (Sh.sppKeyDeposit x) <>
-    encode "stakePoolDeposit"
-        encodeCoin (Sh.sppPoolDeposit x) <>
-    encode "stakePoolRetirementEpochBound"
-        encodeEpochInterval (Sh.sppEMax x) <>
-    encode "desiredNumberOfStakePools"
-        encodeWord16 (Sh.sppNOpt x) <>
-    encode "stakePoolPledgeInfluence"
-        encodeNonNegativeInterval (Sh.sppA0 x) <>
-    encode "minStakePoolCost"
-        encodeCoin (Sh.sppMinPoolCost x) <>
-    encode "monetaryExpansion"
-        encodeUnitInterval (Sh.sppRho x) <>
-    encode "treasuryExpansion"
-        encodeUnitInterval (Sh.sppTau x) <>
-    encode "federatedBlockProductionRatio"
-        encodeUnitInterval (Sh.sppD x) <>
-    encode "extraEntropy"
-        encodeNonce (Sh.sppExtraEntropy x) <>
-    encode "minUtxoDepositConstant"
-        encodeCoin (Sh.sppMinUTxOValue x) <>
-    encode "minUtxoDepositCoefficient"
-        encodeInteger (pure_ 0) <>
-    encode "version"
-        encodeProtVer (Sh.sppProtocolVersion x)
-    & encodeObject
+encodePParamsHKD _ _ _ =
+    -- TODO(dijkstra): rewrite for new ShelleyPParams HKD layout: sppKeyDeposit/sppPoolDeposit/sppMinUTxOValue now return Compact Coin instead of Coin in cardano-ledger 1.20. PR #461 adds an `encodeCompact` callback parameter.
+    error "TODO(dijkstra): encodePParamsHKD needs new signature for Compact Coin fields"
 
 encodePrevHash
     :: TPraos.PrevHash
@@ -731,7 +701,7 @@ encodeProtVer x =
     & encodeObject
 
 encodeRewardAcnt
-    :: Sh.RewardAccount
+    :: Ledger.AccountAddress
     -> Json
 encodeRewardAcnt =
     encodeText . stringifyRewardAcnt
@@ -827,33 +797,30 @@ encodeStakePoolRelay = encodeObject . \case
 
 encodeTx
     :: (MetadataFormat, IncludeCbor)
-    -> Sh.ShelleyTx ShelleyEra
+    -> Sh.Tx Ledger.TopTx ShelleyEra
     -> Json
-encodeTx (fmt, opts) x =
+encodeTx (_fmt, opts) tx@(Sh.MkShelleyTx x) =
     encodeObject
-        ( encodeTxId (Ledger.txIdTxBody @ShelleyEra (Sh.body x))
+        ( encodeTxId (Ledger.txIdTxBody @ShelleyEra (Sh.stBody x))
        <>
         "spends" .= encodeText "inputs"
        <>
-        encodeTxBody (Sh.body x)
+        encodeTxBody (Sh.stBody x)
        <>
         "metadata" .=? OmitWhenNothing identity metadata
        <>
-        encodeWitnessSet opts (Sh.wits x)
+        encodeWitnessSet opts (Sh.stWits x)
        <>
         if includeTransactionCbor opts then
-           "cbor" .= encodeByteStringBase16 (encodeCbor @ShelleyEra x)
+           "cbor" .= encodeByteStringBase16 (encodeCbor @ShelleyEra tx)
         else
            mempty
         )
   where
-    metadata = liftA2
-        (\hash body -> encodeObject ("hash" .= hash <> "labels" .= body))
-        (encodeAuxiliaryDataHash <$> Sh.stbMDHash (Sh.body x))
-        (encodeMetadata (fmt, opts) <$> Sh.auxiliaryData x)
+    metadata = SNothing -- TODO(dijkstra): encodeMetadata era-version constraint can't be solved against new ShelleyEra; need explicit era annotation or new API
 
 encodeTxBody
-    :: Sh.ShelleyTxBody ShelleyEra
+    :: Ledger.TxBody Ledger.TopTx ShelleyEra
     -> Series
 encodeTxBody x =
     "inputs" .=
@@ -912,7 +879,7 @@ encodeUpdate
     => (Ledger.PParamsUpdate era -> [Json])
     -> [Json]
     -> Sh.Update era
-    -> ([Ledger.KeyHash 'Genesis], [Json])
+    -> ([Ledger.KeyHash GenesisRole], [Json])
 encodeUpdate encodePParamsUpdateInEra mirs (Sh.Update (Sh.ProposedPPUpdates m) _epoch) =
     Map.foldrWithKey
         (\k v (votes, proposals) -> (k : votes, encodePParamsUpdateInEra v ++ proposals))
@@ -1068,10 +1035,10 @@ stringifyPoolId (Ledger.KeyHash (CC.UnsafeHash h)) =
     encodeBech32 hrpPool (fromShort h)
 
 stringifyRewardAcnt
-    :: Sh.RewardAccount
+    :: Ledger.AccountAddress
     -> Text
-stringifyRewardAcnt x@(Sh.RewardAccount ntwrk _credential) =
-    encodeBech32 (hrp ntwrk) (Ledger.serialiseRewardAccount x)
+stringifyRewardAcnt x@(Ledger.AccountAddress ntwrk _credential) =
+    encodeBech32 (hrp ntwrk) (Ledger.serialiseAccountAddress x)
   where
     hrp = \case
         Ledger.Mainnet -> hrpStakeMainnet

--- a/server/src/Ogmios/Data/Ledger.hs
+++ b/server/src/Ogmios/Data/Ledger.hs
@@ -17,7 +17,7 @@ import Ogmios.Prelude
 
 import Cardano.Ledger.Address
     ( Addr (..)
-    , RewardAccount (..)
+    , AccountAddress
     )
 import Cardano.Ledger.Alonzo.Plutus.Context
     ( ContextError
@@ -45,8 +45,8 @@ import qualified Prelude
 
 data DiscriminatedEntities
     = DiscriminatedAddresses (Set Addr)
-    | DiscriminatedRewardAccounts (Set RewardAccount)
-    | DiscriminatedPoolRegistrationCertificate (KeyHash 'StakePool)
+    | DiscriminatedRewardAccounts (Set AccountAddress)
+    | DiscriminatedPoolRegistrationCertificate (KeyHash StakePool)
     | DiscriminatedTransaction
     deriving (Show, Ord, Eq)
 
@@ -90,13 +90,12 @@ instance Ord ScriptPurposeIndexInAnyEra where
 scriptPurposeInMostRecentEra
     :: ScriptPurposeIndexInAnyEra
     -> PlutusPurpose AsIx (MostRecentEra (CardanoBlock crypto))
-scriptPurposeInMostRecentEra = \case
-    ScriptPurposeIndexInAnyEra (AlonzoBasedEraAlonzo, ix) ->
-        upgradePlutusPurposeAsIx (upgradePlutusPurposeAsIx ix)
-    ScriptPurposeIndexInAnyEra (AlonzoBasedEraBabbage, ix) ->
-        upgradePlutusPurposeAsIx ix
-    ScriptPurposeIndexInAnyEra (AlonzoBasedEraConway, ix) ->
-        ix
+scriptPurposeInMostRecentEra _ =
+    -- TODO(dijkstra): MostRecentEra is now Dijkstra (not Conway). Each arm needs
+    -- an extra `upgradePlutusPurposeAsIx` step, and a new arm for
+    -- AlonzoBasedEraDijkstra. Plus AlonzoBasedEra likely gained a Dijkstra
+    -- constructor that needs handling.
+    error "TODO(dijkstra): scriptPurposeInMostRecentEra needs Dijkstra arm + extra upgrade step"
 
 data ContextErrorInAnyEra =
     forall era. Era era =>

--- a/server/src/Ogmios/Data/Ledger/PredicateFailure.hs
+++ b/server/src/Ogmios/Data/Ledger/PredicateFailure.hs
@@ -23,7 +23,7 @@ module Ogmios.Data.Ledger.PredicateFailure
     , Language (..)
     , Network (..)
     , ProtVer (..)
-    , RewardAccount (..)
+    , AccountAddress
     , ScriptHash (..)
     , ScriptIntegrityHash
     , ScriptPurposeItemInAnyEra (..)
@@ -43,7 +43,7 @@ import Ogmios.Prelude
 
 import Cardano.Ledger.Address
     ( Addr (..)
-    , RewardAccount (..)
+    , AccountAddress
     )
 import Cardano.Ledger.Allegra.Scripts
     ( ValidityInterval (..)
@@ -85,10 +85,12 @@ import Cardano.Ledger.Hashes
     , TxAuxDataHash
     )
 import Cardano.Ledger.Keys
-    ( Hash
-    , KeyHash (..)
+    ( KeyHash (..)
     , KeyRole (..)
     , VKey (..)
+    )
+import Cardano.Crypto.Hash.Class
+    ( Hash
     )
 import Cardano.Ledger.Plutus.Language
     ( Language (..)
@@ -118,12 +120,12 @@ data MultiEraPredicateFailure
 
     -- All transaction key witnesses must comprised of valid signatures
     = InvalidSignatures
-        { culpritVerificationKeys :: [VKey 'Witness]
+        { culpritVerificationKeys :: [VKey Witness]
         }
 
     -- All required verification key witnesses must be provided.
     | MissingSignatures
-        { missingSignatures :: Set (KeyHash 'Witness)
+        { missingSignatures :: Set (KeyHash Witness)
         }
 
     -- All required script must be provided as witnesses.
@@ -371,12 +373,12 @@ data MultiEraPredicateFailure
 
     -- Committee members that are both added and removed in the same update.
     | ConflictingCommitteeUpdate
-        { conflictingMembers :: Set (Credential 'ColdCommitteeRole)
+        { conflictingMembers :: Set (Credential ColdCommitteeRole)
         }
 
     -- Committee members set to retire in the past. \
     | InvalidCommitteeUpdate
-        { alreadyRetiredMembers :: Set (Credential 'ColdCommitteeRole)
+        { alreadyRetiredMembers :: Set (Credential ColdCommitteeRole)
         }
 
     -- A governance action (except the first) must reference the immediately
@@ -428,12 +430,12 @@ data MultiEraPredicateFailure
 
     -- Stake pool must exist / be registered when delegating to it.
     | UnknownStakePool
-        { poolId :: KeyHash 'StakePool
+        { poolId :: KeyHash StakePool
         }
 
     -- When present, withdrawals must withdraw rewards entirely
     | IncompleteWithdrawals
-        { withdrawals :: Map RewardAccount Coin
+        { withdrawals :: Map AccountAddress Coin
         }
 
     ---------------------------------------------------------------------------
@@ -458,7 +460,7 @@ data MultiEraPredicateFailure
 
     -- Stake pool metadata hash must be smaller than 32 bytes
     | StakePoolMetadataHashTooLarge
-        { poolId :: KeyHash 'StakePool
+        { poolId :: KeyHash StakePool
         , computedMetadataHashSize :: Int
         }
 
@@ -468,12 +470,12 @@ data MultiEraPredicateFailure
 
     -- One cannot register a stake credential twice
     | StakeCredentialAlreadyRegistered
-        { knownCredential :: Credential 'Staking
+        { knownCredential :: Credential Staking
         }
 
     -- Stake credential must be registered for delegation
     | StakeCredentialNotRegistered
-        { unknownCredential :: Credential 'Staking
+        { unknownCredential :: Credential Staking
         }
 
     -- Reward account must be empty when de-registering stake keys
@@ -483,7 +485,7 @@ data MultiEraPredicateFailure
 
     -- Trying to withdraw from credentials that aren't delegated to a DRep
     | ForbiddenWithdrawal
-        { marginalizedCredentials :: Set (KeyHash 'Staking)
+        { marginalizedCredentials :: Set (KeyHash Staking)
         }
 
     -- Trying to withdraw from the treasury an amount different from the one
@@ -513,18 +515,18 @@ data MultiEraPredicateFailure
 
     -- One cannot register as a DRep twice
     | DRepAlreadyRegistered
-        { knownDelegateRepresentative :: Credential 'DRepRole
+        { knownDelegateRepresentative :: Credential DRepRole
         }
 
     -- Delegate representative must be registered for delegation
     | DRepNotRegistered
-        { unknownDelegateRepresentative :: Credential 'DRepRole
+        { unknownDelegateRepresentative :: Credential DRepRole
         }
 
     -- Committee member must be registered and active in order to (a) declare
     -- hot key or (b) resign.
     | UnknownConstitutionalCommitteeMember
-        { unknownConstitutionalCommitteeMember :: Credential 'ColdCommitteeRole
+        { unknownConstitutionalCommitteeMember :: Credential ColdCommitteeRole
         }
 
     ---------------------------------------------------------------------------

--- a/server/src/Ogmios/Data/Ledger/PredicateFailure/Allegra.hs
+++ b/server/src/Ogmios/Data/Ledger/PredicateFailure/Allegra.hs
@@ -2,6 +2,9 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+-- TODO(dijkstra): warnings disabled while removed constructors are stubbed.
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-incomplete-patterns -Wno-unused-matches -Wno-unused-top-binds -Wno-redundant-constraints #-}
+
 module Ogmios.Data.Ledger.PredicateFailure.Allegra where
 
 import Ogmios.Prelude
@@ -39,38 +42,6 @@ encodeUtxoFailure
     => ShelleyBasedEra era
     -> Al.AllegraUtxoPredFailure era
     -> MultiEraPredicateFailure
-encodeUtxoFailure era = \case
-    Al.BadInputsUTxO inputs ->
-        UnknownUtxoReference inputs
-    Al.OutsideValidityIntervalUTxO validityInterval currentSlot ->
-        TransactionOutsideValidityInterval { validityInterval, currentSlot }
-    Al.OutputTooBigUTxO outs ->
-        let culpritOutputs = (\out -> TxOutInAnyEra (era, out)) <$> outs in
-        ValueSizeAboveLimit culpritOutputs
-    Al.MaxTxSizeUTxO (Mismatch measuredSize maximumSize) ->
-        TransactionTooLarge { measuredSize, maximumSize }
-    Al.InputSetEmptyUTxO ->
-        EmptyInputSet
-    Al.FeeTooSmallUTxO (Mismatch suppliedFee minimumRequiredFee) ->
-        TransactionFeeTooSmall { minimumRequiredFee, suppliedFee }
-    Al.ValueNotConservedUTxO (Mismatch consumed produced) ->
-        let valueConsumed = ValueInAnyEra (era, consumed) in
-        let valueProduced = ValueInAnyEra (era, produced) in
-        ValueNotConserved { valueConsumed, valueProduced }
-    Al.WrongNetwork expectedNetwork invalidAddrs ->
-        let invalidEntities = DiscriminatedAddresses invalidAddrs in
-        NetworkMismatch { expectedNetwork, invalidEntities }
-    Al.WrongNetworkWithdrawal expectedNetwork invalidAccts ->
-        let invalidEntities = DiscriminatedRewardAccounts invalidAccts in
-        NetworkMismatch { expectedNetwork, invalidEntities }
-    Al.OutputTooSmallUTxO outs ->
-        let insufficientlyFundedOutputs =
-                (\out -> (TxOutInAnyEra (era, out), Nothing)) <$> outs
-         in InsufficientAdaInOutput { insufficientlyFundedOutputs }
-    Al.OutputBootAddrAttrsTooBig outs ->
-        let culpritOutputs = (\out -> TxOutInAnyEra (era, out)) <$> outs in
-        BootstrapAddressAttributesTooLarge { culpritOutputs }
-    Al.TriesToForgeADA ->
-        MintingOrBurningAda
-    Al.UpdateFailure{} ->
-        InvalidProtocolParametersUpdate
+encodeUtxoFailure _era _ =
+    -- TODO(dijkstra): NonEmptySet vs Set / NonEmpty vs [] / Word32 vs Integer mismatches across many arms in cardano-ledger-allegra 1.9.0.
+    error "TODO(dijkstra): encodeUtxoFailure Allegra"

--- a/server/src/Ogmios/Data/Ledger/PredicateFailure/Alonzo.hs
+++ b/server/src/Ogmios/Data/Ledger/PredicateFailure/Alonzo.hs
@@ -2,6 +2,9 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+-- TODO(dijkstra): warnings disabled while removed constructors are stubbed.
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-incomplete-patterns -Wno-unused-matches -Wno-unused-top-binds -Wno-redundant-constraints #-}
+
 module Ogmios.Data.Ledger.PredicateFailure.Alonzo where
 
 import Ogmios.Prelude
@@ -61,25 +64,9 @@ encodeUtxowFailure
     -> (Sh.PredicateFailure (EraRule "UTXO" era) -> MultiEraPredicateFailure)
     -> Al.AlonzoUtxowPredFailure era
     -> MultiEraPredicateFailure
-encodeUtxowFailure era encodeUtxoFailureInEra = \case
-    Al.MissingRedeemers redeemers ->
-        let missingRedeemers = ScriptPurposeItemInAnyEra . (era,) . fst <$> redeemers
-         in MissingRedeemers { missingRedeemers }
-    Al.MissingRequiredDatums missingDatums _providedDatums ->
-        MissingDatums { missingDatums }
-    Al.NotAllowedSupplementalDatums extraneousDatums _acceptableDatums ->
-        ExtraneousDatums { extraneousDatums }
-    Al.ExtraRedeemers redeemers ->
-        let extraneousRedeemers = ScriptPurposeIndexInAnyEra . (era,) <$> redeemers
-         in ExtraneousRedeemers { extraneousRedeemers }
-    Al.PPViewHashesDontMatch (Mismatch providedIntegrityHash computedIntegrityHash) ->
-        ScriptIntegrityHashMismatch { providedIntegrityHash, computedIntegrityHash }
-    Al.MissingRequiredSigners keys ->
-        MissingSignatures keys
-    Al.UnspendableUTxONoDatumHash orphanScriptInputs ->
-        OrphanScriptInputs { orphanScriptInputs }
-    Al.ShelleyInAlonzoUtxowPredFailure e ->
-        Shelley.encodeUtxowFailure encodeUtxoFailureInEra e
+encodeUtxowFailure _ _ _ =
+    -- TODO(dijkstra): NonEmpty/NonEmptySet container types in cardano-ledger-alonzo 1.15.0 + Mismatch shape changes.
+    error "TODO(dijkstra): encodeUtxowFailure Alonzo"
 
 encodeUtxoFailure
     :: forall era.
@@ -89,59 +76,9 @@ encodeUtxoFailure
     -> (Sh.PredicateFailure (EraRule "UTXOS" era) -> MultiEraPredicateFailure)
     -> Al.AlonzoUtxoPredFailure era
     -> MultiEraPredicateFailure
-encodeUtxoFailure era encodeUtxosFailure' = \case
-    Al.BadInputsUTxO inputs ->
-        UnknownUtxoReference inputs
-    Al.OutsideValidityIntervalUTxO validityInterval currentSlot ->
-        TransactionOutsideValidityInterval { validityInterval, currentSlot }
-    Al.OutputTooBigUTxO outs ->
-        let culpritOutputs = (\(_, _, out) -> TxOutInAnyEra (toShelleyBasedEra era, out)) <$> outs in
-        ValueSizeAboveLimit culpritOutputs
-    Al.MaxTxSizeUTxO (Mismatch measuredSize maximumSize) ->
-        TransactionTooLarge { measuredSize, maximumSize }
-    Al.InputSetEmptyUTxO ->
-        EmptyInputSet
-    Al.FeeTooSmallUTxO (Mismatch suppliedFee minimumRequiredFee)  ->
-        TransactionFeeTooSmall { minimumRequiredFee, suppliedFee }
-    Al.ValueNotConservedUTxO (Mismatch consumed produced) ->
-        let valueConsumed = ValueInAnyEra (toShelleyBasedEra era, consumed) in
-        let valueProduced = ValueInAnyEra (toShelleyBasedEra era, produced) in
-        ValueNotConserved { valueConsumed, valueProduced }
-    Al.WrongNetwork expectedNetwork invalidAddrs ->
-        let invalidEntities = DiscriminatedAddresses invalidAddrs in
-        NetworkMismatch { expectedNetwork, invalidEntities }
-    Al.WrongNetworkWithdrawal expectedNetwork invalidAccts ->
-        let invalidEntities = DiscriminatedRewardAccounts invalidAccts in
-        NetworkMismatch { expectedNetwork, invalidEntities }
-    Al.OutputTooSmallUTxO outs ->
-        let insufficientlyFundedOutputs =
-                (\out -> (TxOutInAnyEra (toShelleyBasedEra era, out), Nothing)) <$> outs
-         in InsufficientAdaInOutput { insufficientlyFundedOutputs }
-    Al.OutputBootAddrAttrsTooBig outs ->
-        let culpritOutputs = (\out -> TxOutInAnyEra (toShelleyBasedEra era, out)) <$> outs in
-        BootstrapAddressAttributesTooLarge { culpritOutputs }
-    Al.TriesToForgeADA ->
-        MintingOrBurningAda
-    Al.InsufficientCollateral providedCollateral minimumRequiredCollateral ->
-        InsufficientCollateral { providedCollateral, minimumRequiredCollateral }
-    Al.ScriptsNotPaidUTxO utxo ->
-        CollateralInputLockedByScript (Map.keys $ unUTxO utxo)
-    Al.WrongNetworkInTxBody (Mismatch _providedNetwork expectedNetwork) ->
-        let invalidEntities = DiscriminatedTransaction in
-        NetworkMismatch { expectedNetwork, invalidEntities }
-    Al.OutsideForecast slot ->
-        SlotOutsideForeseeableFuture { slot }
-    Al.CollateralContainsNonADA value ->
-        let valueInAnyEra = ValueInAnyEra (toShelleyBasedEra era, value) in
-        NonAdaValueAsCollateral valueInAnyEra
-    Al.NoCollateralInputs{} ->
-        MissingCollateralInputs
-    Al.TooManyCollateralInputs (Mismatch countedCollateralInputs maximumCollateralInputs) ->
-        TooManyCollateralInputs { maximumCollateralInputs, countedCollateralInputs }
-    Al.ExUnitsTooBigUTxO (Mismatch providedExUnits maximumExUnits) ->
-        ExecutionUnitsTooLarge { maximumExUnits, providedExUnits }
-    Al.UtxosFailure e ->
-        encodeUtxosFailure' e
+encodeUtxoFailure _ _ _ =
+    -- TODO(dijkstra): same shape issues as encodeUtxowFailure.
+    error "TODO(dijkstra): encodeUtxoFailure Alonzo"
 
 encodeUtxosFailure
     :: forall era.
@@ -150,13 +87,9 @@ encodeUtxosFailure
     => AlonzoBasedEra era
     -> Al.AlonzoUtxosPredFailure era
     -> MultiEraPredicateFailure
-encodeUtxosFailure era = \case
-    Al.ValidationTagMismatch validationTag mismatchReason ->
-        ValidationTagMismatch { validationTag, mismatchReason }
-    Al.CollectErrors errors ->
-        pickPredicateFailure (encodeCollectErrors era errors)
-    Al.UpdateFailure{} ->
-        InvalidProtocolParametersUpdate
+encodeUtxosFailure _era _ =
+    -- TODO(dijkstra): CollectErrors now wraps NonEmpty (CollectError era), need toList.
+    error "TODO(dijkstra): encodeUtxosFailure Alonzo"
 
 encodeCollectErrors
     :: forall era.

--- a/server/src/Ogmios/Data/Ledger/PredicateFailure/Babbage.hs
+++ b/server/src/Ogmios/Data/Ledger/PredicateFailure/Babbage.hs
@@ -2,6 +2,9 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+-- TODO(dijkstra): warnings suppressed pending NonEmpty/NonEmptySet shape fixes for cardano-ledger-babbage 1.13.0.
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-incomplete-patterns -Wno-unused-matches -Wno-unused-top-binds -Wno-redundant-constraints #-}
+
 module Ogmios.Data.Ledger.PredicateFailure.Babbage where
 
 import Ogmios.Prelude
@@ -43,15 +46,9 @@ encodeUtxowFailure
     -> (PredicateFailure (EraRule "UTXOS" era) -> MultiEraPredicateFailure)
     -> Ba.BabbageUtxowPredFailure era
     -> MultiEraPredicateFailure
-encodeUtxowFailure era encodeUtxosFailure = \case
-    Ba.MalformedReferenceScripts scripts ->
-        MalformedScripts scripts
-    Ba.MalformedScriptWitnesses scripts ->
-        MalformedScripts scripts
-    Ba.AlonzoInBabbageUtxowPredFailure e ->
-        Alonzo.encodeUtxowFailure era (encodeUtxoFailure era encodeUtxosFailure) e
-    Ba.UtxoFailure e ->
-        encodeUtxoFailure era encodeUtxosFailure e
+encodeUtxowFailure _ _ _ =
+    -- TODO(dijkstra): NonEmptySet scripts in cardano-ledger-babbage 1.13.0.
+    error "TODO(dijkstra): encodeUtxowFailure Babbage"
 
 encodeUtxoFailure
     :: forall era. (Era era)
@@ -59,18 +56,6 @@ encodeUtxoFailure
     -> (PredicateFailure (EraRule "UTXOS" era) -> MultiEraPredicateFailure)
     -> Ba.BabbageUtxoPredFailure era
     -> MultiEraPredicateFailure
-encodeUtxoFailure era encodeUtxosFailure = \case
-    Ba.AlonzoInBabbageUtxoPredFailure e ->
-        Alonzo.encodeUtxoFailure era encodeUtxosFailure e
-    Ba.IncorrectTotalCollateralField computedTotalCollateral declaredTotalCollateral ->
-        TotalCollateralMismatch { computedTotalCollateral, declaredTotalCollateral }
-    Ba.BabbageNonDisjointRefInputs xs ->
-        ConflictingInputsAndReferences xs
-    Ba.BabbageOutputTooSmallUTxO outs ->
-        let insufficientlyFundedOutputs =
-                (\(out,minAda) ->
-                    ( TxOutInAnyEra (toShelleyBasedEra era, out)
-                    , Just minAda
-                    )
-                ) <$> outs
-         in InsufficientAdaInOutput { insufficientlyFundedOutputs }
+encodeUtxoFailure _ _ _ =
+    -- TODO(dijkstra): NonEmpty insufficientlyFundedOutputs etc.
+    error "TODO(dijkstra): encodeUtxoFailure Babbage"

--- a/server/src/Ogmios/Data/Ledger/PredicateFailure/Conway.hs
+++ b/server/src/Ogmios/Data/Ledger/PredicateFailure/Conway.hs
@@ -2,6 +2,9 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+-- TODO(dijkstra): warnings suppressed; most encode functions stubbed pending Conway-1.22.1 / Dijkstra constructor reshape.
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-incomplete-patterns -Wno-unused-matches -Wno-unused-top-binds -Wno-redundant-constraints -Wno-deprecations #-}
+
 module Ogmios.Data.Ledger.PredicateFailure.Conway where
 
 import Ogmios.Prelude
@@ -60,102 +63,14 @@ encodeLedgerFailure = \case
 encodeGovFailure
     :: Cn.ConwayGovPredFailure ConwayEra
     -> MultiEraPredicateFailure
-encodeGovFailure = \case
-    Cn.GovActionsDoNotExist (toList -> fromList -> governanceActions) ->
-        UnknownGovernanceActions { governanceActions }
-    Cn.MalformedProposal _govAction ->
-        InvalidProtocolParametersUpdate
-    Cn.ProposalProcedureNetworkIdMismatch rewardAccount expectedNetwork ->
-        NetworkMismatch
-            { expectedNetwork
-            , invalidEntities =
-                DiscriminatedRewardAccounts (Set.singleton rewardAccount)
-            }
-    Cn.TreasuryWithdrawalsNetworkIdMismatch rewardAccounts expectedNetwork ->
-        NetworkMismatch
-            { expectedNetwork
-            , invalidEntities =
-                DiscriminatedRewardAccounts rewardAccounts
-            }
-    Cn.ProposalDepositIncorrect (Mismatch providedDeposit (SJust -> expectedDeposit)) ->
-        GovernanceProposalDepositMismatch
-            { providedDeposit
-            , expectedDeposit
-            }
-    Cn.DisallowedVoters (toList -> voters) ->
-        UnauthorizedVotes voters
-    Cn.ConflictingCommitteeUpdate conflictingMembers ->
-        ConflictingCommitteeUpdate
-            { conflictingMembers
-            }
-    Cn.ExpirationEpochTooSmall members ->
-        InvalidCommitteeUpdate
-            { alreadyRetiredMembers = Map.keysSet members
-            }
-    Cn.InvalidPrevGovActionId proposal ->
-        InvalidPreviousGovernanceAction $
-            case Ledger.pProcGovAction proposal of
-                Ledger.ParameterChange actionId _ _guardrail ->
-                    [ ( Ledger.pProcAnchor proposal
-                      , Ledger.PParamUpdatePurpose
-                      , Ledger.unGovPurposeId <$> actionId
-                      )
-                    ]
-                Ledger.HardForkInitiation actionId _ ->
-                    [ ( Ledger.pProcAnchor proposal
-                      , Ledger.HardForkPurpose
-                      , Ledger.unGovPurposeId <$> actionId
-                      )
-                    ]
-                Ledger.UpdateCommittee actionId _ _ _ ->
-                    [ ( Ledger.pProcAnchor proposal
-                      , Ledger.CommitteePurpose
-                      , Ledger.unGovPurposeId <$> actionId
-                      )
-                    ]
-                Ledger.NoConfidence actionId ->
-                    [ ( Ledger.pProcAnchor proposal
-                      , Ledger.CommitteePurpose
-                      , Ledger.unGovPurposeId <$> actionId
-                      )
-                    ]
-                Ledger.NewConstitution actionId _ ->
-                    [ ( Ledger.pProcAnchor proposal
-                      , Ledger.ConstitutionPurpose
-                      , Ledger.unGovPurposeId <$> actionId
-                      )
-                    ]
-                Ledger.TreasuryWithdrawals _withdrawals _guardrail ->
-                    []
-                Ledger.InfoAction ->
-                    []
-    Cn.VotingOnExpiredGovAction (toList -> voters) ->
-        VotingOnExpiredActions voters
-    Cn.ProposalCantFollow _ (Mismatch proposedVersion currentVersion) ->
-        InvalidHardForkVersionBump { proposedVersion, currentVersion }
-    Cn.InvalidPolicyHash providedHash expectedHash ->
-        ConstitutionGuardrailsHashMismatch { providedHash, expectedHash }
-    Cn.DisallowedProposalDuringBootstrap _ ->
-        UnauthorizedGovernanceAction
-    Cn.DisallowedVotesDuringBootstrap votes ->
-        UnauthorizedVotes (toList votes)
-    Cn.VotersDoNotExist voters ->
-        UnknownVoters (toList voters)
-    Cn.ZeroTreasuryWithdrawals _ ->
-        EmptyTreasuryWithdrawal
-    Cn.ProposalReturnAccountDoesNotExist (Ledger.RewardAccount _ unknownCredential) ->
-        StakeCredentialNotRegistered { unknownCredential }
-    Cn.TreasuryWithdrawalReturnAccountsDoNotExist (NE.head -> Ledger.RewardAccount _ unknownCredential) ->
-        StakeCredentialNotRegistered { unknownCredential }
+encodeGovFailure _ =
+    error "TODO(dijkstra): encodeGovFailure Conway"
 
 encodeCertsFailure
     :: Cn.ConwayCertsPredFailure ConwayEra
     -> MultiEraPredicateFailure
-encodeCertsFailure = \case
-    Cn.WithdrawalsNotInRewardsCERTS credentials ->
-        IncompleteWithdrawals credentials
-    Cn.CertFailure e ->
-        encodeCertFailure e
+encodeCertsFailure _ =
+    error "TODO(dijkstra): encodeCertsFailure Conway"
 
 encodeCertFailure
     :: Cn.ConwayCertPredFailure ConwayEra
@@ -181,7 +96,7 @@ encodeDelegFailure = \case
         StakeCredentialAlreadyRegistered { knownCredential }
     Cn.StakeKeyNotRegisteredDELEG unknownCredential  ->
         StakeCredentialNotRegistered { unknownCredential }
-    Cn.StakeKeyHasNonZeroRewardAccountBalanceDELEG rewardAccountBalance ->
+    Cn.StakeKeyHasNonZeroAccountBalanceDELEG rewardAccountBalance ->
         RewardAccountNotEmpty { rewardAccountBalance }
     Cn.DelegateeDRepNotRegisteredDELEG (coerceKeyRole -> unknownCredential) ->
         StakeCredentialNotRegistered { unknownCredential }
@@ -211,126 +126,17 @@ encodeGovCertFailure = \case
 encodeUtxoFailure
     :: Cn.ConwayUtxoPredFailure ConwayEra
     -> MultiEraPredicateFailure
-encodeUtxoFailure = \case
-    Cn.UtxosFailure e ->
-        encodeUtxosFailure e
-    Cn.BadInputsUTxO inputs ->
-        UnknownUtxoReference inputs
-    Cn.OutsideValidityIntervalUTxO validityInterval currentSlot ->
-        TransactionOutsideValidityInterval { validityInterval, currentSlot }
-    Cn.OutputTooBigUTxO outs ->
-        -- TODO: In Conway, we now have access to the output 'actualSize' and
-        -- the protocol parameters max value in addition to the output.
-        --
-        -- It would be good to report those value back in the error.
-        let culpritOutputs = (\(_, _, out) -> TxOutInAnyEra (era, out)) <$> outs in
-        ValueSizeAboveLimit culpritOutputs
-    Cn.MaxTxSizeUTxO (Mismatch measuredSize maximumSize) ->
-        TransactionTooLarge { measuredSize, maximumSize }
-    Cn.InputSetEmptyUTxO ->
-        EmptyInputSet
-    Cn.FeeTooSmallUTxO (Mismatch suppliedFee minimumRequiredFee) ->
-        TransactionFeeTooSmall { minimumRequiredFee, suppliedFee }
-    Cn.ValueNotConservedUTxO (Mismatch consumed produced) ->
-        let valueConsumed = ValueInAnyEra (era, consumed) in
-        let valueProduced = ValueInAnyEra (era, produced) in
-        ValueNotConserved { valueConsumed, valueProduced }
-    Cn.WrongNetwork expectedNetwork invalidAddrs ->
-        let invalidEntities = DiscriminatedAddresses invalidAddrs in
-        NetworkMismatch { expectedNetwork, invalidEntities }
-    Cn.WrongNetworkWithdrawal expectedNetwork invalidAccts ->
-        let invalidEntities = DiscriminatedRewardAccounts invalidAccts in
-        NetworkMismatch { expectedNetwork, invalidEntities }
-    Cn.OutputTooSmallUTxO outs ->
-        let insufficientlyFundedOutputs =
-                (\out -> (TxOutInAnyEra (era, out), Nothing)) <$> outs
-         in InsufficientAdaInOutput { insufficientlyFundedOutputs }
-    Cn.OutputBootAddrAttrsTooBig outs ->
-        let culpritOutputs = (\out -> TxOutInAnyEra (era, out)) <$> outs in
-        BootstrapAddressAttributesTooLarge { culpritOutputs }
-    Cn.InsufficientCollateral providedCollateral minimumRequiredCollateral ->
-        InsufficientCollateral { providedCollateral, minimumRequiredCollateral }
-    Cn.ScriptsNotPaidUTxO utxo ->
-        CollateralInputLockedByScript (Map.keys $ Ledger.unUTxO utxo)
-    Cn.WrongNetworkInTxBody (Mismatch _providedNetwork expectedNetwork) ->
-        let invalidEntities = DiscriminatedTransaction in
-        NetworkMismatch { expectedNetwork, invalidEntities }
-    Cn.OutsideForecast slot ->
-        SlotOutsideForeseeableFuture { slot }
-    Cn.CollateralContainsNonADA value ->
-        let valueInAnyEra = ValueInAnyEra (era, value) in
-        NonAdaValueAsCollateral valueInAnyEra
-    Cn.NoCollateralInputs{} ->
-        MissingCollateralInputs
-    Cn.TooManyCollateralInputs (Mismatch countedCollateralInputs maximumCollateralInputs) ->
-        TooManyCollateralInputs { maximumCollateralInputs, countedCollateralInputs }
-    Cn.ExUnitsTooBigUTxO (Mismatch providedExUnits maximumExUnits) ->
-        ExecutionUnitsTooLarge { maximumExUnits, providedExUnits }
-    Cn.IncorrectTotalCollateralField computedTotalCollateral declaredTotalCollateral ->
-        TotalCollateralMismatch { computedTotalCollateral, declaredTotalCollateral }
-    Cn.BabbageNonDisjointRefInputs xs ->
-        ConflictingInputsAndReferences xs
-    Cn.BabbageOutputTooSmallUTxO outs ->
-        let insufficientlyFundedOutputs =
-                (\(out,minAda) ->
-                    ( TxOutInAnyEra (era, out)
-                    , Just minAda
-                    )
-                ) <$> outs
-         in InsufficientAdaInOutput { insufficientlyFundedOutputs }
-  where
-    era = ShelleyBasedEraConway
+encodeUtxoFailure _ =
+    error "TODO(dijkstra): encodeUtxoFailure Conway"
 
 encodeUtxosFailure
     :: Cn.ConwayUtxosPredFailure ConwayEra
     -> MultiEraPredicateFailure
-encodeUtxosFailure = \case
-    Cn.ValidationTagMismatch validationTag mismatchReason ->
-        ValidationTagMismatch { validationTag, mismatchReason }
-    Cn.CollectErrors errors ->
-        pickPredicateFailure (encodeCollectErrors AlonzoBasedEraConway errors)
+encodeUtxosFailure _ =
+    error "TODO(dijkstra): encodeUtxosFailure Conway"
 
 encodeUtxowFailure
     :: Cn.ConwayUtxowPredFailure ConwayEra
     -> MultiEraPredicateFailure
-encodeUtxowFailure = \case
-    Cn.UtxoFailure e ->
-        encodeUtxoFailure e
-    Cn.MissingRedeemers redeemers ->
-        let missingRedeemers = ScriptPurposeItemInAnyEra . (era,) . fst <$> redeemers
-         in MissingRedeemers { missingRedeemers }
-    Cn.MissingRequiredDatums missingDatums _providedDatums ->
-        MissingDatums { missingDatums }
-    Cn.NotAllowedSupplementalDatums extraneousDatums _acceptableDatums ->
-        ExtraneousDatums { extraneousDatums }
-    Cn.ExtraRedeemers redeemers ->
-        let extraneousRedeemers = ScriptPurposeIndexInAnyEra . (era,) <$> redeemers
-         in ExtraneousRedeemers { extraneousRedeemers }
-    Cn.PPViewHashesDontMatch (Mismatch providedIntegrityHash computedIntegrityHash) ->
-        ScriptIntegrityHashMismatch { providedIntegrityHash, computedIntegrityHash }
-    Cn.UnspendableUTxONoDatumHash orphanScriptInputs ->
-        OrphanScriptInputs { orphanScriptInputs }
-    Cn.InvalidWitnessesUTXOW wits ->
-        InvalidSignatures wits
-    Cn.MissingVKeyWitnessesUTXOW keys ->
-        MissingSignatures keys
-    Cn.MissingScriptWitnessesUTXOW scripts ->
-        MissingScriptWitnesses scripts
-    Cn.ScriptWitnessNotValidatingUTXOW scripts ->
-        FailingScript scripts
-    Cn.MissingTxBodyMetadataHash hash ->
-        MissingMetadataHash hash
-    Cn.MissingTxMetadata hash ->
-        MissingMetadata hash
-    Cn.ConflictingMetadataHash (Mismatch providedAuxiliaryDataHash computedAuxiliaryDataHash) ->
-        MetadataHashMismatch{providedAuxiliaryDataHash, computedAuxiliaryDataHash}
-    Cn.InvalidMetadata ->
-        InvalidMetadata
-    Cn.ExtraneousScriptWitnessesUTXOW scripts ->
-        ExtraneousScriptWitnesses scripts
-    Cn.MalformedScriptWitnesses scripts ->
-        MalformedScripts scripts
-    Cn.MalformedReferenceScripts scripts ->
-        MalformedScripts scripts
-  where
-    era = AlonzoBasedEraConway
+encodeUtxowFailure _ =
+    error "TODO(dijkstra): encodeUtxowFailure Conway"

--- a/server/src/Ogmios/Data/Ledger/PredicateFailure/Mary.hs
+++ b/server/src/Ogmios/Data/Ledger/PredicateFailure/Mary.hs
@@ -2,6 +2,9 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+-- TODO(dijkstra): warnings disabled while ShelleyLedgerPredFailure constructors are missing.
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-incomplete-patterns -Wno-unused-matches -Wno-unused-top-binds -Wno-redundant-constraints #-}
+
 module Ogmios.Data.Ledger.PredicateFailure.Mary where
 
 import Ogmios.Prelude

--- a/server/src/Ogmios/Data/Ledger/PredicateFailure/Shelley.hs
+++ b/server/src/Ogmios/Data/Ledger/PredicateFailure/Shelley.hs
@@ -2,6 +2,8 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+-- TODO(dijkstra): warnings disabled while encodeUtxowFailure/encodeUtxoFailure are stubbed for cardano-ledger-shelley 1.18.1's NonEmpty containers.
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-unused-matches -Wno-incomplete-patterns -Wno-redundant-constraints -Wno-unused-top-binds #-}
 
 module Ogmios.Data.Ledger.PredicateFailure.Shelley where
 
@@ -43,67 +45,16 @@ encodeUtxowFailure
     => (PredicateFailure (EraRule "UTXO" era) -> MultiEraPredicateFailure)
     -> Sh.ShelleyUtxowPredFailure era
     -> MultiEraPredicateFailure
-encodeUtxowFailure encodeUtxoFailure_ = \case
-    Sh.InvalidWitnessesUTXOW wits ->
-        InvalidSignatures wits
-    Sh.MissingVKeyWitnessesUTXOW keys ->
-        MissingSignatures keys
-    Sh.MissingScriptWitnessesUTXOW scripts ->
-        MissingScriptWitnesses scripts
-    Sh.ScriptWitnessNotValidatingUTXOW scripts ->
-        FailingScript scripts
-    Sh.MIRInsufficientGenesisSigsUTXOW{} ->
-        InvalidMIRTransfer
-    Sh.MissingTxBodyMetadataHash hash ->
-        MissingMetadataHash hash
-    Sh.MissingTxMetadata hash ->
-        MissingMetadata hash
-    Sh.ConflictingMetadataHash (Mismatch providedAuxiliaryDataHash computedAuxiliaryDataHash) ->
-        MetadataHashMismatch{providedAuxiliaryDataHash, computedAuxiliaryDataHash}
-    Sh.InvalidMetadata ->
-        InvalidMetadata
-    Sh.ExtraneousScriptWitnessesUTXOW scripts ->
-        ExtraneousScriptWitnesses scripts
-    Sh.UtxoFailure e ->
-        encodeUtxoFailure_ e
+encodeUtxowFailure _ _ =
+    -- TODO(dijkstra): InvalidSignatures/MissingSignatures/MissingScriptWitnesses arms now receive NonEmpty/NonEmptySet from cardano-ledger 1.18.1 — need toList conversions for our MultiEraPredicateFailure shape.
+    error "TODO(dijkstra): encodeUtxowFailure Shelley"
 
 encodeUtxoFailure
     :: Sh.ShelleyUtxoPredFailure ShelleyEra
     -> MultiEraPredicateFailure
-encodeUtxoFailure = \case
-    Sh.BadInputsUTxO inputs ->
-        UnknownUtxoReference inputs
-    Sh.ExpiredUTxO (Mismatch timeToLive currentSlot) ->
-        let validityInterval = ValidityInterval
-                { invalidBefore = SNothing
-                , invalidHereafter = SJust timeToLive
-                }
-         in TransactionOutsideValidityInterval { validityInterval, currentSlot }
-    Sh.MaxTxSizeUTxO (Mismatch measuredSize maximumSize) ->
-        TransactionTooLarge { measuredSize, maximumSize }
-    Sh.InputSetEmptyUTxO ->
-        EmptyInputSet
-    Sh.FeeTooSmallUTxO (Mismatch suppliedFee minimumRequiredFee) ->
-        TransactionFeeTooSmall{minimumRequiredFee, suppliedFee}
-    Sh.ValueNotConservedUTxO (Mismatch consumed produced) ->
-        let valueConsumed = ValueInAnyEra (ShelleyBasedEraShelley, consumed) in
-        let valueProduced = ValueInAnyEra (ShelleyBasedEraShelley, produced) in
-        ValueNotConserved { valueConsumed, valueProduced }
-    Sh.WrongNetwork expectedNetwork invalidAddrs ->
-        let invalidEntities = DiscriminatedAddresses invalidAddrs in
-        NetworkMismatch { expectedNetwork, invalidEntities }
-    Sh.WrongNetworkWithdrawal expectedNetwork invalidAccts ->
-        let invalidEntities = DiscriminatedRewardAccounts invalidAccts in
-        NetworkMismatch { expectedNetwork, invalidEntities }
-    Sh.OutputTooSmallUTxO outs ->
-        let insufficientlyFundedOutputs =
-                (\out -> (TxOutInAnyEra (ShelleyBasedEraShelley, out), Nothing)) <$> outs
-         in InsufficientAdaInOutput { insufficientlyFundedOutputs }
-    Sh.OutputBootAddrAttrsTooBig outs ->
-        let culpritOutputs = (\out -> TxOutInAnyEra (ShelleyBasedEraShelley, out)) <$> outs in
-        BootstrapAddressAttributesTooLarge { culpritOutputs }
-    Sh.UpdateFailure{} ->
-        InvalidProtocolParametersUpdate
+encodeUtxoFailure _ =
+    -- TODO(dijkstra): same shape issues as encodeUtxowFailure (NonEmpty containers, possibly renamed constructors in cardano-ledger-shelley 1.18.1).
+    error "TODO(dijkstra): encodeUtxoFailure Shelley"
 
 encodeDelegsFailure
     :: PredicateFailure (EraRule "DELPL" era) ~ Sh.ShelleyDelplPredFailure era
@@ -111,13 +62,9 @@ encodeDelegsFailure
     => PredicateFailure (EraRule "DELEG" era) ~ Sh.ShelleyDelegPredFailure era
     => Sh.ShelleyDelegsPredFailure era
     -> MultiEraPredicateFailure
-encodeDelegsFailure = \case
-    Sh.DelegateeNotRegisteredDELEG poolId ->
-        UnknownStakePool poolId
-    Sh.WithdrawalsNotInRewardsDELEGS withdrawals ->
-        IncompleteWithdrawals withdrawals
-    Sh.DelplFailure e ->
-        encodeDeplFailure e
+encodeDelegsFailure _ =
+    -- TODO(dijkstra): ShelleyDelegsPredFailure constructors changed in cardano-ledger-shelley 1.18.1 (WithdrawalsNotInRewardsDELEGS removed, DelegateeNotRegisteredDELEG now lives on a sibling type). Needs reshape.
+    error "TODO(dijkstra): encodeDelegsFailure Shelley"
 
 encodeDeplFailure
     :: forall era.

--- a/server/src/Ogmios/Data/Ledger/Rewards.hs
+++ b/server/src/Ogmios/Data/Ledger/Rewards.hs
@@ -2,6 +2,10 @@
 --  License, v. 2.0. If a copy of the MPL was not distributed with this
 --  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+-- TODO(dijkstra): warnings disabled while this module is stubbed for the new
+-- cardano-ledger-core 1.20 API (ChainAccountState / ActiveStake / StakePoolSnapShot / NonZero Coin).
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-unused-top-binds -Wno-unused-matches -Wno-redundant-constraints -Wno-dodgy-imports #-}
+
 module Ogmios.Data.Ledger.Rewards
     ( RewardsProvenance (..)
     , PoolRewardsInfo (..)
@@ -27,6 +31,9 @@ import Cardano.Ledger.Coin
     )
 import Cardano.Ledger.Credential
     ( Credential (..)
+    )
+import Cardano.Ledger.Keys
+    ( KeyRole (..)
     )
 import Cardano.Ledger.Shelley.Genesis
     ( ShelleyGenesis (..)
@@ -98,7 +105,7 @@ data RewardsProvenance = RewardsProvenance
   , activeStake :: !Coin
   -- ^ The amount of Lovelace that is delegated during the given epoch.
   , pools :: Map
-      (KeyHash 'StakePool)
+      (KeyHash StakePool)
       (PoolRewardsInfo)
   -- ^ Stake pools specific information needed to compute the rewards for its members.
   }
@@ -115,7 +122,7 @@ data PoolRewardsInfo = PoolRewardsInfo
   -- ^ The number of blocks the stake pool produced
   , poolLeaderReward :: !Coin
   -- ^ The leader reward
-  , poolDelegators :: !(Map (Credential 'Staking) Coin)
+  , poolDelegators :: !(Map (Credential Staking) Coin)
   -- ^ A map of all its delegators, and their respective stake.
   }
   deriving (Show, Eq, Ord, Generic)
@@ -147,118 +154,12 @@ rewardsProvenance
     -> Coin
     -> ActiveSlotCoeff
     -> RewardsProvenance
-rewardsProvenance slotsPerEpoch b@(BlocksMade b') es@(EpochState acnt _ ss _) maxSupply asc =
-    RewardsProvenance
-        { spe = case slotsPerEpoch of EpochSize n -> n
-        , fees = ssFee ss
-        , blocks = b
-        , blocksCount
-        , maxSupply
-        , deltaR1
-        , totalStake
-        , activeStake
-        , d
-        , expectedBlocks
-        , eta
-        , rPot
-        , deltaT1
-        , pools
-        }
-  where
-    SnapShot stake delegs poolParams =
-        ssStakeGo ss
-
-    Coin reserves =
-        asReserves acnt
-
-    pr =
-      es ^. prevPParamsEpochStateL
-
-    deltaR1 =
-      rationalToCoinViaFloor $
-          min 1 eta
-              * unboundRational (pr ^. ppRhoL)
-              * fromIntegral reserves
-
-    d =
-        unboundRational (pr ^. ppDG)
-
-    expectedBlocks =
-      floor $ (1 - d) * unboundRational (activeSlotVal asc) * fromIntegral (unEpochSize slotsPerEpoch)
-
-    blocksCount =
-        fromIntegral $ Map.foldr (+) 0 b' :: Integer
-
-    eta
-      | unboundRational (pr ^. ppDG) >= 0.8 = 1
-      | otherwise = blocksCount % expectedBlocks
-
-    Coin rPot =
-        ssFee ss <> deltaR1
-
-    deltaT1 =
-        floor $ unboundRational (pr ^. ppTauL) * fromIntegral rPot
-
-    availableRewards =
-        Coin $ rPot - deltaT1
-
-    activeStake =
-        sumAllStake stake
-
-    totalStake =
-        circulation es maxSupply
-
-    stakePerPool =
-        sumStakePerPool delegs stake
-
-    mkPoolRewardInfoCurry =
-      mkPoolRewardInfo
-        pr
-        availableRewards
-        b
-        (fromIntegral blocksCount)
-        stake
-        delegs
-        stakePerPool
-        totalStake
-        activeStake
-
-    delegators :: Map (KeyHash 'StakePool) (Map (Credential 'Staking) Coin)
-    delegators =
-        VMap.foldlWithKey
-            (flipFold $ \account ->
-                let balance = maybe mempty (word64ToCoin . unCompactCoin) (VMap.lookup account (unStake stake))
-                 in Map.alter $ Just . \case
-                        Nothing -> Map.singleton account balance
-                        Just m -> Map.insert account balance m
-            )
-            mempty
-            delegs
-
-    pools =
-        poolParams
-            & VMap.map mkPoolRewardInfoCurry
-            & VMap.toMap
-            & Map.mapWithKey (\poolId -> \case
-                Left s -> PoolRewardsInfo
-                    { poolRelativeStake = s
-                    , poolPot = mempty
-                    , poolBlocks = 0
-                    , poolLeaderReward = mempty
-                    , poolDelegators = fromMaybe mempty (Map.lookup poolId delegators)
-                    }
-                Right i -> PoolRewardsInfo
-                    { poolRelativeStake = Ledger.poolRelativeStake i
-                    , poolPot = Ledger.poolPot i
-                    , poolBlocks = Ledger.poolBlocks i
-                    , poolLeaderReward = lRewardAmount $ Ledger.poolLeaderReward i
-                    , poolDelegators = fromMaybe mempty (Map.lookup poolId delegators)
-                    }
-              )
+rewardsProvenance _ _ _ _ _ =
+    error "TODO(dijkstra): rewardsProvenance needs full rewrite for new cardano-ledger-core 1.20 API (ActiveStake / StakePoolSnapShot / NonZero Coin / ChainAccountState; mkPoolRewardInfo arity changed)"
 
 circulation :: EpochState era -> Coin -> Coin
 circulation (EpochState acnt _ _ _) supply =
-  supply <-> asReserves acnt
+  supply <-> (error "TODO(dijkstra): asReserves no longer on ChainAccountState in cardano-ledger-core 1.20; needs new accessor" :: Coin)
 
 flipFold :: (k -> v -> a -> a) -> (a -> k -> v -> a)
 flipFold f a k v = f k v a

--- a/server/src/Ogmios/Data/Protocol/TxSubmission.hs
+++ b/server/src/Ogmios/Data/Protocol/TxSubmission.hs
@@ -424,7 +424,7 @@ evaluateExecutionUnits
         -- ^ Information about epoch sizes, for converting slots to UTC times
     -> UTxO era
         -- ^ A UTXO needed to resolve inputs
-    -> Core.Tx era
+    -> Core.Tx Core.TopTx era
         -- ^ The actual transaction
     -> EvaluateTransactionResponse block
 evaluateExecutionUnits pparams systemStart epochInfo utxo tx =
@@ -526,6 +526,7 @@ utxoFromMempool =
             error "inputs: unsupported era."
         GenTxByron{} ->
             error "inputs: unsupported era."
+        _ -> error "TODO(dijkstra): inputs needs GenTxDijkstra arm"
 
     outputs :: GenTx block -> MultiEraUTxO block
     outputs = \case
@@ -551,6 +552,7 @@ utxoFromMempool =
             error "outputs: unsupported era."
         GenTxByron{} ->
             error "outputs: unsupported era."
+        _ -> error "TODO(dijkstra): outputs needs GenTxDijkstra arm + Dijkstra MultiEraUTxO ctor"
 
 mergeUtxo ::  MultiEraUTxO block -> MultiEraUTxO block -> MultiEraUTxO block
 mergeUtxo a b = case (a, b) of

--- a/server/src/Ogmios/Prelude.hs
+++ b/server/src/Ogmios/Prelude.hs
@@ -366,13 +366,14 @@ fromEraIndex
     :: EraIndex (CardanoEras StandardCrypto)
     -> Maybe SomeShelleyEra
 fromEraIndex = \case
-    EraIndex                   Z{}       -> Nothing
-    EraIndex                (S Z{})      -> Just (SomeShelleyEra ShelleyBasedEraShelley)
-    EraIndex             (S (S Z{}))     -> Just (SomeShelleyEra ShelleyBasedEraAllegra)
-    EraIndex          (S (S (S Z{})))    -> Just (SomeShelleyEra ShelleyBasedEraMary)
-    EraIndex       (S (S (S (S Z{}))))   -> Just (SomeShelleyEra ShelleyBasedEraAlonzo)
-    EraIndex    (S (S (S (S (S Z{})))))  -> Just (SomeShelleyEra ShelleyBasedEraBabbage)
-    EraIndex (S (S (S (S (S (S Z{})))))) -> Just (SomeShelleyEra ShelleyBasedEraConway)
+    EraIndex                      Z{}        -> Nothing
+    EraIndex                   (S Z{})       -> Just (SomeShelleyEra ShelleyBasedEraShelley)
+    EraIndex                (S (S Z{}))      -> Just (SomeShelleyEra ShelleyBasedEraAllegra)
+    EraIndex             (S (S (S Z{})))     -> Just (SomeShelleyEra ShelleyBasedEraMary)
+    EraIndex          (S (S (S (S Z{}))))    -> Just (SomeShelleyEra ShelleyBasedEraAlonzo)
+    EraIndex       (S (S (S (S (S Z{})))))   -> Just (SomeShelleyEra ShelleyBasedEraBabbage)
+    EraIndex    (S (S (S (S (S (S Z{}))))))  -> Just (SomeShelleyEra ShelleyBasedEraConway)
+    EraIndex (S (S (S (S (S (S (S Z{}))))))) -> error "TODO(dijkstra): fromEraIndex Dijkstra arm"
 
 -- | Encode an object into a CBOR binary bytestring, based on the era encoder.
 encodeCbor


### PR DESCRIPTION
> **⚠️ This is a WIP/exploration draft.** 30 source files contain `TODO(dijkstra)`
> stubs (`error "..."` placeholders, ~100 sites). The library typechecks against
> the new dep stack but most runtime code paths are non-functional.
> Opened to discuss the migration surface before doing the real work.

## What's here

Two commits on top of master:

1. **`upgrade dependencies to cardano-node==11.0.1`** — clean dep bump (5 files, +62/-77):
   - `cardano-node 10.5.1 → 11.0.1`
   - `cardano-ledger-conway 1.19.0.0 → ≥1.22.1.0`
   - `ouroboros-consensus 0.27.0.0 → ^>=3.0.1`
   - `ouroboros-network 0.21.3.0 → ^>=1.1`
   - `io-classes 1.5.0.0 → ^>=1.8`
   - Removes the three `CardanoSolutions/*` source-repository-package forks
     (`GetDRepDelegations` / `NodeToClientV_21` / etc.) — all upstream now in `ouroboros-consensus 3.0.1` / `ouroboros-network 1.1` / `cardano-ledger-conway 1.22.1`
   - Adds `validation < 1.2` pin and `blockio +serialblockio` (drops the
     `liburing` build-time dependency)
   - hpack-regenerated cabal files for the sub-library rename
     (`ouroboros-network-api` → `ouroboros-network:api`, etc.)

2. **`WIP: stub out source to compile against new deps`** — mechanical adaptation + stubs (30 files, +380/-1160). `cabal build ogmios:lib:ogmios -j4` succeeds.

## Major themes (each `TODO(dijkstra)` is a unit of real work)

- **`type data KeyRole`** — tick-prefix dropped for `'StakePool` / `'Staking` / `'Witness` / etc. across 5 files; `'Genesis` → `GenesisRole`
- **Accessor renames** — `Sh.body` / `.wits` / `.auxiliaryData` → `Sh.stBody` / `.stWits` / `.stAuxData`; `Al.body` / etc. → `Al.atBody` / etc.; `ppXxx` → `sppXxx`; `Sh.txSeqTxns'` → `Sh.shelleyBlockBodyTxs`; `Al.txSeqTxns` → `Al.alonzoBlockBodyTxs`
- **Type renames** — `RewardAccount` → `AccountAddress`; `PoolParams` → `StakePoolParams`; `Sh.ShelleyTxBody` / `Al.AlonzoTxBody` / etc. (now pattern syns) → `Ledger.TxBody Ledger.TopTx era`; `Sh.ShelleyTx era` → `Sh.Tx Ledger.TopTx era`
- **Module relocations** — `Cardano.Ledger.PoolParams` → `Cardano.Ledger.State`; `.Shelley.BlockChain` → `.Shelley.BlockBody`; `.Alonzo.TxSeq` → `.Alonzo.BlockBody`; `upgradeTxBody` from `.Core` to `.Api.Tx.Body`; `WitVKey` to `Cardano.Ledger.Keys.WitVKey`; `Ouroboros.Network.NodeToClient[.Version]` → `Cardano.Network.NodeToClient` (`cardano-diffusion`)
- **Constraint propagation** — `MonadEvaluate m` added to 5 mini-protocol runners, `mkClient`, `connectHealthCheckClient`, `newWebSocketApp`; `App` newtype derives `MonadEvaluate`; `NFData a` added to `localTxMonitor`
- **`NetworkConnectTracers` retyped** — `nctMuxTracer` → `nctMuxTracers`, retyped to `Mx.TracersWithBearer`; outer type gains an `m` parameter (currently stubbed `undefined`)
- **`CardanoCodecConfig` Dijkstra slot** — stubbed `undefined` for the new 8th era arg in consensus 3.0.1

## Stubbed (still TODO; these are the real work units)

`encodePParamsHKD` Shelley / Alonzo / Babbage / Conway (Compact Coin / new `encodeCompact` callback); all era `encodeTx` arms (lens migration needed per [PR #461](https://github.com/CardanoSolutions/ogmios/pull/461)); `encodeAuxiliaryData` / `encodeScript` Alonzo (`Al.TimelockScript` ctor removed); `encodeGenesis` Alonzo (`AlonzoExtraConfig` split); all PredicateFailure encoders (`NonEmpty` / `NonEmptySet` shifts + ctor renames like `WithdrawalsNotInRewardsDELEGS`, `TriesToForgeADA`, `MissingRequiredSigners`, `StakeKeyHasNonZeroRewardAccountBalanceDELEG` → `…HasNonZeroAccountBalanceDELEG`); `Rewards.rewardsProvenance` / `circulation` (`ChainAccountState` / `ActiveStake` / `StakePoolSnapShot` / `NonZero Coin`; `mkPoolRewardInfo` arity); `Ledger.scriptPurposeInMostRecentEra` (needs Dijkstra arm + extra `upgradePlutusPurposeAsIx`); `EraTranslation` `Upgrade AlonzoTx ConwayEra` instance commented out (kind change to `TxLevel -> Type -> Type`; should follow PR #461 and use `Tx TopTx`); `encodeSubmitTransactionError` / `encodeTx` dispatcher in `Json.hs` (`ApplyTxError` is a type now, not a pattern); `keepRedundantConstraint` era guards detuned in `Query.hs` / `TxMonitor.hs` (needs `Cardano.Ledger.Dijkstra.Era` wired in to re-arm against `DijkstraEra`); `withoutFutureParameters` in `App/Configuration.hs` (`AlonzoExtraConfig` / `UpgradeAlonzoPParams` split + `Maybe CostModels`); `Ledger.pmHash` / `drepDeposit` / `asReserves` / `asTreasury` (Compact / ByteArray / accessor changes); Dijkstra branches in `fromEraIndex` / `eraIndexToCardanoEra` / `toRawTxIdHash` / `inputs` / `outputs`.

## Werror suppressions

To keep the build green with the stubs in place, these files have file-local
`-Wno-…` pragmas (mostly `unused-imports` / `unused-matches` / `unused-top-binds` /
`incomplete-patterns` / `redundant-constraints` / `dodgy-imports` / `dodgy-exports` /
`deprecations` / `orphans`): `Rewards.hs`, `EraTranslation.hs`, `Shelley.hs` / `Allegra.hs` / `Mary.hs` / `Alonzo.hs` / `Babbage.hs` / `Conway.hs` (Json), `Query.hs`, `Json.hs`, `Orphans.hs`, all 6 PredicateFailure modules, `App/Configuration.hs`, `App/Protocol/TxMonitor.hs`, `App/Protocol/TxSubmission.hs`. Each pragma carries a `TODO(dijkstra)` note explaining why.

## Open questions for review

1. The lens-based `encodeTx` migration that PR #461 chose vs unwrapping `MkShelleyTx` — preferences before I commit to a direction across all 6 era encoders?
2. `EraTranslation` `Upgrade` instances: PR #461 replaces `AlonzoTx` / `BabbageTx` / etc. with the generic `Tx TopTx` from `Cardano.Ledger.Core`. Sound approach?
3. Same for the `keepRedundantConstraint` era-guard hack — should that move to `DijkstraEra` once we add the `cardano-ledger-dijkstra` dep, or replace with something else?

Plumbing the rest of Dijkstra (new modules `Ogmios.Data.Json.Dijkstra` /
`Ogmios.Data.Ledger.PredicateFailure.Dijkstra`; era added to dispatchers; JSON
schema updates) is intentionally deferred to keep this draft focused on
"what does the dep bump alone break".

🤖 Note: build adaptation generated with Claude Code under my supervision.
